### PR TITLE
feat(web): add weekly operational agenda board

### DIFF
--- a/web/src/api/appointments.test.ts
+++ b/web/src/api/appointments.test.ts
@@ -37,4 +37,57 @@ describe('appointments API auth transport', () => {
       auth: true,
     });
   });
+
+  it('composes a monday-friday operational week from the current day endpoints', async () => {
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [{ id: 'slot-1', professional_id: 'professional-1', start_time: '2026-04-07T09:00:00Z', end_time: '2026-04-07T09:30:00Z', status: 'available', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [{ id: 'slot-2', professional_id: 'professional-1', start_time: '2026-04-10T11:00:00Z', end_time: '2026-04-10T11:30:00Z', status: 'booked', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }] });
+    requestMock.mockResolvedValueOnce({ items: [{ id: 'appointment-1', slot_id: 'slot-2', professional_id: 'professional-1', patient_id: 'patient-1', status: 'booked', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }] });
+
+    const appointments = await import('./appointments');
+
+    const week = await appointments.listOperationalWeek({ professional_id: 'professional-1', date: '2026-04-08' });
+
+    expect(requestMock).toHaveBeenCalledTimes(10);
+    expect(requestMock).toHaveBeenNthCalledWith(1, '/appointments-api', '/slots', {
+      query: { professional_id: 'professional-1', date: '2026-04-06' },
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(10, '/appointments-api', '/appointments', {
+      query: { professional_id: 'professional-1', date: '2026-04-10' },
+      auth: true,
+    });
+    expect(week.weekStart).toBe('2026-04-06');
+    expect(week.days.map((day) => day.date)).toEqual(['2026-04-06', '2026-04-07', '2026-04-08', '2026-04-09', '2026-04-10']);
+    expect(week.timeBands).toEqual(['09:00', '11:00']);
+    expect(week.days[1]?.summary.available).toBe(1);
+    expect(week.days[4]?.summary.booked).toBe(1);
+  });
+
+  it('fails fast when a day slice cannot be composed instead of fabricating week data', async () => {
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockRejectedValueOnce(new Error('weekday slots unavailable'));
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+    requestMock.mockResolvedValueOnce({ items: [] });
+
+    const appointments = await import('./appointments');
+
+    await expect(
+      appointments.listOperationalWeek({ professional_id: 'professional-1', date: '2026-04-08' }),
+    ).rejects.toThrow('weekday slots unavailable');
+
+    expect(requestMock).toHaveBeenCalledTimes(10);
+  });
 });

--- a/web/src/api/appointments.ts
+++ b/web/src/api/appointments.ts
@@ -6,6 +6,7 @@ import type {
   ListResponse,
   Slot,
 } from '../types/appointments';
+import { getOperationalWeekDays, normalizeOperationalTimeBands } from '../features/schedule/helpers';
 
 const APPOINTMENTS_API_BASE = '/appointments-api';
 
@@ -20,6 +21,24 @@ type SlotFilters = {
   professional_id?: string;
   status?: string;
   date?: string;
+};
+
+export type OperationalWeekDay = {
+  date: string;
+  weekdayLabel: string;
+  slots: Slot[];
+  appointments: Appointment[];
+  summary: {
+    available: number;
+    booked: number;
+    cancelled: number;
+  };
+};
+
+export type OperationalWeek = {
+  weekStart: string;
+  days: OperationalWeekDay[];
+  timeBands: string[];
 };
 
 export function listSlots(filters: SlotFilters) {
@@ -51,4 +70,52 @@ export function cancelAppointment(appointmentId: string) {
 		method: 'PATCH',
 		auth: true,
 	});
+}
+
+export async function listOperationalWeek(filters: Required<Pick<SlotFilters, 'professional_id' | 'date'>>) {
+	const weekDays = getOperationalWeekDays(filters.date);
+	const days = await Promise.all(
+		weekDays.map(async (day) => {
+			const [slotsResponse, appointmentsResponse] = await Promise.all([
+				listSlots({ professional_id: filters.professional_id, date: day.date }),
+				listAppointments({ professional_id: filters.professional_id, date: day.date }),
+			]);
+
+			const slots = [...slotsResponse.items].sort(compareByStartTime);
+			const appointments = [...appointmentsResponse.items].sort(compareBySlotOrder(slots));
+
+			return {
+				date: day.date,
+				weekdayLabel: day.weekdayLabel,
+				slots,
+				appointments,
+				summary: {
+					available: slots.filter((slot) => slot.status === 'available').length,
+					booked: appointments.filter((appointment) => appointment.status === 'booked').length,
+					cancelled: appointments.filter((appointment) => appointment.status === 'cancelled').length,
+				},
+			};
+		}),
+	);
+
+	return {
+		weekStart: weekDays[0]?.date ?? filters.date,
+		days,
+		timeBands: normalizeOperationalTimeBands(days.flatMap((day) => day.slots)),
+	};
+}
+
+function compareByStartTime(left: Slot, right: Slot) {
+	return new Date(left.start_time).getTime() - new Date(right.start_time).getTime();
+}
+
+function compareBySlotOrder(slots: Slot[]) {
+	const slotOrder = new Map(slots.map((slot, index) => [slot.id, index]));
+
+	return (left: Appointment, right: Appointment) => {
+		const leftOrder = slotOrder.get(left.slot_id) ?? Number.MAX_SAFE_INTEGER;
+		const rightOrder = slotOrder.get(right.slot_id) ?? Number.MAX_SAFE_INTEGER;
+
+		return leftOrder - rightOrder;
+	};
 }

--- a/web/src/features/schedule/ScheduleDemo.test.tsx
+++ b/web/src/features/schedule/ScheduleDemo.test.tsx
@@ -1,11 +1,13 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../../api/http';
+import type { Appointment, Slot } from '../../types/appointments';
 import { ScheduleDemo } from './ScheduleDemo';
 
 const {
   cancelAppointmentMock,
   createAppointmentMock,
+  createSlotsBulkMock,
   listSlotsMock,
   listAppointmentsMock,
   listProfessionalsMock,
@@ -13,6 +15,7 @@ const {
 } = vi.hoisted(() => ({
   cancelAppointmentMock: vi.fn(),
   createAppointmentMock: vi.fn(),
+  createSlotsBulkMock: vi.fn(),
   listSlotsMock: vi.fn(),
   listAppointmentsMock: vi.fn(),
   listProfessionalsMock: vi.fn(),
@@ -22,9 +25,38 @@ const {
 vi.mock('../../api/appointments', () => ({
   cancelAppointment: cancelAppointmentMock,
   createAppointment: createAppointmentMock,
-  createSlotsBulk: vi.fn(),
+  createSlotsBulk: createSlotsBulkMock,
   listAppointments: listAppointmentsMock,
   listSlots: listSlotsMock,
+  listOperationalWeek: async ({ professional_id, date }: { professional_id: string; date: string }) => {
+    const weekDays = getWeekDays(date);
+    const days = await Promise.all(
+      weekDays.map(async (day) => {
+        const [slotsResponse, appointmentsResponse] = await Promise.all([
+          listSlotsMock({ professional_id, date: day.date }),
+          listAppointmentsMock({ professional_id, date: day.date }),
+        ]);
+
+        return {
+          date: day.date,
+          weekdayLabel: day.weekdayLabel,
+          slots: slotsResponse.items,
+          appointments: appointmentsResponse.items,
+          summary: {
+            available: slotsResponse.items.filter((slot: Slot) => slot.status === 'available').length,
+            booked: appointmentsResponse.items.filter((appointment: { status: string }) => appointment.status === 'booked').length,
+            cancelled: appointmentsResponse.items.filter((appointment: { status: string }) => appointment.status === 'cancelled').length,
+          },
+        };
+      }),
+    );
+
+    return {
+      weekStart: weekDays[0]?.date ?? date,
+      days,
+      timeBands: [...new Set(days.flatMap((day) => day.slots.map((slot: Slot) => slot.start_time.slice(11, 16))))].sort(),
+    };
+  },
 }));
 
 vi.mock('../../api/directory', () => ({
@@ -32,23 +64,38 @@ vi.mock('../../api/directory', () => ({
   listProfessionals: listProfessionalsMock,
 }));
 
-describe('ScheduleDemo auth failures', () => {
+describe('ScheduleDemo weekly operational board', () => {
   beforeEach(() => {
     cancelAppointmentMock.mockReset();
     createAppointmentMock.mockReset();
+    createSlotsBulkMock.mockReset();
     listSlotsMock.mockReset();
     listAppointmentsMock.mockReset();
     listProfessionalsMock.mockReset();
     listPatientsMock.mockReset();
   });
 
-  it('invalidates the session on 401 schedule failures without showing denial feedback', async () => {
-    listProfessionalsMock.mockResolvedValue({
-      items: [activeProfessional()],
-    });
-    listPatientsMock.mockResolvedValue({
-      items: [activePatient()],
-    });
+  it('renders the explicit forbidden agenda branch without bootstrapping schedule data', () => {
+    render(
+      <ScheduleDemo
+        agendaMode={{ kind: 'forbidden', message: 'Tu perfil no tiene permisos para usar esta agenda.' }}
+        onSessionInvalid={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Agenda bloqueada')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Acceso denegado' })).toBeInTheDocument();
+    expect(screen.getByText('Tu perfil no tiene permisos para usar esta agenda.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Actualizar/i })).not.toBeInTheDocument();
+    expect(listProfessionalsMock).not.toHaveBeenCalled();
+    expect(listPatientsMock).not.toHaveBeenCalled();
+    expect(listSlotsMock).not.toHaveBeenCalled();
+    expect(listAppointmentsMock).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the session on 401 weekly load failures without showing denial feedback', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
     listSlotsMock.mockRejectedValue(new ApiError('Sesión vencida', 401));
     listAppointmentsMock.mockResolvedValue({ items: [] });
 
@@ -63,65 +110,84 @@ describe('ScheduleDemo auth failures', () => {
     expect(screen.queryByText(/Acceso denegado:/i)).not.toBeInTheDocument();
   });
 
-  it('shows denial feedback on 403 schedule failures without invalidating the session', async () => {
-    listProfessionalsMock.mockResolvedValue({
-      items: [activeProfessional()],
-    });
-    listPatientsMock.mockResolvedValue({
-      items: [activePatient()],
-    });
-    listSlotsMock.mockRejectedValue(new ApiError('No podés ver esta agenda.', 403));
-    listAppointmentsMock.mockResolvedValue({ items: [] });
-
-    const onSessionInvalid = vi.fn();
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={onSessionInvalid} />);
-
-    expect(await screen.findByText('Acceso denegado: No podés ver esta agenda.')).toBeInTheDocument();
-    expect(onSessionInvalid).not.toHaveBeenCalled();
-  });
-
-  it('locks doctors to their own professional agenda', async () => {
-    listProfessionalsMock.mockResolvedValue({
-      items: [activeProfessional(), secondProfessional()],
-    });
-    listPatientsMock.mockResolvedValue({
-      items: [activePatient()],
-    });
-    listSlotsMock.mockResolvedValue({ items: [] });
-    listAppointmentsMock.mockResolvedValue({ items: [] });
+  it('locks doctors to their own professional agenda while loading the visible monday-friday week', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional(), secondProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    mockWeekSlices({});
 
     render(
       <ScheduleDemo agendaMode={{ kind: 'doctor-own', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />,
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByText('Ana Médica').length).toBeGreaterThan(0);
-    });
+    expect((await screen.findAllByText('Lun 06/04')).length).toBeGreaterThan(0);
+
     expect(screen.queryByRole('combobox', { name: 'Profesional' })).not.toBeInTheDocument();
-    await waitFor(() => {
-      expect(listSlotsMock).toHaveBeenCalledWith({ professional_id: 'professional-1', date: expect.any(String) });
-    });
+    expect(listSlotsMock).toHaveBeenCalledTimes(5);
+    expect(listSlotsMock.mock.calls.map(([filters]) => filters)).toEqual([
+      { professional_id: 'professional-1', date: '2026-04-06' },
+      { professional_id: 'professional-1', date: '2026-04-07' },
+      { professional_id: 'professional-1', date: '2026-04-08' },
+      { professional_id: 'professional-1', date: '2026-04-09' },
+      { professional_id: 'professional-1', date: '2026-04-10' },
+    ]);
   });
 
-  it('uses the slot grid as the only booking selector and reserves the clicked slot', async () => {
+  it('shows a monday-friday weekly board with explicit empty weekdays', async () => {
     listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
     listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    listSlotsMock.mockResolvedValue({
-      items: [
-        availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z'),
-        availableSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z'),
-      ],
+    mockWeekSlices({
+      '2026-04-06': { slots: [availableSlot('slot-mon', '2026-04-06T09:00:00Z', '2026-04-06T09:30:00Z')] },
+      '2026-04-08': { slots: [availableSlot('slot-wed', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
     });
-    listAppointmentsMock.mockResolvedValue({ items: [] });
-    createAppointmentMock.mockResolvedValue({ id: 'appointment-2' });
 
     render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
 
-    const targetSlot = await screen.findByRole('button', { name: /10:00 - 10:30 UTC/i });
-    expect(screen.queryByLabelText('Slot a reservar')).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
+    expect((await screen.findAllByText('Lun 06/04')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Mar 07/04').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Mié 08/04').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Jue 09/04').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Vie 10/04').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Sáb/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Dom/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText('Sin actividad para este día').length).toBeGreaterThan(0);
+  });
 
-    fireEvent.click(targetSlot);
+  it('uses the selected slot cell as the only booking selector and preserves supported actions only', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    mockWeekRefreshes([
+      {
+        '2026-04-08': {
+          slots: [
+            availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z'),
+            availableSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z'),
+          ],
+        },
+      },
+      {
+        '2026-04-08': {
+          slots: [bookedSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')],
+          appointments: [bookedAppointment('appointment-1', 'slot-2')],
+        },
+      },
+    ]);
+    createAppointmentMock.mockResolvedValue({ id: 'appointment-1' });
+
+    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0]);
+
+    const slotCell = await screen.findByRole('button', { name: /Mié 08\/04 .*10:00 - 10:30 UTC/i });
+
+    expect(screen.queryByLabelText('Slot a reservar')).not.toBeInTheDocument();
+    expect(screen.getByText('Elegí profesional y semana para cargar la operación visible sin salir del espacio actual.')).toBeInTheDocument();
+    expect(screen.getByText('Acción secundaria: cargá disponibilidad para el día seleccionado sin salir de esta vista.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Reprogramar/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Ver detalle/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+    fireEvent.click(slotCell);
     fireEvent.click(screen.getByRole('button', { name: 'Reservar turno' }));
 
     await waitFor(() => {
@@ -131,114 +197,115 @@ describe('ScheduleDemo auth failures', () => {
         professional_id: 'professional-1',
       });
     });
-  });
-
-  it('keeps supporting guidance secondary without adding alternate agenda workflows', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    listSlotsMock.mockResolvedValue({
-      items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-    });
-    listAppointmentsMock.mockResolvedValue({ items: [] });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    expect(await screen.findByText('Paso 1: elegí profesional y fecha para cargar la disponibilidad del día.')).toBeInTheDocument();
-    expect(screen.getByText('Paso 2 opcional: cargá disponibilidad para esa agenda sin salir de esta vista.')).toBeInTheDocument();
-    expect(screen.getByText('Paso 3: elegí un horario desde la grilla principal y asignalo a un paciente.')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Slot a reservar')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Reprogramar/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Ver detalle/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
-  });
-
-  it('keeps cancellation refresh highlighting while hiding raw appointment and slot identifiers', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    listSlotsMock
-      .mockResolvedValueOnce({
-        items: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-      })
-      .mockResolvedValueOnce({
-        items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-      });
-    listAppointmentsMock
-      .mockResolvedValueOnce({
-        items: [bookedAppointment('appointment-1', 'slot-1')],
-      })
-      .mockResolvedValueOnce({
-        items: [cancelledAppointment('appointment-1', 'slot-1')],
-      });
-    cancelAppointmentMock.mockResolvedValue(undefined);
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Cancelar' }));
-
-    expect(await screen.findByText(/volvió a quedar disponible/i)).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: /09:00 - 09:30 UTC/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.queryByText(/Appointment:/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Slot:/i)).not.toBeInTheDocument();
-  });
-
-  it('keeps the reserve and cancel workflow unchanged while surfacing user-facing appointment context', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    listSlotsMock
-      .mockResolvedValueOnce({
-        items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-      })
-      .mockResolvedValueOnce({
-        items: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-      })
-      .mockResolvedValueOnce({
-        items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-      });
-    listAppointmentsMock
-      .mockResolvedValueOnce({ items: [] })
-      .mockResolvedValueOnce({
-        items: [bookedAppointment('appointment-1', 'slot-1')],
-      })
-      .mockResolvedValueOnce({
-        items: [cancelledAppointment('appointment-1', 'slot-1')],
-      });
-    createAppointmentMock.mockResolvedValue({ id: 'appointment-1' });
-    cancelAppointmentMock.mockResolvedValue(undefined);
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    fireEvent.click(await screen.findByRole('button', { name: /09:00 - 09:30 UTC/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Reservar turno' }));
-
-    await waitFor(() => {
-      expect(createAppointmentMock).toHaveBeenCalledWith({
-        slot_id: 'slot-1',
-        patient_id: 'patient-1',
-        professional_id: 'professional-1',
-      });
-    });
 
     expect(await screen.findByText('Turno reservado correctamente.')).toBeInTheDocument();
     expect(await screen.findByText('Juan Pérez')).toBeInTheDocument();
-    expect(screen.getByText('09:00 - 09:30 UTC')).toBeInTheDocument();
-    expect(
-      screen.getByText((content, element) => element?.tagName === 'SMALL' && content.includes('Ana Médica ·')),
-    ).toBeInTheDocument();
     expect(screen.getByText('Reservado')).toBeInTheDocument();
-    expect(screen.queryByText(/Appointment:/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Slot:/i)).not.toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+  it('lets the operator select a weekday card and keeps support actions bound to that selected day', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    mockWeekRefreshes([
+      {},
+      { '2026-04-08': { slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')] } },
+    ]);
+    createSlotsBulkMock.mockResolvedValue({
+      items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+    });
+
+    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    const weekdayCard = (await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0];
+    fireEvent.click(weekdayCard);
+
+    expect(weekdayCard).toHaveAttribute('aria-pressed', 'true');
+    expect(await screen.findAllByText('Sin actividad para este día')).not.toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generar slots' }));
+
+    await waitFor(() => {
+      expect(createSlotsBulkMock).toHaveBeenCalledWith({
+        professional_id: 'professional-1',
+        date: '2026-04-08',
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      });
+    });
+
+    expect(await screen.findByText('Se generaron 1 slot correctamente.')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Mié 08\/04 .*09:00 - 09:30 UTC/i })).toBeInTheDocument();
+  });
+
+  it('supports week browsing and cancellation while keeping released slot feedback intact', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    mockWeekRefreshes([
+      { '2026-04-08': { slots: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')], appointments: [bookedAppointment('appointment-1', 'slot-1')] } },
+      { '2026-04-13': { slots: [availableSlot('slot-next', '2026-04-13T09:00:00Z', '2026-04-13T09:30:00Z')] } },
+      { '2026-04-08': { slots: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')], appointments: [bookedAppointment('appointment-1', 'slot-1')] } },
+      { '2026-04-08': { slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')], appointments: [cancelledAppointment('appointment-1', 'slot-1')] } },
+    ]);
+    cancelAppointmentMock.mockResolvedValue(undefined);
+
+    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    const appointmentCell = await screen.findByTestId('board-cell-2026-04-08-09:00');
+    expect(within(appointmentCell).getByText('Juan Pérez')).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: /Mié 08\/04/i })[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Semana siguiente' }));
+    expect(await screen.findByText('Lun 13/04')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mié 15\/04/i })).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Semana anterior' }));
+    expect(await screen.findByRole('button', { name: /Mié 08\/04/i })).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancelar' }));
 
     await waitFor(() => {
       expect(cancelAppointmentMock).toHaveBeenCalledWith('appointment-1');
     });
 
     expect(await screen.findByText(/volvió a quedar disponible/i)).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: /09:00 - 09:30 UTC/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Cancelado')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Mié 08\/04 .*09:00 - 09:30 UTC/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(within(screen.getByTestId('board-cell-2026-04-08-09:00')).getByText('Cancelado')).toBeInTheDocument();
+    expect(screen.queryByText(/Appointment:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Slot:/i)).not.toBeInTheDocument();
   });
 });
+
+function mockWeekSlices(days: Record<string, { slots?: Slot[]; appointments?: Appointment[] }>) {
+  listSlotsMock.mockImplementation(({ date }: { date: string }) => Promise.resolve({ items: days[date]?.slots ?? [] }));
+  listAppointmentsMock.mockImplementation(({ date }: { date: string }) => Promise.resolve({ items: days[date]?.appointments ?? [] }));
+}
+
+function mockWeekRefreshes(weeks: Array<Record<string, { slots?: Slot[]; appointments?: Appointment[] }>>) {
+  let activeWeekIndex = 0;
+  let callsInWeek = 0;
+
+  const advanceWeekIfNeeded = () => {
+    callsInWeek += 1;
+    if (callsInWeek === 10) {
+      callsInWeek = 0;
+      if (activeWeekIndex < weeks.length - 1) {
+        activeWeekIndex += 1;
+      }
+    }
+  };
+
+  listSlotsMock.mockImplementation(({ date }: { date: string }) => {
+    const result = Promise.resolve({ items: weeks[activeWeekIndex]?.[date]?.slots ?? [] });
+    advanceWeekIfNeeded();
+    return result;
+  });
+
+  listAppointmentsMock.mockImplementation(({ date }: { date: string }) => {
+    const result = Promise.resolve({ items: weeks[activeWeekIndex]?.[date]?.appointments ?? [] });
+    advanceWeekIfNeeded();
+    return result;
+  });
+}
 
 function availableSlot(id: string, startTime: string, endTime: string) {
   return {
@@ -246,7 +313,7 @@ function availableSlot(id: string, startTime: string, endTime: string) {
     professional_id: 'professional-1',
     start_time: startTime,
     end_time: endTime,
-    status: 'available',
+    status: 'available' as const,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   };
@@ -255,7 +322,7 @@ function availableSlot(id: string, startTime: string, endTime: string) {
 function bookedSlot(id: string, startTime: string, endTime: string) {
   return {
     ...availableSlot(id, startTime, endTime),
-    status: 'booked',
+    status: 'booked' as const,
   };
 }
 
@@ -265,7 +332,7 @@ function bookedAppointment(id: string, slotId: string) {
     slot_id: slotId,
     patient_id: 'patient-1',
     professional_id: 'professional-1',
-    status: 'booked',
+    status: 'booked' as const,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   };
@@ -274,7 +341,7 @@ function bookedAppointment(id: string, slotId: string) {
 function cancelledAppointment(id: string, slotId: string) {
   return {
     ...bookedAppointment(id, slotId),
-    status: 'cancelled',
+    status: 'cancelled' as const,
   };
 }
 
@@ -315,4 +382,21 @@ function activePatient() {
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   };
+}
+
+function getWeekDays(date: string) {
+  const parsedDate = new Date(`${date}T00:00:00Z`);
+  const dayOfWeek = parsedDate.getUTCDay();
+  const offsetToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  parsedDate.setUTCDate(parsedDate.getUTCDate() + offsetToMonday);
+
+  return Array.from({ length: 5 }, (_, index) => {
+    const currentDate = new Date(parsedDate);
+    currentDate.setUTCDate(parsedDate.getUTCDate() + index);
+
+    return {
+      date: currentDate.toISOString().slice(0, 10),
+      weekdayLabel: ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'][currentDate.getUTCDay()] + ` ${currentDate.toISOString().slice(8, 10)}/${currentDate.toISOString().slice(5, 7)}`,
+    };
+  });
 }

--- a/web/src/features/schedule/ScheduleDemo.tsx
+++ b/web/src/features/schedule/ScheduleDemo.tsx
@@ -1,11 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { cancelAppointment, createAppointment, createSlotsBulk, listAppointments, listSlots } from '../../api/appointments';
+import { cancelAppointment, createAppointment, createSlotsBulk, listOperationalWeek, type OperationalWeekDay } from '../../api/appointments';
 import { listPatients, listProfessionals } from '../../api/directory';
 import { type AgendaMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
 import type { Appointment, BulkCreateSlotsPayload, Slot } from '../../types/appointments';
 import type { Patient, Professional } from '../../types/directory';
-import { formatDateInputValue, formatDateTimeRange, formatLongDate } from './helpers';
+import {
+  formatDateInputValue,
+  formatDateTimeRange,
+  formatLongDate,
+  formatTimeBand,
+  getUtcWeekStart,
+  mapDateToOperationalWeek,
+} from './helpers';
 
 type ScheduleDemoProps = {
   agendaMode: AgendaMode;
@@ -13,14 +20,17 @@ type ScheduleDemoProps = {
 };
 
 export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps) {
+  const initialSelectedDate = mapDateToOperationalWeek(formatDateInputValue());
   const [professionals, setProfessionals] = useState<Professional[]>([]);
   const [patients, setPatients] = useState<Patient[]>([]);
   const [selectedProfessionalId, setSelectedProfessionalId] = useState('');
   const [selectedPatientId, setSelectedPatientId] = useState('');
-  const [selectedDate, setSelectedDate] = useState(formatDateInputValue());
+  const [selectedDate, setSelectedDate] = useState(initialSelectedDate);
+  const [weekStart, setWeekStart] = useState(getUtcWeekStart(initialSelectedDate));
+  const [days, setDays] = useState<OperationalWeekDay[]>([]);
+  const [timeBands, setTimeBands] = useState<string[]>([]);
+  const [focusedBand, setFocusedBand] = useState('');
   const [selectedSlotId, setSelectedSlotId] = useState('');
-  const [daySlots, setDaySlots] = useState<Slot[]>([]);
-  const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [isRefreshingAgenda, setIsRefreshingAgenda] = useState(false);
   const [isCreatingSlots, setIsCreatingSlots] = useState(false);
@@ -36,13 +46,13 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
   const [slotDurationMinutes, setSlotDurationMinutes] = useState<BulkCreateSlotsPayload['slot_duration_minutes']>(30);
   const releasedSlotIdRef = useRef('');
 
+  const isDoctorAgenda = agendaMode.kind === 'doctor-own';
+
   const clearReleasedSlotFeedback = useCallback(() => {
     releasedSlotIdRef.current = '';
     setReleasedSlotId('');
     setReleasedSlotLabel('');
   }, []);
-
-  const isDoctorAgenda = agendaMode.kind === 'doctor-own';
 
   const handleApiFailure = useCallback(
     (error: unknown, fallbackMessage: string) => {
@@ -65,37 +75,27 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
     () => professionals.find((professional) => professional.id === selectedProfessionalId) ?? null,
     [professionals, selectedProfessionalId],
   );
-
-  const selectedPatient = useMemo(
-    () => patients.find((patient) => patient.id === selectedPatientId) ?? null,
-    [patients, selectedPatientId],
-  );
-
-  const availableSlots = useMemo(
-    () => daySlots.filter((slot) => slot.status === 'available').sort(compareByStartTime),
-    [daySlots],
-  );
-
-  const slotById = useMemo(
-    () => new Map(daySlots.map((slot) => [slot.id, slot])),
-    [daySlots],
-  );
-
-  const selectedSlot = useMemo(() => slotById.get(selectedSlotId) ?? null, [selectedSlotId, slotById]);
-
+  const selectedPatient = useMemo(() => patients.find((patient) => patient.id === selectedPatientId) ?? null, [patients, selectedPatientId]);
   const patientNameById = useMemo(
     () => new Map(patients.map((patient) => [patient.id, `${patient.first_name} ${patient.last_name}`])),
     [patients],
   );
-
-  const bookedAppointmentsCount = useMemo(
-    () => appointments.filter((appointment) => appointment.status === 'booked').length,
-    [appointments],
+  const allSlots = useMemo(() => days.flatMap((day) => day.slots), [days]);
+  const allAppointments = useMemo(() => days.flatMap((day) => day.appointments), [days]);
+  const slotById = useMemo(() => new Map(allSlots.map((slot) => [slot.id, slot])), [allSlots]);
+  const appointmentBySlotId = useMemo(
+    () => new Map(allAppointments.filter((appointment) => appointment.status === 'booked').map((appointment) => [appointment.slot_id, appointment])),
+    [allAppointments],
   );
-
-  const cancelledAppointmentsCount = useMemo(
-    () => appointments.filter((appointment) => appointment.status === 'cancelled').length,
-    [appointments],
+  const selectedSlot = useMemo(() => slotById.get(selectedSlotId) ?? null, [selectedSlotId, slotById]);
+  const selectedWeekDay = useMemo(() => days.find((day) => day.date === selectedDate) ?? null, [days, selectedDate]);
+  const weeklySummary = useMemo(
+    () => ({
+      available: days.reduce((total, day) => total + day.summary.available, 0),
+      booked: days.reduce((total, day) => total + day.summary.booked, 0),
+      cancelled: days.reduce((total, day) => total + day.summary.cancelled, 0),
+    }),
+    [days],
   );
 
   const bootstrap = useCallback(async () => {
@@ -115,7 +115,6 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
       setAccessDeniedMessage('');
 
       const [professionalsResponse, patientsResponse] = await Promise.all([listProfessionals(), listPatients()]);
-
       const nextProfessionals = professionalsResponse.items.filter((professional) => professional.active);
       const nextPatients = patientsResponse.items.filter((patient) => patient.active);
 
@@ -126,15 +125,13 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
           return agendaMode.professionalId;
         }
 
-	      return nextProfessionals.some((professional) => professional.id === current) ? current : nextProfessionals[0]?.id || '';
-	    });
-      setSelectedPatientId((current) =>
-        nextPatients.some((patient) => patient.id === current) ? current : nextPatients[0]?.id || '',
-      );
+        return nextProfessionals.some((professional) => professional.id === current) ? current : nextProfessionals[0]?.id || '';
+      });
+      setSelectedPatientId((current) => (nextPatients.some((patient) => patient.id === current) ? current : nextPatients[0]?.id || ''));
     } catch (error) {
-		const nextError = handleApiFailure(error, 'No se pudieron cargar profesionales y pacientes.');
-		setErrorMessage(nextError.errorMessage);
-		setAccessDeniedMessage(nextError.accessDeniedMessage);
+      const nextError = handleApiFailure(error, 'No se pudieron cargar profesionales y pacientes.');
+      setErrorMessage(nextError.errorMessage);
+      setAccessDeniedMessage(nextError.accessDeniedMessage);
     } finally {
       setIsBootstrapping(false);
     }
@@ -142,15 +139,17 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
 
   const refreshAgenda = useCallback(async () => {
     if (agendaMode.kind === 'forbidden') {
-      setDaySlots([]);
-      setAppointments([]);
+      setDays([]);
+      setTimeBands([]);
+      setFocusedBand('');
       setSelectedSlotId('');
       return;
     }
 
-    if (!selectedProfessionalId || !selectedDate) {
-      setDaySlots([]);
-      setAppointments([]);
+    if (!selectedProfessionalId || !weekStart) {
+      setDays([]);
+      setTimeBands([]);
+      setFocusedBand('');
       setSelectedSlotId('');
       return;
     }
@@ -160,33 +159,42 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
       setErrorMessage('');
       setAccessDeniedMessage('');
 
-      const [slotsResponse, appointmentsResponse] = await Promise.all([
-        listSlots({ professional_id: selectedProfessionalId, date: selectedDate }),
-        listAppointments({ professional_id: selectedProfessionalId, date: selectedDate }),
-      ]);
+      const nextWeek = await listOperationalWeek({ professional_id: selectedProfessionalId, date: weekStart });
+      const nextSlots = nextWeek.days.flatMap((day) => day.slots);
 
-      const nextSlots = [...slotsResponse.items].sort(compareByStartTime);
-      const nextAppointments = [...appointmentsResponse.items].sort(compareAppointmentsBySlot(nextSlots));
+      setWeekStart(nextWeek.weekStart);
+      setDays(nextWeek.days);
+      setTimeBands(nextWeek.timeBands);
+      setSelectedDate((current) => {
+        if (nextWeek.days.some((day) => day.date === current)) {
+          return current;
+        }
 
-      setDaySlots(nextSlots);
-      setAppointments(nextAppointments);
+        return nextWeek.days[0]?.date ?? current;
+      });
       setSelectedSlotId((current) =>
         nextSlots.find((slot) => slot.id === releasedSlotIdRef.current && slot.status === 'available')?.id ||
         nextSlots.find((slot) => slot.id === current && slot.status === 'available')?.id ||
         nextSlots.find((slot) => slot.status === 'available')?.id ||
         '',
       );
+      setFocusedBand((current) => current || nextWeek.timeBands[0] || '');
     } catch (error) {
-		const nextError = handleApiFailure(error, 'No se pudo cargar la agenda seleccionada.');
-		setErrorMessage(nextError.errorMessage);
-		setAccessDeniedMessage(nextError.accessDeniedMessage);
-      setDaySlots([]);
-      setAppointments([]);
+      const nextError = handleApiFailure(error, 'No se pudo cargar la agenda seleccionada.');
+      setErrorMessage(nextError.errorMessage);
+      setAccessDeniedMessage(nextError.accessDeniedMessage);
+      setDays([]);
+      setTimeBands([]);
+      setFocusedBand('');
       setSelectedSlotId('');
     } finally {
       setIsRefreshingAgenda(false);
     }
-  }, [agendaMode.kind, handleApiFailure, selectedDate, selectedProfessionalId]);
+  }, [agendaMode.kind, handleApiFailure, selectedProfessionalId, weekStart]);
+
+  useEffect(() => {
+    void bootstrap();
+  }, [bootstrap]);
 
   useEffect(() => {
     if (isBootstrapping) {
@@ -195,10 +203,6 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
 
     void refreshAgenda();
   }, [isBootstrapping, refreshAgenda]);
-
-  useEffect(() => {
-    void bootstrap();
-  }, [bootstrap]);
 
   async function handleBookAppointment() {
     if (!selectedProfessionalId || !selectedPatientId || !selectedSlotId) {
@@ -222,16 +226,16 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
       setSuccessMessage('Turno reservado correctamente.');
       await refreshAgenda();
     } catch (error) {
-		const nextError = handleApiFailure(error, 'No se pudo reservar el turno.');
-		setErrorMessage(nextError.errorMessage);
-		setAccessDeniedMessage(nextError.accessDeniedMessage);
+      const nextError = handleApiFailure(error, 'No se pudo reservar el turno.');
+      setErrorMessage(nextError.errorMessage);
+      setAccessDeniedMessage(nextError.accessDeniedMessage);
     } finally {
       setIsBooking(false);
     }
   }
 
   async function handleCancelAppointment(appointmentId: string) {
-    const appointment = appointments.find((item) => item.id === appointmentId);
+    const appointment = allAppointments.find((item) => item.id === appointmentId);
     const slot = appointment ? slotById.get(appointment.slot_id) : null;
 
     try {
@@ -252,9 +256,9 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
       );
       await refreshAgenda();
     } catch (error) {
-		const nextError = handleApiFailure(error, 'No se pudo cancelar el turno.');
-		setErrorMessage(nextError.errorMessage);
-		setAccessDeniedMessage(nextError.accessDeniedMessage);
+      const nextError = handleApiFailure(error, 'No se pudo cancelar el turno.');
+      setErrorMessage(nextError.errorMessage);
+      setAccessDeniedMessage(nextError.accessDeniedMessage);
     } finally {
       setCancellingAppointmentId('');
     }
@@ -293,12 +297,29 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
       );
       await refreshAgenda();
     } catch (error) {
-		const nextError = handleApiFailure(error, 'No se pudieron generar los slots.');
-		setErrorMessage(nextError.errorMessage);
-		setAccessDeniedMessage(nextError.accessDeniedMessage);
+      const nextError = handleApiFailure(error, 'No se pudieron generar los slots.');
+      setErrorMessage(nextError.errorMessage);
+      setAccessDeniedMessage(nextError.accessDeniedMessage);
     } finally {
       setIsCreatingSlots(false);
     }
+  }
+
+  function shiftWeek(daysOffset: number) {
+    const currentWeekStart = new Date(`${weekStart}T00:00:00Z`);
+    const currentSelectedDay = new Date(`${selectedDate}T00:00:00Z`);
+    const selectedDayOffset = Math.round((currentSelectedDay.getTime() - currentWeekStart.getTime()) / 86400000);
+    const nextWeekStart = new Date(currentWeekStart);
+
+    nextWeekStart.setUTCDate(nextWeekStart.getUTCDate() + daysOffset);
+
+    const nextSelectedDay = new Date(nextWeekStart);
+    nextSelectedDay.setUTCDate(nextSelectedDay.getUTCDate() + selectedDayOffset);
+
+    clearReleasedSlotFeedback();
+    setWeekStart(formatDateInputValue(nextWeekStart));
+    setSelectedDate(formatDateInputValue(nextSelectedDay));
+    setSelectedSlotId('');
   }
 
   if (agendaMode.kind === 'forbidden') {
@@ -313,26 +334,16 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
 
   return (
     <div className="stack schedule-demo">
-      <header className="card schedule-hero">
-        <div className="schedule-hero-copy stack">
-          <div className="hero-kicker">Agenda diaria</div>
-          <div className="stack-tight">
-            <h1>Agenda de turnos</h1>
-            <p>
-              Elegí la fecha y el profesional, revisá la disponibilidad generada y reservá o cancelá con el flujo que
-              ya existe hoy.
-            </p>
-          </div>
-
+      <section className="card schedule-overview stack">
+        <div className="stack">
           <div className="schedule-hero-badges status-bar">
             <span className="badge neutral">Profesionales activos: {professionals.length}</span>
             <span className="badge neutral">Pacientes activos: {patients.length}</span>
-            <span className="badge neutral">Slots del día: {daySlots.length}</span>
-            <span className="badge info">UTC fijo para evitar corrimientos</span>
+            <span className="badge neutral">Disponibles semana: {weeklySummary.available}</span>
           </div>
 
           {(successMessage || errorMessage || accessDeniedMessage) && (
-            <div className="status-bar">
+            <div className="status-bar" aria-live="polite">
               {successMessage ? <span className="badge success">{successMessage}</span> : null}
               {errorMessage ? <span className="badge error">{errorMessage}</span> : null}
               {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
@@ -341,172 +352,247 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
         </div>
 
         <div className="schedule-hero-panel">
-            <div className="schedule-hero-panel-head">
-            <span className="summary-label">Agenda seleccionada</span>
+          <div className="schedule-hero-panel-head">
+            <span className="summary-label">Contexto de agenda</span>
             <strong>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name}` : 'Sin profesional'}</strong>
             <small>{selectedProfessional?.specialty ?? 'Elegí un profesional para revisar la agenda.'}</small>
           </div>
 
           <div className="schedule-stat-grid">
             <article className="schedule-stat-card">
-              <span className="summary-label">Fecha</span>
-              <strong>{formatLongDate(selectedDate)}</strong>
-              <small>Vista filtrada por día.</small>
+              <span className="summary-label">Semana UTC</span>
+              <strong>{formatLongDate(weekStart)}</strong>
+              <small>Tablero operativo de lunes a viernes.</small>
             </article>
             <article className="schedule-stat-card">
               <span className="summary-label">Disponibles</span>
-              <strong>{availableSlots.length}</strong>
-              <small>{availableSlots.length > 0 ? 'Listos para seleccionar.' : 'Todavía sin disponibilidad.'}</small>
+              <strong>{weeklySummary.available}</strong>
+              <small>{weeklySummary.available > 0 ? 'Listos para reservar.' : 'Sin disponibilidad reservable.'}</small>
             </article>
             <article className="schedule-stat-card">
               <span className="summary-label">Reservados</span>
-              <strong>{bookedAppointmentsCount}</strong>
-              <small>Turnos activos del día.</small>
+              <strong>{weeklySummary.booked}</strong>
+              <small>Turnos activos visibles.</small>
             </article>
             <article className="schedule-stat-card">
               <span className="summary-label">Cancelados</span>
-              <strong>{cancelledAppointmentsCount}</strong>
-              <small>Historial visible en agenda.</small>
+              <strong>{weeklySummary.cancelled}</strong>
+              <small>Visibles para seguimiento.</small>
             </article>
           </div>
         </div>
-      </header>
+      </section>
 
-      <div className="layout schedule-layout">
-        <aside className="schedule-sidebar stack">
-          <section className="card card-accent schedule-controls-card stack">
-            <div>
-              <span className="summary-label">Contexto</span>
-              <h2>Filtros de agenda</h2>
-              <p className="helper">Paso 1: elegí profesional y fecha para cargar la disponibilidad del día.</p>
-            </div>
-
-            <div className="field">
-              <label htmlFor="professional">Profesional</label>
-              {isDoctorAgenda ? (
-                <div className="inline-note">
-                  <strong>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name}` : 'Mi agenda'}</strong>
-                  <span>{selectedProfessional?.specialty ?? 'Agenda fija por ownership del doctor.'}</span>
-                </div>
-              ) : (
-                <select
-                  id="professional"
-                  value={selectedProfessionalId}
-                  onChange={(event) => {
-                    clearReleasedSlotFeedback();
-                    setSelectedProfessionalId(event.target.value);
-                  }}
-                  disabled={isBootstrapping || professionals.length === 0}
-                >
-                  {professionals.length === 0 ? <option value="">No hay profesionales</option> : null}
-                  {professionals.map((professional) => (
-                    <option key={professional.id} value={professional.id}>
-                      {professional.first_name} {professional.last_name} · {professional.specialty}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </div>
-
-            <div className="field">
-              <label htmlFor="date">Fecha</label>
-              <input
-                id="date"
-                type="date"
-                value={selectedDate}
-                onChange={(event) => {
-                  clearReleasedSlotFeedback();
-                  setSelectedDate(event.target.value);
-                }}
-              />
-              <small className="helper">La fecha se interpreta en UTC, igual que la disponibilidad del backend.</small>
-            </div>
-
-            <button
-              className="button secondary"
-              type="button"
-              onClick={() => {
-                clearReleasedSlotFeedback();
-                void refreshAgenda();
-              }}
-              disabled={isBootstrapping || isRefreshingAgenda}
-            >
+      <section className="card card-accent schedule-controls-card stack">
+        <div className="schedule-controls-head">
+          <div>
+            <span className="summary-label">Contexto</span>
+            <h2>Filtros de agenda</h2>
+            <p className="helper">Elegí profesional y semana para cargar la operación visible sin salir del espacio actual.</p>
+          </div>
+          <div className="schedule-controls-toolbar">
+            <span className="badge info">UTC fijo para evitar corrimientos</span>
+            <button className="button secondary" type="button" onClick={() => void refreshAgenda()} disabled={isBootstrapping || isRefreshingAgenda}>
               {isRefreshingAgenda ? 'Actualizando...' : 'Actualizar agenda'}
             </button>
-          </section>
+          </div>
+        </div>
 
-          <section className="card schedule-generator-card stack" aria-labelledby="generate-slots-title">
-            <div className="stack-tight">
-              <span className="summary-label schedule-dark-eyebrow">Automatización</span>
-              <h2 id="generate-slots-title">Generar slots</h2>
-              <p className="helper">Paso 2 opcional: cargá disponibilidad para esa agenda sin salir de esta vista.</p>
-            </div>
-
-            <div className="time-grid">
-              <div className="field">
-                <label htmlFor="slot-start-time">Desde</label>
-                <input
-                  id="slot-start-time"
-                  type="time"
-                  value={slotStartTime}
-                  onChange={(event) => setSlotStartTime(event.target.value)}
-                />
+        <div className="schedule-filters-grid">
+          <div className="field">
+            <label htmlFor="professional">Profesional</label>
+            {isDoctorAgenda ? (
+              <div className="inline-note">
+                <strong>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name}` : 'Mi agenda'}</strong>
+                <span>{selectedProfessional?.specialty ?? 'Agenda fija por ownership del doctor.'}</span>
               </div>
-
-              <div className="field">
-                <label htmlFor="slot-end-time">Hasta</label>
-                <input id="slot-end-time" type="time" value={slotEndTime} onChange={(event) => setSlotEndTime(event.target.value)} />
-              </div>
-            </div>
-
-            <div className="field">
-              <label htmlFor="slot-duration">Duración del slot</label>
+            ) : (
               <select
-                id="slot-duration"
-                value={slotDurationMinutes}
-                onChange={(event) => setSlotDurationMinutes(Number(event.target.value) as BulkCreateSlotsPayload['slot_duration_minutes'])}
+                id="professional"
+                value={selectedProfessionalId}
+                onChange={(event) => {
+                  clearReleasedSlotFeedback();
+                  setSelectedProfessionalId(event.target.value);
+                }}
+                disabled={isBootstrapping || professionals.length === 0}
               >
-                {[15, 20, 30, 60].map((duration) => (
-                  <option key={duration} value={duration}>
-                    {duration} minutos
+                {professionals.length === 0 ? <option value="">No hay profesionales</option> : null}
+                {professionals.map((professional) => (
+                  <option key={professional.id} value={professional.id}>
+                    {professional.first_name} {professional.last_name} · {professional.specialty}
                   </option>
                 ))}
               </select>
-            </div>
+            )}
+          </div>
 
-            <div className="schedule-generator-summary">
-              <span>Ventana</span>
-              <strong>
-                {slotStartTime} → {slotEndTime}
-              </strong>
-              <small>{slotDurationMinutes} min por slot</small>
-            </div>
+          <div className="field">
+            <label htmlFor="date">Fecha</label>
+            <input
+              id="date"
+              type="date"
+              value={selectedDate}
+              onChange={(event) => {
+                const nextSelectedDate = mapDateToOperationalWeek(event.target.value);
 
-            <button
-              className="button schedule-generator-button"
-              type="button"
-              onClick={() => void handleCreateSlots()}
-              disabled={isBootstrapping || isRefreshingAgenda || isCreatingSlots || !selectedProfessionalId || !selectedDate}
-            >
-              {isCreatingSlots ? 'Generando...' : 'Generar slots'}
+                clearReleasedSlotFeedback();
+                setSelectedDate(nextSelectedDate);
+                setWeekStart(getUtcWeekStart(nextSelectedDate));
+                setSelectedSlotId('');
+              }}
+            />
+            <small className="helper">La fecha define el día operativo seleccionado; la semana visible se acomoda en UTC alrededor de ese día.</small>
+          </div>
+
+          <div className="schedule-controls-toolbar">
+            <button className="button secondary" type="button" onClick={() => shiftWeek(-7)} disabled={isBootstrapping || isRefreshingAgenda}>
+              Semana anterior
             </button>
+            <button className="button secondary" type="button" onClick={() => shiftWeek(7)} disabled={isBootstrapping || isRefreshingAgenda}>
+              Semana siguiente
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <div className="layout schedule-layout">
+        <section className="stack schedule-main">
+          <section className="card stack">
+            <div className="section-header">
+              <div>
+                <span className="summary-label">Tablero</span>
+                <h2>Semana operativa</h2>
+                <p>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name} · foco actual ${formatLongDate(selectedDate)}` : 'Seleccioná un profesional para ver disponibilidad.'}</p>
+              </div>
+            </div>
+
+            {releasedSlotId && releasedSlotLabel ? (
+              <div className="slot-grid-feedback" role="status">
+                <strong>Slot liberado</strong>
+                <span>{releasedSlotLabel} ya está otra vez disponible y quedó seleccionado para que se note el cambio.</span>
+              </div>
+            ) : null}
+
+            <div className="schedule-week-board stack">
+              <div className="schedule-week-header" role="row">
+                <div className="summary-label schedule-week-axis">UTC</div>
+                {days.map((day) => (
+                  <button
+                    key={day.date}
+                    type="button"
+                    aria-pressed={day.date === selectedDate}
+                    className={`schedule-day-card${day.date === selectedDate ? ' selected' : ''}`}
+                    onClick={() => {
+                      setSelectedDate(day.date);
+                      setSelectedSlotId('');
+                    }}
+                  >
+                    <strong>{day.weekdayLabel}</strong>
+                    <small>{day.date === selectedDate ? 'Día seleccionado para operar' : 'Hacé click para operar este día'}</small>
+                    {day.slots.length === 0 && day.appointments.length === 0 ? <small>Sin actividad para este día</small> : null}
+                    <small>
+                      {day.summary.available} disp. · {day.summary.booked} reserv. · {day.summary.cancelled} canc.
+                    </small>
+                  </button>
+                ))}
+              </div>
+
+              {timeBands.length === 0 ? (
+                <div className="schedule-week-empty-grid">
+                  <div className="summary-label schedule-week-axis">UTC</div>
+                  {days.map((day) => (
+                    <div key={day.date} className="empty-state">
+                      <strong>{day.weekdayLabel}</strong>
+                      <span>Sin actividad para este día</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                timeBands.map((band) => (
+                  <div key={band} className={`schedule-week-row${focusedBand === band ? ' selected' : ''}`} role="row">
+                    <div className="summary-label">{band}</div>
+                    {days.map((day) => {
+                      const slot = day.slots.find((item) => formatTimeBand(item.start_time) === band) ?? null;
+                      const appointment = slot ? appointmentBySlotId.get(slot.id) ?? day.appointments.find((item) => item.slot_id === slot.id) ?? null : null;
+                      const patientName = appointment ? patientNameById.get(appointment.patient_id) ?? appointment.patient_id : '';
+                      const isSelectedSlot = slot?.id === selectedSlotId;
+                      const isReleasedSlot = slot?.id === releasedSlotId;
+                      const cellLabel = slot ? `${day.weekdayLabel} · ${formatDateTimeRange(slot.start_time, slot.end_time)}` : `${day.weekdayLabel} · ${band}`;
+
+                      return (
+                        <div key={`${day.date}-${band}`} data-testid={`board-cell-${day.date}-${band}`} className={`card schedule-board-cell${day.date === selectedDate ? ' selected-day' : ''}`}>
+                          {slot?.status === 'available' ? (
+                            <div className="stack-tight">
+                              {appointment?.status === 'cancelled' ? (
+                                <>
+                                  <strong>{patientName}</strong>
+                                  <span className="pill cancelled">Cancelado</span>
+                                </>
+                              ) : null}
+                              <button
+                                type="button"
+                                aria-pressed={isSelectedSlot}
+                                className={`slot-button${isSelectedSlot ? ' selected' : ''}${isReleasedSlot ? ' released' : ''}`}
+                                onClick={() => {
+                                  setSelectedDate(day.date);
+                                  setSelectedSlotId(slot.id);
+                                  setFocusedBand(band);
+                                  if (slot.id !== releasedSlotId) {
+                                    setReleasedSlotId('');
+                                    setReleasedSlotLabel('');
+                                  }
+                                }}
+                              >
+                                <span className="slot-card-kicker">Horario disponible</span>
+                                <strong>{cellLabel}</strong>
+                                <span className="slot-note">{isReleasedSlot ? 'Se liberó recién' : 'Seleccioná este horario'}</span>
+                              </button>
+                            </div>
+                          ) : appointment ? (
+                            <div className="stack-tight">
+                              <strong>{patientName}</strong>
+                              <small>{slot ? formatDateTimeRange(slot.start_time, slot.end_time) : 'Horario no disponible'}</small>
+                              {selectedProfessional ? (
+                                <small>
+                                  {selectedProfessional.first_name} {selectedProfessional.last_name} · {formatLongDate(day.date)}
+                                </small>
+                              ) : null}
+                              <span className={`pill${appointment.status === 'cancelled' ? ' cancelled' : ''}`}>{appointment.status === 'cancelled' ? 'Cancelado' : 'Reservado'}</span>
+                              <button
+                                className="button ghost"
+                                type="button"
+                                onClick={() => {
+                                  setSelectedDate(day.date);
+                                  setFocusedBand(band);
+                                  void handleCancelAppointment(appointment.id);
+                                }}
+                                disabled={appointment.status === 'cancelled' || cancellingAppointmentId === appointment.id}
+                              >
+                                {cancellingAppointmentId === appointment.id ? 'Cancelando...' : 'Cancelar'}
+                              </button>
+                            </div>
+                          ) : (
+                            <span className="helper">—</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
           </section>
 
           <section className="card schedule-booking-card stack">
             <div>
               <span className="summary-label">Reserva</span>
               <h2>Reservar turno</h2>
-              <p className="helper">Paso 3: elegí un horario desde la grilla principal y asignalo a un paciente.</p>
+              <p className="helper">La reserva sigue arrancando desde la grilla principal: primero elegí un horario y después asignalo a un paciente.</p>
             </div>
 
             <div className="field">
               <label htmlFor="patient">Paciente</label>
-              <select
-                id="patient"
-                value={selectedPatientId}
-                onChange={(event) => setSelectedPatientId(event.target.value)}
-                disabled={isBootstrapping || patients.length === 0}
-              >
+              <select id="patient" value={selectedPatientId} onChange={(event) => setSelectedPatientId(event.target.value)} disabled={isBootstrapping || patients.length === 0}>
                 {patients.length === 0 ? <option value="">No hay pacientes</option> : null}
                 {patients.map((patient) => (
                   <option key={patient.id} value={patient.id}>
@@ -525,170 +611,62 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
               </span>
             </div>
 
-            <button
-              className="button"
-              type="button"
-              onClick={() => void handleBookAppointment()}
-              disabled={isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId || !selectedPatientId}
-            >
+            <button className="button" type="button" onClick={() => void handleBookAppointment()} disabled={isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId || !selectedPatientId}>
               {isBooking ? 'Reservando...' : 'Reservar turno'}
             </button>
+          </section>
+        </section>
+
+        <aside className="schedule-sidebar stack">
+          <section className="card schedule-generator-card stack" aria-labelledby="generate-slots-title">
+            <div className="stack-tight">
+              <span className="summary-label schedule-dark-eyebrow">Soporte</span>
+              <h2 id="generate-slots-title">Generar slots</h2>
+              <p className="helper">Acción secundaria: cargá disponibilidad para el día seleccionado sin salir de esta vista.</p>
+            </div>
 
             <div className="inline-note">
-              <strong>Nota:</strong> si cargás un paciente o profesional en Directorio, al volver a Agenda se refresca la base
-              disponible sin recargar toda la app.
+              <strong>{selectedWeekDay?.weekdayLabel ?? 'Sin día seleccionado'}</strong>
+              <span>{selectedWeekDay ? formatLongDate(selectedWeekDay.date) : 'Elegí una fecha para cargar disponibilidad.'}</span>
             </div>
+
+            <div className="time-grid">
+              <div className="field">
+                <label htmlFor="slot-start-time">Desde</label>
+                <input id="slot-start-time" type="time" value={slotStartTime} onChange={(event) => setSlotStartTime(event.target.value)} />
+              </div>
+
+              <div className="field">
+                <label htmlFor="slot-end-time">Hasta</label>
+                <input id="slot-end-time" type="time" value={slotEndTime} onChange={(event) => setSlotEndTime(event.target.value)} />
+              </div>
+            </div>
+
+            <div className="field">
+              <label htmlFor="slot-duration">Duración del slot</label>
+              <select id="slot-duration" value={slotDurationMinutes} onChange={(event) => setSlotDurationMinutes(Number(event.target.value) as BulkCreateSlotsPayload['slot_duration_minutes'])}>
+                {[15, 20, 30, 60].map((duration) => (
+                  <option key={duration} value={duration}>
+                    {duration} minutos
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="schedule-generator-summary">
+              <span>Ventana</span>
+              <strong>
+                {slotStartTime} → {slotEndTime}
+              </strong>
+              <small>{slotDurationMinutes} min por slot</small>
+            </div>
+
+            <button className="button schedule-generator-button" type="button" onClick={() => void handleCreateSlots()} disabled={isBootstrapping || isRefreshingAgenda || isCreatingSlots || !selectedProfessionalId || !selectedDate}>
+              {isCreatingSlots ? 'Generando...' : 'Generar slots'}
+            </button>
           </section>
         </aside>
-
-        <section className="stack schedule-main">
-          <article className="card">
-            <div className="section-header">
-              <div>
-                <h2>Slots disponibles</h2>
-                <p>
-                  {selectedProfessional
-                    ? `${selectedProfessional.first_name} ${selectedProfessional.last_name} · ${formatLongDate(selectedDate)}`
-                    : 'Seleccioná un profesional para ver disponibilidad.'}
-                </p>
-              </div>
-              <span className="badge neutral">{availableSlots.length} disponibles</span>
-            </div>
-
-            {isBootstrapping || isRefreshingAgenda ? (
-              <div className="empty-state empty-state-soft">Cargando disponibilidad...</div>
-            ) : availableSlots.length === 0 ? (
-              <div className="empty-state">
-                <strong>Sin slots disponibles</strong>
-                <span>Generá disponibilidad o cambiá la fecha para mostrar horarios reservables.</span>
-              </div>
-            ) : (
-                <>
-                  {releasedSlotId && releasedSlotLabel ? (
-                    <div className="slot-grid-feedback" role="status">
-                      <strong>Slot liberado</strong>
-                      <span>{releasedSlotLabel} ya está otra vez disponible y quedó seleccionado para que se note el cambio.</span>
-                    </div>
-                  ) : null}
-
-                  <div className="slot-grid schedule-slot-grid">
-                    {availableSlots.map((slot) => {
-                      const isSelected = slot.id === selectedSlotId;
-                      const isRecentlyReleased = slot.id === releasedSlotId;
-
-                      return (
-                        <button
-                          key={slot.id}
-                          type="button"
-                          aria-pressed={isSelected}
-                          className={`slot-button${isSelected ? ' selected' : ''}${isRecentlyReleased ? ' released' : ''}`}
-                          onClick={() => {
-                            setSelectedSlotId(slot.id);
-
-                            if (slot.id !== releasedSlotId) {
-                              setReleasedSlotId('');
-                              setReleasedSlotLabel('');
-                            }
-                          }}
-                        >
-                          <span className="slot-card-kicker">Horario disponible</span>
-                          <strong>{formatDateTimeRange(slot.start_time, slot.end_time)}</strong>
-                          <span className="slot-note">{isRecentlyReleased ? 'Se liberó recién' : 'Seleccioná este horario'}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </>
-            )}
-          </article>
-
-          <article className="card">
-            <div className="section-header">
-              <div>
-                <h2>Turnos del día</h2>
-                <p>Listado simple con paciente, horario y estado listo para operar.</p>
-              </div>
-              <span className="badge neutral">{appointments.length} total</span>
-            </div>
-
-            {isBootstrapping || isRefreshingAgenda ? (
-              <div className="empty-state empty-state-soft">Cargando turnos...</div>
-            ) : appointments.length === 0 ? (
-              <div className="empty-state">
-                <strong>Sin turnos cargados</strong>
-                <span>Reservá uno desde un slot disponible para que la demo muestre el flujo completo.</span>
-              </div>
-            ) : (
-                <div className="list schedule-appointments-list">
-                  {appointments.map((appointment) => {
-                    const slot = slotById.get(appointment.slot_id);
-                    const patientName = patientNameById.get(appointment.patient_id) ?? appointment.patient_id;
-                    const isCancelled = appointment.status === 'cancelled';
-
-                    return (
-                      <div key={appointment.id} className="appointment-item">
-                        <div className="appointment-main">
-                          <div className="appointment-avatar" aria-hidden="true">
-                            {getInitials(patientName)}
-                          </div>
-
-                          <div className="stack-tight">
-                            <strong>{patientName}</strong>
-                            <small>{slot ? formatDateTimeRange(slot.start_time, slot.end_time) : 'Horario no disponible'}</small>
-                            {selectedProfessional ? (
-                              <small>
-                                {selectedProfessional.first_name} {selectedProfessional.last_name} · {formatLongDate(selectedDate)}
-                              </small>
-                            ) : null}
-                          </div>
-                        </div>
-
-                        <div className="appointment-meta">
-                          <span className={`pill${isCancelled ? ' cancelled' : ''}`}>{isCancelled ? 'Cancelado' : 'Reservado'}</span>
-                        </div>
-
-                        <div className="appointment-actions">
-                          <button
-                            className="button ghost"
-                            type="button"
-                            onClick={() => void handleCancelAppointment(appointment.id)}
-                            disabled={isCancelled || cancellingAppointmentId === appointment.id}
-                          >
-                            {cancellingAppointmentId === appointment.id ? 'Cancelando...' : 'Cancelar'}
-                          </button>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-            )}
-          </article>
-        </section>
       </div>
     </div>
   );
-}
-
-function getInitials(fullName: string) {
-  return fullName
-    .split(' ')
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((chunk) => chunk[0]?.toUpperCase() ?? '')
-    .join('');
-}
-
-function compareByStartTime(left: Slot, right: Slot) {
-  return new Date(left.start_time).getTime() - new Date(right.start_time).getTime();
-}
-
-function compareAppointmentsBySlot(slots: Slot[]) {
-  const slotOrder = new Map(slots.map((slot, index) => [slot.id, index]));
-
-  return (left: Appointment, right: Appointment) => {
-    const leftOrder = slotOrder.get(left.slot_id) ?? Number.MAX_SAFE_INTEGER;
-    const rightOrder = slotOrder.get(right.slot_id) ?? Number.MAX_SAFE_INTEGER;
-
-    return leftOrder - rightOrder;
-  };
 }

--- a/web/src/features/schedule/helpers.test.ts
+++ b/web/src/features/schedule/helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatWeekdayLabel,
+  getOperationalWeekDays,
+  getUtcWeekStart,
+  mapDateToOperationalWeek,
+  normalizeOperationalTimeBands,
+} from './helpers';
+
+describe('schedule week helpers', () => {
+  it('derives the monday week start in UTC from any selected day', () => {
+    expect(getUtcWeekStart('2026-04-08')).toBe('2026-04-06');
+    expect(getUtcWeekStart('2026-04-12')).toBe('2026-04-06');
+  });
+
+  it('maps any selected day to a visible monday-friday operational week', () => {
+    expect(getOperationalWeekDays('2026-04-06').map((day) => day.date)).toEqual([
+      '2026-04-06',
+      '2026-04-07',
+      '2026-04-08',
+      '2026-04-09',
+      '2026-04-10',
+    ]);
+    expect(mapDateToOperationalWeek('2026-04-12')).toBe('2026-04-10');
+  });
+
+  it('formats short weekday labels and normalizes sparse time bands', () => {
+    expect(formatWeekdayLabel('2026-04-06')).toBe('Lun 06/04');
+    expect(
+      normalizeOperationalTimeBands([
+        { start_time: '2026-04-06T10:00:00Z' },
+        { start_time: '2026-04-07T09:00:00Z' },
+        { start_time: '2026-04-06T10:00:00Z' },
+      ]),
+    ).toEqual(['09:00', '10:00']);
+  });
+});

--- a/web/src/features/schedule/helpers.ts
+++ b/web/src/features/schedule/helpers.ts
@@ -1,6 +1,13 @@
 const AGENDA_DEMO_LOCALE = 'es-AR';
 const AGENDA_DEMO_TIME_ZONE = 'UTC';
 
+const WEEKDAY_SHORT_LABELS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'] as const;
+
+export type OperationalWeekDay = {
+  date: string;
+  weekdayLabel: string;
+};
+
 // Demo rule: backend stores and filters agenda timestamps in UTC,
 // so the frontend must render and default dates in UTC as well.
 export function formatDateInputValue(date = new Date()) {
@@ -16,6 +23,68 @@ export function formatDateTimeRange(startTime: string, endTime: string) {
   const end = new Date(endTime);
 
   return `${formatTime(start)} - ${formatTime(end)} UTC`;
+}
+
+export function formatWeekdayLabel(date: string) {
+  const parsedDate = new Date(`${date}T00:00:00Z`);
+  const weekday = WEEKDAY_SHORT_LABELS[parsedDate.getUTCDay()];
+  const day = `${parsedDate.getUTCDate()}`.padStart(2, '0');
+  const month = `${parsedDate.getUTCMonth() + 1}`.padStart(2, '0');
+
+  return `${weekday} ${day}/${month}`;
+}
+
+export function getUtcWeekStart(date: string) {
+  const parsedDate = new Date(`${date}T00:00:00Z`);
+  const dayOfWeek = parsedDate.getUTCDay();
+  const offsetToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+
+  parsedDate.setUTCDate(parsedDate.getUTCDate() + offsetToMonday);
+
+  return formatDateInputValue(parsedDate);
+}
+
+export function mapDateToOperationalWeek(date: string) {
+  const parsedDate = new Date(`${date}T00:00:00Z`);
+  const dayOfWeek = parsedDate.getUTCDay();
+
+  if (dayOfWeek === 6) {
+    parsedDate.setUTCDate(parsedDate.getUTCDate() - 1);
+  }
+
+  if (dayOfWeek === 0) {
+    parsedDate.setUTCDate(parsedDate.getUTCDate() - 2);
+  }
+
+  return formatDateInputValue(parsedDate);
+}
+
+export function getOperationalWeekDays(date: string): OperationalWeekDay[] {
+  const weekStart = getUtcWeekStart(date);
+
+  return Array.from({ length: 5 }, (_, index) => {
+    const currentDate = new Date(`${weekStart}T00:00:00Z`);
+    currentDate.setUTCDate(currentDate.getUTCDate() + index);
+
+    const currentDateValue = formatDateInputValue(currentDate);
+
+    return {
+      date: currentDateValue,
+      weekdayLabel: formatWeekdayLabel(currentDateValue),
+    };
+  });
+}
+
+export function normalizeOperationalTimeBands(items: Array<{ start_time: string }>) {
+  return [...new Set(items.map((item) => formatTimeBand(item.start_time)))].sort();
+}
+
+export function formatTimeBand(dateTime: string) {
+  const parsedDate = new Date(dateTime);
+  const hours = `${parsedDate.getUTCHours()}`.padStart(2, '0');
+  const minutes = `${parsedDate.getUTCMinutes()}`.padStart(2, '0');
+
+  return `${hours}:${minutes}`;
 }
 
 export function formatLongDate(date: string) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -75,10 +75,6 @@ button {
   margin: 0 auto;
 }
 
-.app-shell {
-  gap: 20px;
-}
-
 .auth-shell {
   max-width: 560px;
 }
@@ -376,13 +372,35 @@ button {
   gap: 18px;
 }
 
+.schedule-demo {
+  --schedule-ink: #2b1718;
+  --schedule-soft-text: #6a5657;
+  --schedule-burgundy: #570000;
+  --schedule-burgundy-soft: #f7ecec;
+  --schedule-gold: #735c00;
+  --schedule-gold-soft: #fff7dd;
+  --schedule-surface: #fcf8f5;
+  --schedule-surface-strong: #f4eeea;
+  --schedule-ghost-border: rgba(87, 0, 0, 0.12);
+}
+
+.schedule-overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 24px;
+  align-items: start;
+}
+
 .schedule-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.95fr);
-  gap: 20px;
-  padding: 28px;
-  border-color: #d7e3ef;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.96) 100%);
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.95fr);
+  gap: 24px;
+  padding: 32px;
+  border-color: var(--schedule-ghost-border);
+  background:
+    radial-gradient(circle at top right, rgba(254, 214, 91, 0.14), transparent 34%),
+    linear-gradient(180deg, rgba(255, 251, 247, 0.98) 0%, rgba(247, 239, 235, 0.96) 100%);
+  box-shadow: 0 18px 38px rgba(43, 23, 24, 0.06);
 }
 
 .schedule-hero-copy {
@@ -391,6 +409,7 @@ button {
 
 .schedule-hero-copy p {
   max-width: 60ch;
+  color: var(--schedule-soft-text);
 }
 
 .schedule-hero-badges {
@@ -401,10 +420,11 @@ button {
   display: grid;
   gap: 16px;
   align-content: start;
-  padding: 20px;
-  border-radius: var(--radius-lg);
-  border: 1px solid #dde6f0;
-  background: #f8fafc;
+  padding: 22px;
+  border-radius: 24px;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  background: rgba(255, 252, 250, 0.82);
+  backdrop-filter: blur(18px);
 }
 
 .schedule-hero-panel-head {
@@ -414,23 +434,60 @@ button {
 
 .schedule-hero-panel-head strong {
   font-size: 1.2rem;
+  color: var(--schedule-ink);
 }
 
 .schedule-stat-card {
   display: grid;
   gap: 4px;
   padding: 14px;
-  border: 1px solid #dbe5ee;
-  background: #ffffff;
+  border: 1px solid rgba(87, 0, 0, 0.06);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(250, 245, 241, 0.92) 100%);
 }
 
 .schedule-stat-card strong {
   font-size: 1.02rem;
-  color: var(--text);
+  color: var(--schedule-ink);
 }
 
 .schedule-layout {
   align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+}
+
+.schedule-controls-card,
+.schedule-booking-card,
+.schedule-slots-card,
+.schedule-appointments-card,
+.schedule-generator-card {
+  border-color: rgba(87, 0, 0, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(249, 244, 240, 0.96) 100%);
+}
+
+.schedule-controls-head,
+.schedule-controls-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.schedule-controls-toolbar {
+  flex-wrap: wrap;
+}
+
+.schedule-filters-grid,
+.schedule-primary-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.schedule-filters-grid {
+  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+}
+
+.schedule-primary-grid {
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
 }
 
 .patients-workspace-grid {
@@ -501,16 +558,16 @@ button {
 }
 
 .schedule-generator-card {
-  border-color: #e6dccf;
-  background: linear-gradient(180deg, #fffdf9 0%, #fbf5ec 100%);
+  border-color: rgba(115, 92, 0, 0.14);
+  background: linear-gradient(180deg, rgba(255, 252, 245, 0.98) 0%, rgba(250, 242, 223, 0.96) 100%);
 }
 
 .schedule-generator-summary {
   display: grid;
   gap: 4px;
   padding: 14px 16px;
-  border: 1px solid #eadfce;
-  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(115, 92, 0, 0.12);
+  background: rgba(255, 252, 246, 0.92);
 }
 
 .schedule-generator-summary span {
@@ -526,7 +583,11 @@ button {
 }
 
 .schedule-generator-button {
-  background: #31261f;
+  background: linear-gradient(135deg, #705600 0%, #8b6b00 100%);
+}
+
+.schedule-generator-button:hover:not(:disabled) {
+  background: linear-gradient(135deg, #5e4800 0%, #735c00 100%);
 }
 
 .field {
@@ -654,16 +715,41 @@ button {
 }
 
 .slot-grid-feedback {
-  border: 1px solid #bbf7d0;
-  background: #f0fdf4;
+  border: 1px solid rgba(22, 101, 52, 0.14);
+  background: #f4fbf4;
   color: var(--success-text);
   margin-bottom: 14px;
 }
 
+.schedule-demo .button {
+  background: linear-gradient(135deg, #570000 0%, #800000 100%);
+  box-shadow: 0 8px 24px rgba(43, 23, 24, 0.08);
+}
+
+.schedule-demo .button:hover:not(:disabled) {
+  background: linear-gradient(135deg, #480000 0%, #6d0000 100%);
+}
+
+.schedule-demo .button.secondary {
+  background: rgba(255, 252, 246, 0.9);
+  color: var(--schedule-ink);
+  border-color: rgba(115, 92, 0, 0.14);
+}
+
+.schedule-demo .button.secondary:hover:not(:disabled),
+.schedule-demo .button.ghost:hover:not(:disabled) {
+  background: rgba(255, 247, 221, 0.92);
+}
+
+.schedule-demo .button.ghost {
+  color: var(--schedule-ink);
+  border-color: rgba(87, 0, 0, 0.12);
+}
+
 .inline-note {
-  border: 1px solid #d7e6fb;
-  background: #f8fbff;
-  color: #26436f;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  background: var(--schedule-surface);
+  color: var(--schedule-ink);
 }
 
 .slot-button {
@@ -672,15 +758,15 @@ button {
   gap: 6px;
   min-height: 108px;
   padding: 16px;
-  border: 1px solid #dfe6ee;
-  background: #fff;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.92);
   text-align: left;
   box-shadow: none;
   transition: border-color 0.14s ease, background 0.14s ease, box-shadow 0.14s ease;
 }
 
 .slot-button:hover {
-  border-color: #cbd5e1;
+  border-color: rgba(87, 0, 0, 0.16);
   box-shadow: var(--shadow-soft);
 }
 
@@ -692,13 +778,90 @@ button {
 }
 
 .slot-button.selected {
-  border-color: #d6b18f;
-  background: #fff7ed;
+  border-color: rgba(115, 92, 0, 0.2);
+  background: var(--schedule-gold-soft);
 }
 
 .slot-button.released {
   border-color: #86efac;
   background: #f0fdf4;
+}
+
+.schedule-week-board {
+  display: grid;
+  gap: 12px;
+  overflow-x: auto;
+}
+
+.schedule-week-header,
+.schedule-week-row,
+.schedule-week-empty-grid {
+  display: grid;
+  grid-template-columns: minmax(72px, 88px) repeat(5, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+  min-width: 1080px;
+}
+
+.schedule-week-axis {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 8px;
+  border-radius: var(--radius-md);
+  background: rgba(87, 0, 0, 0.04);
+  border: 1px solid rgba(87, 0, 0, 0.08);
+}
+
+.schedule-day-card {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(250, 245, 241, 0.96) 100%);
+  text-align: left;
+  transition: border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
+}
+
+.schedule-day-card:hover {
+  border-color: rgba(115, 92, 0, 0.26);
+  box-shadow: var(--shadow-soft);
+}
+
+.schedule-day-card.selected {
+  border-color: rgba(115, 92, 0, 0.28);
+  background: var(--schedule-gold-soft);
+}
+
+.schedule-week-row {
+  position: relative;
+}
+
+.schedule-week-row.selected::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-md);
+  background: rgba(115, 92, 0, 0.05);
+  pointer-events: none;
+}
+
+.schedule-week-row > * {
+  position: relative;
+  z-index: 1;
+}
+
+.schedule-board-cell {
+  min-height: 132px;
+  display: grid;
+  align-content: start;
+  padding: 0;
+}
+
+.schedule-board-cell.selected-day {
+  border-color: rgba(115, 92, 0, 0.2);
+  background: rgba(255, 252, 246, 0.98);
 }
 
 .slot-note,
@@ -722,8 +885,8 @@ button {
   display: grid;
   gap: 10px;
   padding: 16px;
-  border: 1px solid #e3e9f4;
-  background: #fbfcfe;
+  border: 1px solid rgba(87, 0, 0, 0.06);
+  background: rgba(255, 252, 250, 0.95);
 }
 
 .schedule-appointments-list {
@@ -743,8 +906,8 @@ button {
   width: 42px;
   height: 42px;
   border-radius: 50%;
-  background: #e7eef8;
-  color: #26436f;
+  background: var(--schedule-burgundy-soft);
+  color: var(--schedule-burgundy);
   font-weight: 800;
 }
 
@@ -759,15 +922,19 @@ button {
   color: var(--success-text);
 }
 
+.schedule-booking-footnote {
+  color: var(--schedule-soft-text);
+}
+
 .pill.cancelled {
   background: var(--error-bg);
   color: var(--error-text);
 }
 
 .empty-state {
-  border: 1px dashed #d4deea;
-  background: var(--bg-surface-muted);
-  color: var(--text-soft);
+  border: 1px dashed rgba(87, 0, 0, 0.12);
+  background: var(--schedule-surface-strong);
+  color: var(--schedule-soft-text);
 }
 
 .empty-state strong {
@@ -785,7 +952,9 @@ button {
   .hero-summary-grid,
   .overview-grid,
   .surface-tabs,
-  .schedule-hero {
+  .schedule-hero,
+  .schedule-primary-grid,
+  .schedule-filters-grid {
     grid-template-columns: 1fr;
   }
 
@@ -809,7 +978,9 @@ button {
   }
 
   .surface-switcher-header,
-  .section-header {
+  .section-header,
+  .schedule-controls-head,
+  .schedule-controls-toolbar {
     flex-direction: column;
     align-items: stretch;
   }
@@ -830,5 +1001,11 @@ button {
   .section-hero-card h1,
   .section-hero-card h2 {
     font-size: 1.8rem;
+  }
+
+  .schedule-week-header,
+  .schedule-week-row,
+  .schedule-week-empty-grid {
+    min-width: 980px;
   }
 }


### PR DESCRIPTION
Closes #21

## Summary
- replace the single-day agenda surface with a Monday-Friday weekly operational board that keeps all weekdays visible in one screen
- preserve current supported actions by keeping one selected operational day, booking from actionable slot cells, cancellation from appointment entries, and slot generation from the support rail
- add focused frontend runtime coverage for weekly composition, weekday selection, guardrails, and preserved workflow behavior over the existing day-based API model

## Changes
| File | Change |
|------|--------|
| `web/src/api/appointments.ts` | Adds frontend week composition helper over existing daily agenda endpoints |
| `web/src/api/appointments.test.ts` | Verifies weekly composition and guardrail failure behavior |
| `web/src/features/schedule/helpers.ts` | Adds UTC-safe operational week/date helpers |
| `web/src/features/schedule/helpers.test.ts` | Verifies week helper behavior and UTC alignment |
| `web/src/features/schedule/ScheduleDemo.tsx` | Implements the Monday-Friday weekly operational agenda board |
| `web/src/features/schedule/ScheduleDemo.test.tsx` | Verifies weekday selection, preserved actions, and weekly-board guardrails |
| `web/src/styles.css` | Adds weekly agenda board layout and agenda-scoped styling needed for the matrix view |

## Test Plan
- [x] `npm test -- src/api/appointments.test.ts src/features/schedule/helpers.test.ts src/features/schedule/ScheduleDemo.test.tsx` in `web/`
- [x] `npm run typecheck` in `web/`
- [x] Verified no shell-wide redesign, no bulk editing, no backend range API assumption, and no new route/permission behavior in this slice

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Added docs/contract updates where behavior changed
- [x] Used conventional commits only
- [x] No `Co-Authored-By` trailers added