### PR TITLE
refactor(web): extract authenticated app shell

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -37,8 +37,9 @@ describe('App actor-aware shell', () => {
     render(<App />);
 
     expect(screen.getByRole('heading', { name: 'Panel de trabajo de la clínica' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Mi agenda' })).toBeInTheDocument();
     expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(
-      expect.arrayContaining(['Atención del díaMi agendaTus turnos y disponibilidad de hoy.', 'SeguimientoPacientesResumen clínico y encounters del paciente.']),
+      expect.arrayContaining(['Atención semanalMi agendaTus turnos y disponibilidad operativa de la semana.', 'SeguimientoPacientesResumen clínico y encounters del paciente.']),
     );
     expect(screen.getAllByRole('tab')).toHaveLength(2);
     expect(screen.getByText('schedule:doctor-own')).toBeInTheDocument();
@@ -50,9 +51,10 @@ describe('App actor-aware shell', () => {
     render(<App />);
 
     expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(
-      expect.arrayContaining(['Gestión diariaAgendaTurnos, disponibilidad y cambios del día.', 'AdmisiónPacientesBúsqueda y selección para tareas administrativas.']),
+      expect.arrayContaining(['Gestión semanalAgendaTablero operativo para comparar y accionar toda la semana.', 'AdmisiónPacientesBúsqueda y selección para tareas administrativas.']),
     );
     expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
     expect(screen.getByText('schedule:operational-shared')).toBeInTheDocument();
   });
 
@@ -81,6 +83,7 @@ describe('App actor-aware shell', () => {
 
     expect(screen.getAllByRole('tab')).toHaveLength(1);
     expect(screen.getAllByRole('tab')[0]?.textContent).toBe('Base clínicaDirectorioPacientes y profesionales para operar la clínica.');
+    expect(screen.getByRole('heading', { name: 'Directorio' })).toBeInTheDocument();
     expect(screen.getByText('directory:setup-shared')).toBeInTheDocument();
   });
 
@@ -93,6 +96,7 @@ describe('App actor-aware shell', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /Pacientes/i }));
 
+    expect(screen.getByRole('heading', { name: 'Pacientes' })).toBeInTheDocument();
     expect(screen.getByText('patients:secretary-operational')).toBeInTheDocument();
     expect(screen.queryByText('schedule:operational-shared')).not.toBeInTheDocument();
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,17 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
-import { deriveActorCapabilities, type SurfaceId } from './auth/actorCapabilities';
+import { AppShell } from './app-shell/AppShell';
+import { deriveActorCapabilities, resolveShellSurfaceMetadata, type SurfaceId } from './auth/actorCapabilities';
 import { useAuthSession } from './auth/useAuthSession';
 import { LoginScreen } from './features/auth/LoginScreen';
 import { DirectoryDemo } from './features/directory/DirectoryDemo';
 import { PatientsWorkspace } from './features/patients/PatientsWorkspace';
 import { ScheduleDemo } from './features/schedule/ScheduleDemo';
-
-type SurfaceDefinition = {
-  id: SurfaceId;
-  label: string;
-  eyebrow: string;
-  description: string;
-};
 
 export default function App() {
   const auth = useAuthSession();
@@ -20,7 +14,13 @@ export default function App() {
     [auth.user],
   );
   const availableSurfaces = useMemo(
-    () => (capabilities ? capabilities.visibleSurfaces.map((surface) => getSurfaceDefinition(surface, capabilities)) : []),
+    () =>
+      capabilities
+        ? capabilities.visibleSurfaces.map((surface) => ({
+            id: surface,
+            ...resolveShellSurfaceMetadata(surface, capabilities),
+          }))
+        : [],
     [capabilities],
   );
   const [activeSurface, setActiveSurface] = useState<SurfaceId>('agenda');
@@ -57,110 +57,29 @@ export default function App() {
   }
 
   return (
-    <main className="page">
-      <div className="shell app-shell stack">
-        <header className="hero hero-product card">
-          <div className="hero-kicker">Clinic Platform · sesión activa</div>
-          <div className="hero-copy stack-tight">
-            <h1>Panel de trabajo de la clínica</h1>
-            <p>
-              Entrá con tu perfil y seguí la operación diaria desde los espacios habilitados para ese rol, sin cambiar
-              el flujo actual.
-            </p>
-          </div>
-
-          <div className="hero-summary-grid">
-            <article className="summary-tile">
-              <span className="summary-label">Espacio actual</span>
-              <strong>{activeSurfaceDefinition?.label ?? 'Agenda'}</strong>
-              <small>{activeSurfaceDefinition?.description ?? 'Cada vista conserva su propio foco.'}</small>
-            </article>
-            <article className="summary-tile">
-              <span className="summary-label">Cuenta</span>
-              <strong>{auth.user.email}</strong>
-              <small>Perfil: {auth.user.role}</small>
-            </article>
-          </div>
-
-          <div className="toolbar shell-toolbar">
-            <span className="badge neutral">Expira: {formatSessionExpiry(auth.expiresAt)}</span>
-            {auth.user.role === 'admin' ? <span className="badge info">Admin: mantenimiento y configuración base</span> : null}
-            <button className="button button-secondary" type="button" onClick={auth.logout}>
-              Cerrar sesión
-            </button>
-          </div>
-        </header>
-
-        <section className="surface-switcher card stack-tight" aria-label="Selector de espacios">
-          <div className="surface-switcher-header">
-            <div>
-              <h2>Tu espacio de trabajo</h2>
-              <p>Mostramos solamente las áreas disponibles para este perfil, con el mismo acceso y permisos de hoy.</p>
-            </div>
-            <span className="badge neutral">{availableSurfaces.length} área(s) habilitada(s)</span>
-          </div>
-
-          <div className="surface-tabs" role="tablist" aria-label="Áreas disponibles">
-            {availableSurfaces.map((surface) => (
-              <button
-                key={surface.id}
-                type="button"
-                role="tab"
-                aria-selected={activeSurface === surface.id}
-                className={`surface-tab${activeSurface === surface.id ? ' active' : ''}`}
-                onClick={() => setActiveSurface(surface.id)}
-              >
-                <span className="surface-tab-eyebrow">{surface.eyebrow}</span>
-                <strong>{surface.label}</strong>
-                <small>{surface.description}</small>
-              </button>
-            ))}
-          </div>
-        </section>
-
-        {activeSurface === 'agenda' && capabilities ? (
-          <ScheduleDemo agendaMode={capabilities.agendaMode} onSessionInvalid={auth.logout} />
-        ) : null}
-        {activeSurface === 'directory' && capabilities ? (
-          <DirectoryDemo directoryMode={capabilities.directoryMode} onSessionInvalid={auth.logout} />
-        ) : null}
-        {activeSurface === 'patients' && capabilities ? (
-          <PatientsWorkspace patientsMode={capabilities.patientsMode} onSessionInvalid={auth.logout} />
-        ) : null}
-      </div>
-    </main>
+    <AppShell
+      account={{
+        email: auth.user.email,
+        role: auth.user.role,
+        sessionExpiryLabel: formatSessionExpiry(auth.expiresAt),
+        isAdmin: auth.user.role === 'admin',
+      }}
+      activeSurface={activeSurface}
+      activeSurfaceCountLabel={`${availableSurfaces.length} área(s) habilitada(s)`}
+      intro={activeSurfaceDefinition?.intro ?? { eyebrow: 'Espacio', title: 'Agenda', description: 'Cada vista conserva su propio foco.' }}
+      navItems={availableSurfaces.map((surface) => surface.navItem)}
+      onLogout={auth.logout}
+      onSelectSurface={setActiveSurface}
+    >
+      {activeSurface === 'agenda' && capabilities ? <ScheduleDemo agendaMode={capabilities.agendaMode} onSessionInvalid={auth.logout} /> : null}
+      {activeSurface === 'directory' && capabilities ? (
+        <DirectoryDemo directoryMode={capabilities.directoryMode} onSessionInvalid={auth.logout} />
+      ) : null}
+      {activeSurface === 'patients' && capabilities ? (
+        <PatientsWorkspace patientsMode={capabilities.patientsMode} onSessionInvalid={auth.logout} />
+      ) : null}
+    </AppShell>
   );
-}
-
-function getSurfaceDefinition(surfaceId: SurfaceId, capabilities: NonNullable<ReturnType<typeof deriveActorCapabilities>>): SurfaceDefinition {
-  if (surfaceId === 'agenda') {
-    return capabilities.agendaMode.kind === 'doctor-own'
-      ? { id: 'agenda', label: 'Mi agenda', eyebrow: 'Atención del día', description: 'Tus turnos y disponibilidad de hoy.' }
-      : { id: 'agenda', label: 'Agenda', eyebrow: 'Gestión diaria', description: 'Turnos, disponibilidad y cambios del día.' };
-  }
-
-  if (surfaceId === 'patients') {
-    return capabilities.patientsMode.kind === 'secretary-operational'
-      ? {
-          id: 'patients',
-          label: 'Pacientes',
-          eyebrow: 'Admisión',
-          description: 'Búsqueda y selección para tareas administrativas.',
-        }
-      : {
-          id: 'patients',
-          label: 'Pacientes',
-          eyebrow: 'Seguimiento',
-          description: 'Resumen clínico y encounters del paciente.',
-        };
-  }
-
-  return {
-    id: 'directory',
-    label: 'Directorio',
-    eyebrow: 'Base clínica',
-    description: 'Pacientes y profesionales para operar la clínica.',
-  };
 }
 
 function formatSessionExpiry(expiresAt: string | null) {

--- a/web/src/app-shell/AppShell.tsx
+++ b/web/src/app-shell/AppShell.tsx
@@ -1,0 +1,91 @@
+import type { AppShellProps } from './AppShell.types';
+
+export function AppShell({
+  account,
+  activeSurface,
+  activeSurfaceCountLabel,
+  children,
+  intro,
+  navItems,
+  onLogout,
+  onSelectSurface,
+}: AppShellProps) {
+  const activeNavItem = navItems.find((item) => item.id === activeSurface) ?? navItems[0];
+
+  return (
+    <main className="page">
+      <div className="shell app-shell-frame stack">
+        <header className="card app-shell-header stack">
+          <div className="app-shell-header-main">
+            <div className="stack-tight hero-copy">
+              <div className="hero-kicker">Clinic Platform · sesión activa</div>
+              <h1>Panel de trabajo de la clínica</h1>
+              <p>
+                Entrá con tu perfil y seguí la operación diaria desde los espacios habilitados para ese rol, sin cambiar
+                el flujo actual.
+              </p>
+            </div>
+
+            <div className="hero-summary-grid">
+              <article className="summary-tile">
+                <span className="summary-label">Espacio actual</span>
+                <strong>{activeNavItem?.label ?? intro.title}</strong>
+                <small>{activeNavItem?.description ?? intro.description}</small>
+              </article>
+              <article className="summary-tile">
+                <span className="summary-label">Cuenta</span>
+                <strong>{account.email}</strong>
+                <small>Perfil: {account.role}</small>
+              </article>
+            </div>
+          </div>
+
+          <div className="toolbar shell-toolbar">
+            <span className="badge neutral">Expira: {account.sessionExpiryLabel}</span>
+            {account.isAdmin ? <span className="badge info">Admin: mantenimiento y configuración base</span> : null}
+            <button className="button button-secondary" type="button" onClick={onLogout}>
+              Cerrar sesión
+            </button>
+          </div>
+        </header>
+
+        <section className="card app-shell-nav stack-tight" aria-label="Selector de espacios">
+          <div className="app-shell-nav-header">
+            <div>
+              <h2>Tu espacio de trabajo</h2>
+              <p>Mostramos solamente las áreas disponibles para este perfil, con el mismo acceso y permisos de hoy.</p>
+            </div>
+            <span className="badge neutral">{activeSurfaceCountLabel}</span>
+          </div>
+
+          <div className="surface-tabs" role="tablist" aria-label="Áreas disponibles">
+            {navItems.map((surface) => (
+              <button
+                key={surface.id}
+                type="button"
+                role="tab"
+                aria-selected={activeSurface === surface.id}
+                className={`surface-tab${activeSurface === surface.id ? ' active' : ''}`}
+                onClick={() => onSelectSurface(surface.id)}
+              >
+                <span className="surface-tab-eyebrow">{surface.eyebrow}</span>
+                <strong>{surface.label}</strong>
+                <small>{surface.description}</small>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="card app-shell-surface-frame stack-tight">
+          <div className="stack-tight app-shell-surface-intro">
+            <span className="hero-kicker">{intro.eyebrow}</span>
+            <h2>{intro.title}</h2>
+            <p>{intro.description}</p>
+          </div>
+        </section>
+
+        <div className="app-shell-surface-content">{children}</div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app-shell/AppShell.types.ts
+++ b/web/src/app-shell/AppShell.types.ts
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import type { ShellNavItem, ShellSurfaceIntro, SurfaceId } from '../auth/actorCapabilities';
+
+export type AppShellAccountSummary = {
+  email: string;
+  role: string;
+  sessionExpiryLabel: string;
+  isAdmin: boolean;
+};
+
+export type AppShellProps = {
+  account: AppShellAccountSummary;
+  activeSurface: SurfaceId;
+  activeSurfaceCountLabel: string;
+  intro: ShellSurfaceIntro;
+  navItems: ShellNavItem[];
+  onLogout: () => void;
+  onSelectSurface: (surfaceId: SurfaceId) => void;
+  children: ReactNode;
+};

--- a/web/src/auth/actorCapabilities.test.ts
+++ b/web/src/auth/actorCapabilities.test.ts
@@ -1,15 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { deriveActorCapabilities } from './actorCapabilities';
+import { deriveActorCapabilities, resolveShellSurfaceMetadata } from './actorCapabilities';
 
 describe('deriveActorCapabilities', () => {
   it('keeps doctor focused on own agenda and patients', () => {
     const capabilities = deriveActorCapabilities(user({ role: 'doctor', professional_id: 'professional-1' }));
+    const agendaShell = resolveShellSurfaceMetadata('agenda', capabilities);
+    const patientsShell = resolveShellSurfaceMetadata('patients', capabilities);
 
     expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
     expect(capabilities.defaultSurface).toBe('agenda');
     expect(capabilities.agendaMode).toEqual({ kind: 'doctor-own', professionalId: 'professional-1' });
     expect(capabilities.patientsMode).toEqual({ kind: 'doctor-clinical', professionalId: 'professional-1' });
     expect(capabilities.directoryMode.kind).toBe('forbidden');
+    expect(agendaShell.navItem).toEqual({
+      id: 'agenda',
+      label: 'Mi agenda',
+      eyebrow: 'Atención semanal',
+      description: 'Tus turnos y disponibilidad operativa de la semana.',
+    });
+    expect(patientsShell.intro).toEqual({
+      eyebrow: 'Seguimiento',
+      title: 'Pacientes',
+      description: 'Resumen clínico y encounters del paciente.',
+    });
   });
 
   it('blocks malformed doctor without professional association', () => {
@@ -28,22 +41,39 @@ describe('deriveActorCapabilities', () => {
 
   it('gives secretary operational agenda and patient access without admin symmetry', () => {
     const capabilities = deriveActorCapabilities(user({ role: 'secretary' }));
+    const agendaShell = resolveShellSurfaceMetadata('agenda', capabilities);
+    const patientsShell = resolveShellSurfaceMetadata('patients', capabilities);
+    const directoryShell = resolveShellSurfaceMetadata('directory', capabilities);
 
     expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
     expect(capabilities.defaultSurface).toBe('agenda');
     expect(capabilities.agendaMode).toEqual({ kind: 'operational-shared' });
     expect(capabilities.patientsMode).toEqual({ kind: 'secretary-operational' });
     expect(capabilities.directoryMode).toEqual({ kind: 'setup-shared' });
+    expect(agendaShell.navItem.label).toBe('Agenda');
+    expect(patientsShell.intro).toEqual({
+      eyebrow: 'Admisión',
+      title: 'Pacientes',
+      description: 'Búsqueda y selección para tareas administrativas.',
+    });
+    expect(directoryShell.navItem).toEqual({
+      id: 'directory',
+      label: 'Directorio',
+      eyebrow: 'Base clínica',
+      description: 'Pacientes y profesionales para operar la clínica.',
+    });
   });
 
   it('keeps admin on setup-oriented surfaces only', () => {
     const capabilities = deriveActorCapabilities(user({ role: 'admin' }));
+    const directoryShell = resolveShellSurfaceMetadata('directory', capabilities);
 
     expect(capabilities.visibleSurfaces).toEqual(['directory']);
     expect(capabilities.defaultSurface).toBe('directory');
     expect(capabilities.directoryMode).toEqual({ kind: 'setup-shared' });
     expect(capabilities.agendaMode.kind).toBe('forbidden');
     expect(capabilities.patientsMode.kind).toBe('forbidden');
+    expect(directoryShell.intro.title).toBe('Directorio');
   });
 
   it('falls back to a blocked agenda-only shell for unknown roles', () => {

--- a/web/src/auth/actorCapabilities.ts
+++ b/web/src/auth/actorCapabilities.ts
@@ -14,6 +14,24 @@ export type PatientsMode =
 
 export type DirectoryMode = { kind: 'setup-shared' } | { kind: 'forbidden'; message: string };
 
+export type ShellNavItem = {
+  id: SurfaceId;
+  label: string;
+  eyebrow: string;
+  description: string;
+};
+
+export type ShellSurfaceIntro = {
+  eyebrow: string;
+  title: string;
+  description: string;
+};
+
+export type ShellSurfaceMetadata = {
+  navItem: ShellNavItem;
+  intro: ShellSurfaceIntro;
+};
+
 export type ActorCapabilities = {
   visibleSurfaces: SurfaceId[];
   defaultSurface: SurfaceId;
@@ -74,5 +92,84 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
     agendaMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
     patientsMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
     directoryMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
+  };
+}
+
+export function resolveShellSurfaceMetadata(
+  surfaceId: SurfaceId,
+  capabilities: ActorCapabilities,
+): ShellSurfaceMetadata {
+  if (surfaceId === 'agenda') {
+    return capabilities.agendaMode.kind === 'doctor-own'
+      ? {
+          navItem: {
+            id: 'agenda',
+            label: 'Mi agenda',
+            eyebrow: 'Atención semanal',
+            description: 'Tus turnos y disponibilidad operativa de la semana.',
+          },
+          intro: {
+            eyebrow: 'Atención semanal',
+            title: 'Mi agenda',
+            description: 'Tus turnos y disponibilidad operativa de la semana.',
+          },
+        }
+      : {
+          navItem: {
+            id: 'agenda',
+            label: 'Agenda',
+            eyebrow: 'Gestión semanal',
+            description: 'Tablero operativo para comparar y accionar toda la semana.',
+          },
+          intro: {
+            eyebrow: 'Gestión semanal',
+            title: 'Agenda',
+            description: 'Tablero operativo para comparar y accionar toda la semana.',
+          },
+        };
+  }
+
+  if (surfaceId === 'patients') {
+    return capabilities.patientsMode.kind === 'secretary-operational'
+      ? {
+          navItem: {
+            id: 'patients',
+            label: 'Pacientes',
+            eyebrow: 'Admisión',
+            description: 'Búsqueda y selección para tareas administrativas.',
+          },
+          intro: {
+            eyebrow: 'Admisión',
+            title: 'Pacientes',
+            description: 'Búsqueda y selección para tareas administrativas.',
+          },
+        }
+      : {
+          navItem: {
+            id: 'patients',
+            label: 'Pacientes',
+            eyebrow: 'Seguimiento',
+            description: 'Resumen clínico y encounters del paciente.',
+          },
+          intro: {
+            eyebrow: 'Seguimiento',
+            title: 'Pacientes',
+            description: 'Resumen clínico y encounters del paciente.',
+          },
+        };
+  }
+
+  return {
+    navItem: {
+      id: 'directory',
+      label: 'Directorio',
+      eyebrow: 'Base clínica',
+      description: 'Pacientes y profesionales para operar la clínica.',
+    },
+    intro: {
+      eyebrow: 'Base clínica',
+      title: 'Directorio',
+      description: 'Pacientes y profesionales para operar la clínica.',
+    },
   };
 }

--- a/web/src/features/directory/DirectoryDemo.tsx
+++ b/web/src/features/directory/DirectoryDemo.tsx
@@ -139,10 +139,7 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
 
   return (
     <div className="stack">
-      <header className="hero section-hero section-hero-card card">
-        <div className="hero-kicker">Setup base</div>
-        <h2>Directorio demo</h2>
-        <p>Alta rápida y listado claro para poblar la demo sin mezclar esta superficie con la operación diaria.</p>
+      <section className="card stack">
         <div className="status-bar">
           <span className="badge neutral">Pacientes: {patients.length}</span>
           <span className="badge neutral">Profesionales: {professionals.length}</span>
@@ -151,7 +148,8 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
           {errorMessage ? <span className="badge error">{errorMessage}</span> : null}
           {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
         </div>
-      </header>
+        <div className="inline-note">Alta rápida y listados claros para poblar la demo sin mezclar esta superficie con la operación diaria.</div>
+      </section>
 
       <div className="directory-grid">
         <section className="card stack">

--- a/web/src/features/patients/PatientsWorkspace.tsx
+++ b/web/src/features/patients/PatientsWorkspace.tsx
@@ -216,17 +216,7 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
 
   return (
     <div className="stack">
-      <header className="hero section-hero section-hero-card card">
-        <div className="hero-kicker">
-          {patientsMode.kind === 'doctor-clinical' ? 'Doctor workspace · alcance mínimo' : 'Pacientes operativos · secretaría'}
-        </div>
-        <h2>{patientsMode.kind === 'doctor-clinical' ? 'Pacientes activos y nota inicial' : 'Pacientes activos para agenda y administración'}</h2>
-        <p>
-          {patientsMode.kind === 'doctor-clinical'
-            ? 'Elegir paciente, ver encounters y registrar una evolución corta sin inventar una historia clínica completa.'
-            : 'Buscar y seleccionar pacientes para tareas operativas sin habilitar trabajo clínico ni encounters.'}
-        </p>
-
+      <section className="card stack">
         <div className="status-bar">
           <span className="badge neutral">Pacientes activos: {activePatients.length}</span>
           <span className="badge neutral">Encounters visibles: {encounters.length}</span>
@@ -236,7 +226,12 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
           {successMessage ? <span className="badge success">{successMessage}</span> : null}
           {patientsError ? <span className="badge error">{patientsError}</span> : null}
         </div>
-      </header>
+        <div className="inline-note">
+          {patientsMode.kind === 'doctor-clinical'
+            ? 'Elegí paciente, revisá encounters y registrá una evolución corta sin inventar una historia clínica completa.'
+            : 'Este cuerpo mantiene foco operativo: búsqueda y selección para secretaría sin habilitar trabajo clínico.'}
+        </div>
+      </section>
 
       <div className="patients-workspace-grid">
         <section className="card stack patients-sidebar">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -75,7 +75,8 @@ button {
   margin: 0 auto;
 }
 
-.app-shell {
+.app-shell,
+.app-shell-frame {
   gap: 20px;
 }
 
@@ -163,15 +164,59 @@ button {
 }
 
 .hero-product,
-.section-hero-card {
+.section-hero-card,
+.app-shell-header,
+.app-shell-surface-frame {
   gap: 18px;
 }
 
 .hero-product h1,
+.app-shell-header h1,
 .section-hero-card h1,
+.app-shell-surface-frame h2,
 .section-hero-card h2 {
   font-size: clamp(1.95rem, 3vw, 2.65rem);
   line-height: 1.08;
+}
+
+.app-shell-header-main,
+.app-shell-surface-intro,
+.app-shell-surface-content {
+  display: grid;
+  gap: 18px;
+}
+
+.app-shell-header {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(237, 244, 255, 0.92) 100%);
+}
+
+.app-shell-nav {
+  gap: 16px;
+}
+
+.app-shell-nav-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.app-shell-nav-header h2 {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+}
+
+.app-shell-nav-header p,
+.app-shell-surface-intro p {
+  margin: 0;
+}
+
+.app-shell-surface-frame {
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+
+.app-shell-surface-content {
+  gap: 20px;
 }
 
 .hero-copy {
@@ -376,13 +421,35 @@ button {
   gap: 18px;
 }
 
+.schedule-demo {
+  --schedule-ink: #2b1718;
+  --schedule-soft-text: #6a5657;
+  --schedule-burgundy: #570000;
+  --schedule-burgundy-soft: #f7ecec;
+  --schedule-gold: #735c00;
+  --schedule-gold-soft: #fff7dd;
+  --schedule-surface: #fcf8f5;
+  --schedule-surface-strong: #f4eeea;
+  --schedule-ghost-border: rgba(87, 0, 0, 0.12);
+}
+
+.schedule-overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 24px;
+  align-items: start;
+}
+
 .schedule-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.95fr);
-  gap: 20px;
-  padding: 28px;
-  border-color: #d7e3ef;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.96) 100%);
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.95fr);
+  gap: 24px;
+  padding: 32px;
+  border-color: var(--schedule-ghost-border);
+  background:
+    radial-gradient(circle at top right, rgba(254, 214, 91, 0.14), transparent 34%),
+    linear-gradient(180deg, rgba(255, 251, 247, 0.98) 0%, rgba(247, 239, 235, 0.96) 100%);
+  box-shadow: 0 18px 38px rgba(43, 23, 24, 0.06);
 }
 
 .schedule-hero-copy {
@@ -391,6 +458,7 @@ button {
 
 .schedule-hero-copy p {
   max-width: 60ch;
+  color: var(--schedule-soft-text);
 }
 
 .schedule-hero-badges {
@@ -401,10 +469,11 @@ button {
   display: grid;
   gap: 16px;
   align-content: start;
-  padding: 20px;
-  border-radius: var(--radius-lg);
-  border: 1px solid #dde6f0;
-  background: #f8fafc;
+  padding: 22px;
+  border-radius: 24px;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  background: rgba(255, 252, 250, 0.82);
+  backdrop-filter: blur(18px);
 }
 
 .schedule-hero-panel-head {
@@ -414,23 +483,60 @@ button {
 
 .schedule-hero-panel-head strong {
   font-size: 1.2rem;
+  color: var(--schedule-ink);
 }
 
 .schedule-stat-card {
   display: grid;
   gap: 4px;
   padding: 14px;
-  border: 1px solid #dbe5ee;
-  background: #ffffff;
+  border: 1px solid rgba(87, 0, 0, 0.06);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(250, 245, 241, 0.92) 100%);
 }
 
 .schedule-stat-card strong {
   font-size: 1.02rem;
-  color: var(--text);
+  color: var(--schedule-ink);
 }
 
 .schedule-layout {
   align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+}
+
+.schedule-controls-card,
+.schedule-booking-card,
+.schedule-slots-card,
+.schedule-appointments-card,
+.schedule-generator-card {
+  border-color: rgba(87, 0, 0, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(249, 244, 240, 0.96) 100%);
+}
+
+.schedule-controls-head,
+.schedule-controls-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.schedule-controls-toolbar {
+  flex-wrap: wrap;
+}
+
+.schedule-filters-grid,
+.schedule-primary-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.schedule-filters-grid {
+  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+}
+
+.schedule-primary-grid {
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
 }
 
 .patients-workspace-grid {
@@ -501,16 +607,16 @@ button {
 }
 
 .schedule-generator-card {
-  border-color: #e6dccf;
-  background: linear-gradient(180deg, #fffdf9 0%, #fbf5ec 100%);
+  border-color: rgba(115, 92, 0, 0.14);
+  background: linear-gradient(180deg, rgba(255, 252, 245, 0.98) 0%, rgba(250, 242, 223, 0.96) 100%);
 }
 
 .schedule-generator-summary {
   display: grid;
   gap: 4px;
   padding: 14px 16px;
-  border: 1px solid #eadfce;
-  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(115, 92, 0, 0.12);
+  background: rgba(255, 252, 246, 0.92);
 }
 
 .schedule-generator-summary span {
@@ -526,7 +632,11 @@ button {
 }
 
 .schedule-generator-button {
-  background: #31261f;
+  background: linear-gradient(135deg, #705600 0%, #8b6b00 100%);
+}
+
+.schedule-generator-button:hover:not(:disabled) {
+  background: linear-gradient(135deg, #5e4800 0%, #735c00 100%);
 }
 
 .field {
@@ -654,16 +764,41 @@ button {
 }
 
 .slot-grid-feedback {
-  border: 1px solid #bbf7d0;
-  background: #f0fdf4;
+  border: 1px solid rgba(22, 101, 52, 0.14);
+  background: #f4fbf4;
   color: var(--success-text);
   margin-bottom: 14px;
 }
 
+.schedule-demo .button {
+  background: linear-gradient(135deg, #570000 0%, #800000 100%);
+  box-shadow: 0 8px 24px rgba(43, 23, 24, 0.08);
+}
+
+.schedule-demo .button:hover:not(:disabled) {
+  background: linear-gradient(135deg, #480000 0%, #6d0000 100%);
+}
+
+.schedule-demo .button.secondary {
+  background: rgba(255, 252, 246, 0.9);
+  color: var(--schedule-ink);
+  border-color: rgba(115, 92, 0, 0.14);
+}
+
+.schedule-demo .button.secondary:hover:not(:disabled),
+.schedule-demo .button.ghost:hover:not(:disabled) {
+  background: rgba(255, 247, 221, 0.92);
+}
+
+.schedule-demo .button.ghost {
+  color: var(--schedule-ink);
+  border-color: rgba(87, 0, 0, 0.12);
+}
+
 .inline-note {
-  border: 1px solid #d7e6fb;
-  background: #f8fbff;
-  color: #26436f;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  background: var(--schedule-surface);
+  color: var(--schedule-ink);
 }
 
 .slot-button {
@@ -672,15 +807,15 @@ button {
   gap: 6px;
   min-height: 108px;
   padding: 16px;
-  border: 1px solid #dfe6ee;
-  background: #fff;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.92);
   text-align: left;
   box-shadow: none;
   transition: border-color 0.14s ease, background 0.14s ease, box-shadow 0.14s ease;
 }
 
 .slot-button:hover {
-  border-color: #cbd5e1;
+  border-color: rgba(87, 0, 0, 0.16);
   box-shadow: var(--shadow-soft);
 }
 
@@ -692,8 +827,8 @@ button {
 }
 
 .slot-button.selected {
-  border-color: #d6b18f;
-  background: #fff7ed;
+  border-color: rgba(115, 92, 0, 0.2);
+  background: var(--schedule-gold-soft);
 }
 
 .slot-button.released {
@@ -722,8 +857,8 @@ button {
   display: grid;
   gap: 10px;
   padding: 16px;
-  border: 1px solid #e3e9f4;
-  background: #fbfcfe;
+  border: 1px solid rgba(87, 0, 0, 0.06);
+  background: rgba(255, 252, 250, 0.95);
 }
 
 .schedule-appointments-list {
@@ -743,8 +878,8 @@ button {
   width: 42px;
   height: 42px;
   border-radius: 50%;
-  background: #e7eef8;
-  color: #26436f;
+  background: var(--schedule-burgundy-soft);
+  color: var(--schedule-burgundy);
   font-weight: 800;
 }
 
@@ -759,15 +894,19 @@ button {
   color: var(--success-text);
 }
 
+.schedule-booking-footnote {
+  color: var(--schedule-soft-text);
+}
+
 .pill.cancelled {
   background: var(--error-bg);
   color: var(--error-text);
 }
 
 .empty-state {
-  border: 1px dashed #d4deea;
-  background: var(--bg-surface-muted);
-  color: var(--text-soft);
+  border: 1px dashed rgba(87, 0, 0, 0.12);
+  background: var(--schedule-surface-strong);
+  color: var(--schedule-soft-text);
 }
 
 .empty-state strong {
@@ -785,7 +924,9 @@ button {
   .hero-summary-grid,
   .overview-grid,
   .surface-tabs,
-  .schedule-hero {
+  .schedule-hero,
+  .schedule-primary-grid,
+  .schedule-filters-grid {
     grid-template-columns: 1fr;
   }
 
@@ -809,7 +950,10 @@ button {
   }
 
   .surface-switcher-header,
-  .section-header {
+  .app-shell-nav-header,
+  .section-header,
+  .schedule-controls-head,
+  .schedule-controls-toolbar {
     flex-direction: column;
     align-items: stretch;
   }
@@ -827,8 +971,11 @@ button {
   }
 
   .hero-product h1,
+  .app-shell-header h1,
   .section-hero-card h1,
+  .app-shell-surface-frame h2,
   .section-hero-card h2 {
     font-size: 1.8rem;
   }
+
 }


### PR DESCRIPTION
Closes #22

## Summary
- extract a shared authenticated app shell from `App.tsx` so top-level framing and navigation stop living ad hoc in feature entrypoints
- centralize shell metadata and role-aware surface navigation in capability-driven logic while preserving current actor access and default-surface behavior
- keep agenda, patients, and directory internals mostly intact while removing page-level framing duplication from feature surfaces

## Changes
| File | Change |
|------|--------|
| `web/src/app-shell/AppShell.tsx` | Adds the shared authenticated app frame component |
| `web/src/app-shell/AppShell.types.ts` | Defines shell-level frame contracts |
| `web/src/App.tsx` | Delegates authenticated framing to `AppShell` |
| `web/src/App.test.tsx` | Verifies shell framing and top-level surface behavior through the new app shell |
| `web/src/auth/actorCapabilities.ts` | Centralizes shell surface metadata alongside capability-derived access rules |
| `web/src/auth/actorCapabilities.test.ts` | Verifies shell metadata stays aligned with actor capability semantics |
| `web/src/features/patients/PatientsWorkspace.tsx` | Removes duplicated page-level hero framing while preserving feature content |
| `web/src/features/directory/DirectoryDemo.tsx` | Removes duplicated page-level hero framing while preserving feature content |
| `web/src/styles.css` | Adds shell-level frame styles and ownership boundaries for the shared app shell |

## Test Plan
- [x] `npm test -- src/App.test.tsx src/auth/actorCapabilities.test.ts` in `web/`
- [x] `npm run typecheck` in `web/`
- [x] Verified the change stays structural only: no router, backend, permission, or deep feature redesign changes in this slice

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Added docs/contract updates where behavior changed
- [x] Used conventional commits only
- [x] No `Co-Authored-By` trailers added