### PR TITLE
feat(web): deliver shell visual breakthrough

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -34,15 +34,28 @@ describe('App actor-aware shell', () => {
   it('shows agenda and patients for doctors, defaulting to agenda', () => {
     useAuthSessionMock.mockReturnValue(authSession({ role: 'doctor', professional_id: 'professional-1' }));
 
-    render(<App />);
+    const { container } = render(<App />);
 
-    expect(screen.getByRole('heading', { name: 'Panel de trabajo de la clínica' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Mi agenda' })).toBeInTheDocument();
-    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(
-      expect.arrayContaining(['Atención semanalMi agendaTus turnos y disponibilidad operativa de la semana.', 'SeguimientoPacientesResumen clínico y encounters del paciente.']),
-    );
-    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.getAllByText('Centro operativo clínico').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Amicus')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
+    const doctorNavButtons = screen.getAllByRole('button', { name: /Agenda|Pacientes/ });
+    expect(doctorNavButtons).toHaveLength(2);
+    expect(doctorNavButtons[0]).toHaveTextContent('Operación clínica');
+    expect(doctorNavButtons[0]).toHaveTextContent('Agenda');
+    expect(doctorNavButtons[1]).toHaveTextContent('Relación asistencial');
+    expect(doctorNavButtons[1]).toHaveTextContent('Pacientes');
+    expect(screen.getByRole('button', { name: /Agenda/i })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByText('schedule:doctor-own')).toBeInTheDocument();
+
+    const shellPage = container.querySelector('.page-app-shell');
+    expect(shellPage?.firstElementChild).toHaveClass('app-shell-layout');
+    expect(container.querySelector('.app-shell-frame')).not.toBeInTheDocument();
+    expect(container.querySelector('.app-shell-column > .app-shell-topbar')).toBeInTheDocument();
+    expect(container.querySelector('.app-shell-column > .app-shell-page-intro')).toBeInTheDocument();
+    expect(container.querySelector('.app-shell-column > .app-shell-stage')).toBeInTheDocument();
+    expect(container.querySelector('.app-shell-brand-image')).not.toBeInTheDocument();
+    expect(container.querySelector('.app-shell-brand-mark-fallback')).toHaveTextContent('A');
   });
 
   it('shows agenda and patients for secretaries without directory shell symmetry', () => {
@@ -50,10 +63,10 @@ describe('App actor-aware shell', () => {
 
     render(<App />);
 
-    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(
-      expect.arrayContaining(['Gestión semanalAgendaTablero operativo para comparar y accionar toda la semana.', 'AdmisiónPacientesBúsqueda y selección para tareas administrativas.']),
-    );
-    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    const secretaryNavButtons = screen.getAllByRole('button', { name: /Agenda|Pacientes/ });
+    expect(secretaryNavButtons).toHaveLength(2);
+    expect(secretaryNavButtons[0]).toHaveTextContent('Agenda');
+    expect(secretaryNavButtons[1]).toHaveTextContent('Pacientes');
     expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
     expect(screen.getByText('schedule:operational-shared')).toBeInTheDocument();
   });
@@ -73,7 +86,26 @@ describe('App actor-aware shell', () => {
     render(<App />);
 
     expect(screen.getByText('login-screen')).toBeInTheDocument();
-    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Áreas disponibles' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the loading surface outside the authenticated shell', () => {
+    useAuthSessionMock.mockReturnValue({
+      status: 'loading',
+      accessToken: null,
+      expiresAt: null,
+      user: null,
+      errorMessage: '',
+      isSubmitting: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    render(<App />);
+
+    expect(screen.getByRole('heading', { name: 'Recuperando tu sesión...' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Agenda' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Áreas disponibles' })).not.toBeInTheDocument();
   });
 
   it('shows directory as the only default surface for admins', () => {
@@ -81,8 +113,10 @@ describe('App actor-aware shell', () => {
 
     render(<App />);
 
-    expect(screen.getAllByRole('tab')).toHaveLength(1);
-    expect(screen.getAllByRole('tab')[0]?.textContent).toBe('Base clínicaDirectorioPacientes y profesionales para operar la clínica.');
+    expect(screen.getByRole('navigation', { name: 'Áreas disponibles' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Directorio/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /Directorio/ })[0]).toHaveTextContent('Base operativa');
+    expect(screen.getAllByRole('button', { name: /Directorio/ })[0]).toHaveTextContent('Directorio');
     expect(screen.getByRole('heading', { name: 'Directorio' })).toBeInTheDocument();
     expect(screen.getByText('directory:setup-shared')).toBeInTheDocument();
   });
@@ -94,11 +128,56 @@ describe('App actor-aware shell', () => {
 
     expect(screen.getByText('schedule:operational-shared')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('tab', { name: /Pacientes/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Pacientes/i }));
 
+    expect(screen.getByRole('button', { name: /Pacientes/i })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('heading', { name: 'Pacientes' })).toBeInTheDocument();
     expect(screen.getByText('patients:secretary-operational')).toBeInTheDocument();
     expect(screen.queryByText('schedule:operational-shared')).not.toBeInTheDocument();
+  });
+
+  it('keeps the feature body inside the shell-owned stage when switching surfaces', () => {
+    useAuthSessionMock.mockReturnValue(authSession({ role: 'doctor', professional_id: 'professional-1' }));
+
+    render(<App />);
+
+    const agendaStage = screen.getByRole('region', { name: 'Contenido de Agenda' });
+    expect(agendaStage).toContainElement(screen.getByText('schedule:doctor-own'));
+    expect(agendaStage).not.toContainElement(screen.queryByText('patients:doctor-clinical'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Pacientes/i }));
+
+    const patientsStage = screen.getByRole('region', { name: 'Contenido de Pacientes' });
+    expect(patientsStage).toContainElement(screen.getByText('patients:doctor-clinical'));
+    expect(patientsStage).not.toContainElement(screen.queryByText('schedule:doctor-own'));
+  });
+
+  it('preserves blocked fallback shell behavior for unknown roles', () => {
+    useAuthSessionMock.mockReturnValue(authSession({ role: 'auditor' }));
+
+    render(<App />);
+
+    expect(screen.getAllByRole('button', { name: /Agenda/ })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Agenda/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
+    expect(screen.getByText('schedule:forbidden')).toBeInTheDocument();
+  });
+
+  it('keeps the rendered surface corrected to the allowed default when the actor loses the current one', () => {
+    useAuthSessionMock.mockReturnValue(authSession({ role: 'doctor', professional_id: 'professional-1' }));
+
+    const { rerender } = render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Pacientes/i }));
+    expect(screen.getByText('patients:doctor-clinical')).toBeInTheDocument();
+
+    useAuthSessionMock.mockReturnValue(authSession({ role: 'admin' }));
+    rerender(<App />);
+
+    expect(screen.getAllByRole('button', { name: /Directorio/ })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Directorio/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('directory:setup-shared')).toBeInTheDocument();
+    expect(screen.queryByText('patients:doctor-clinical')).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,7 +36,8 @@ export default function App() {
     }
   }, [activeSurface, capabilities]);
 
-  const activeSurfaceDefinition = availableSurfaces.find((surface) => surface.id === activeSurface) ?? availableSurfaces[0];
+  const normalizedActiveSurface = capabilities?.visibleSurfaces.includes(activeSurface) ? activeSurface : capabilities?.defaultSurface;
+  const activeSurfaceDefinition = availableSurfaces.find((surface) => surface.id === normalizedActiveSurface) ?? availableSurfaces[0];
 
   if (auth.status === 'loading') {
     return (
@@ -56,29 +57,59 @@ export default function App() {
     return <LoginScreen errorMessage={auth.errorMessage} isSubmitting={auth.isSubmitting} onLogin={auth.login} />;
   }
 
+  const renderActiveSurface = () => {
+    if (!capabilities) {
+      return null;
+    }
+
+    if (normalizedActiveSurface === 'agenda') {
+      return <ScheduleDemo agendaMode={capabilities.agendaMode} onSessionInvalid={auth.logout} />;
+    }
+
+    if (normalizedActiveSurface === 'directory') {
+      return <DirectoryDemo directoryMode={capabilities.directoryMode} onSessionInvalid={auth.logout} />;
+    }
+
+    if (normalizedActiveSurface === 'patients') {
+      return <PatientsWorkspace patientsMode={capabilities.patientsMode} onSessionInvalid={auth.logout} />;
+    }
+
+    return null;
+  };
+
   return (
-    <AppShell
+      <AppShell
+      header={{
+        productName: 'Amicus',
+        workspaceName: 'Centro operativo clínico',
+        workspaceDescription: '',
+      }}
       account={{
         email: auth.user.email,
         role: auth.user.role,
         sessionExpiryLabel: formatSessionExpiry(auth.expiresAt),
-        isAdmin: auth.user.role === 'admin',
       }}
-      activeSurface={activeSurface}
-      activeSurfaceCountLabel={`${availableSurfaces.length} área(s) habilitada(s)`}
-      intro={activeSurfaceDefinition?.intro ?? { eyebrow: 'Espacio', title: 'Agenda', description: 'Cada vista conserva su propio foco.' }}
+      activeSurface={normalizedActiveSurface ?? activeSurface}
+      sidebar={{
+        eyebrow: 'Espacios',
+        title: 'Panel de trabajo',
+        description: '',
+      }}
+      pageIntro={{
+        ...(activeSurfaceDefinition?.intro ?? {
+          eyebrow: 'Espacio',
+          title: 'Agenda',
+          description: 'Cada vista conserva su propio foco.',
+        }),
+      }}
+      body={{
+        ariaLabel: `Contenido de ${activeSurfaceDefinition?.intro.title ?? 'Agenda'}`,
+        children: renderActiveSurface(),
+      }}
       navItems={availableSurfaces.map((surface) => surface.navItem)}
       onLogout={auth.logout}
       onSelectSurface={setActiveSurface}
-    >
-      {activeSurface === 'agenda' && capabilities ? <ScheduleDemo agendaMode={capabilities.agendaMode} onSessionInvalid={auth.logout} /> : null}
-      {activeSurface === 'directory' && capabilities ? (
-        <DirectoryDemo directoryMode={capabilities.directoryMode} onSessionInvalid={auth.logout} />
-      ) : null}
-      {activeSurface === 'patients' && capabilities ? (
-        <PatientsWorkspace patientsMode={capabilities.patientsMode} onSessionInvalid={auth.logout} />
-      ) : null}
-    </AppShell>
+    />
   );
 }
 

--- a/web/src/app-shell/AppShell.primitives.tsx
+++ b/web/src/app-shell/AppShell.primitives.tsx
@@ -1,0 +1,75 @@
+import type { ElementType, HTMLAttributes, ReactNode } from 'react';
+
+type PrimitiveTone = 'neutral' | 'info' | 'success' | 'error';
+
+type PrimitiveProps<T extends ElementType> = {
+  as?: T;
+  className?: string;
+  children?: ReactNode;
+} & Omit<HTMLAttributes<HTMLElement>, 'className' | 'children'>;
+
+type EmptyStateProps = {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  className?: string;
+};
+
+export function PageContainer({ as, className, children, ...props }: PrimitiveProps<ElementType>) {
+  return renderPrimitive(as ?? 'div', joinClasses('foundation-page-container', className), children, props);
+}
+
+export function SectionCard({ as, className, children, ...props }: PrimitiveProps<ElementType>) {
+  return renderPrimitive(as ?? 'section', joinClasses('card foundation-section-card', className), children, props);
+}
+
+export function Badge({ className, tone = 'neutral', children, ...props }: PrimitiveProps<'span'> & { tone?: PrimitiveTone }) {
+  return (
+    <span className={joinClasses('badge', tone, 'foundation-badge', className)} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export function InlineNotice({ as, className, children, ...props }: PrimitiveProps<ElementType>) {
+  return renderPrimitive(as ?? 'div', joinClasses('foundation-inline-notice', className), children, props);
+}
+
+export function EmptyState({ eyebrow, title, description, className }: EmptyStateProps) {
+  return (
+    <section className={joinClasses('foundation-empty-state empty-state', className)}>
+      {eyebrow ? <span className="hero-kicker">{eyebrow}</span> : null}
+      <strong>{title}</strong>
+      {description ? <span>{description}</span> : null}
+    </section>
+  );
+}
+
+export function ActionBar({ as, className, children, ...props }: PrimitiveProps<ElementType>) {
+  return renderPrimitive(as ?? 'div', joinClasses('foundation-action-bar', className), children, props);
+}
+
+export function SummaryTile({ as, className, children, ...props }: PrimitiveProps<ElementType>) {
+  return renderPrimitive(as ?? 'article', joinClasses('summary-tile foundation-summary-tile', className), children, props);
+}
+
+export function ContentSplit({ as, className, children, ...props }: PrimitiveProps<ElementType>) {
+  return renderPrimitive(as ?? 'div', joinClasses('foundation-content-split', className), children, props);
+}
+
+function renderPrimitive(
+  Component: ElementType,
+  className: string,
+  children: ReactNode,
+  props: Omit<HTMLAttributes<HTMLElement>, 'className' | 'children'>,
+) {
+  return (
+    <Component className={className} {...props}>
+      {children}
+    </Component>
+  );
+}
+
+function joinClasses(...values: Array<string | undefined>) {
+  return values.filter(Boolean).join(' ');
+}

--- a/web/src/app-shell/AppShell.tsx
+++ b/web/src/app-shell/AppShell.tsx
@@ -1,90 +1,118 @@
+import { Badge } from './AppShell.primitives';
 import type { AppShellProps } from './AppShell.types';
 
 export function AppShell({
+  header,
   account,
   activeSurface,
-  activeSurfaceCountLabel,
-  children,
-  intro,
+  body,
+  pageIntro,
   navItems,
   onLogout,
   onSelectSurface,
 }: AppShellProps) {
   const activeNavItem = navItems.find((item) => item.id === activeSurface) ?? navItems[0];
+  const surfaceToneClass = `app-shell-surface-${activeSurface}`;
+  const productWords = header.productName.trim().split(/\s+/);
+  const brandLead = productWords[0] ?? header.productName;
+  const brandTail = productWords.slice(1).join(' ');
+  const brandInitials = productWords
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
 
   return (
-    <main className="page">
-      <div className="shell app-shell-frame stack">
-        <header className="card app-shell-header stack">
-          <div className="app-shell-header-main">
-            <div className="stack-tight hero-copy">
-              <div className="hero-kicker">Clinic Platform · sesión activa</div>
-              <h1>Panel de trabajo de la clínica</h1>
-              <p>
-                Entrá con tu perfil y seguí la operación diaria desde los espacios habilitados para ese rol, sin cambiar
-                el flujo actual.
-              </p>
-            </div>
-
-            <div className="hero-summary-grid">
-              <article className="summary-tile">
-                <span className="summary-label">Espacio actual</span>
-                <strong>{activeNavItem?.label ?? intro.title}</strong>
-                <small>{activeNavItem?.description ?? intro.description}</small>
-              </article>
-              <article className="summary-tile">
-                <span className="summary-label">Cuenta</span>
-                <strong>{account.email}</strong>
-                <small>Perfil: {account.role}</small>
-              </article>
+    <main className={`page page-app-shell ${surfaceToneClass}`}>
+      <div className="app-shell-layout">
+        <aside className="app-shell-rail" aria-label="Navegación principal">
+          <div className="app-shell-rail-brand-block stack">
+            <div className="app-shell-brand">
+              {header.logo ? (
+                <span className="app-shell-brand-mark app-shell-brand-mark-image-wrap">
+                  <img className="app-shell-brand-image" src={header.logo.src} alt={header.logo.alt} />
+                </span>
+              ) : (
+                <span className="app-shell-brand-mark app-shell-brand-mark-fallback" aria-hidden="true">
+                  {brandInitials}
+                </span>
+              )}
+              <div className="stack-tight app-shell-brand-copy">
+                <span className="hero-kicker">{header.workspaceName}</span>
+                <strong className="app-shell-brand-wordmark">
+                  <span>{brandLead}</span>
+                  {brandTail ? <span>{brandTail}</span> : null}
+                </strong>
+              </div>
             </div>
           </div>
 
-          <div className="toolbar shell-toolbar">
-            <span className="badge neutral">Expira: {account.sessionExpiryLabel}</span>
-            {account.isAdmin ? <span className="badge info">Admin: mantenimiento y configuración base</span> : null}
-            <button className="button button-secondary" type="button" onClick={onLogout}>
+          <nav className="app-shell-nav" aria-label="Áreas disponibles">
+            <ul className="app-shell-nav-list" role="list">
+              {navItems.map((surface) => (
+                <li key={surface.id}>
+                  <button
+                    type="button"
+                    aria-pressed={activeSurface === surface.id}
+                    className={`app-shell-nav-item${activeSurface === surface.id ? ' active' : ''}`}
+                    onClick={() => onSelectSurface(surface.id)}
+                  >
+                    <span className="app-shell-nav-item-marker" aria-hidden="true" />
+                    <span className="app-shell-nav-item-copy">
+                      <span className="surface-tab-eyebrow">{surface.eyebrow}</span>
+                      <strong>{surface.label}</strong>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <footer className="app-shell-rail-footer stack-tight" aria-label="Cuenta">
+            <div className="app-shell-rail-account stack-tight">
+              <span className="summary-label">Cuenta activa</span>
+              <strong>{account.email}</strong>
+              <small>{account.role}</small>
+            </div>
+
+            <button className="button button-secondary app-shell-rail-logout" type="button" onClick={onLogout}>
               Cerrar sesión
             </button>
-          </div>
-        </header>
+          </footer>
+        </aside>
 
-        <section className="card app-shell-nav stack-tight" aria-label="Selector de espacios">
-          <div className="app-shell-nav-header">
-            <div>
-              <h2>Tu espacio de trabajo</h2>
-              <p>Mostramos solamente las áreas disponibles para este perfil, con el mismo acceso y permisos de hoy.</p>
+        <div className="app-shell-column">
+          <header className="app-shell-topbar">
+            <div className="app-shell-topbar-context stack-tight">
+              <span className="summary-label">{header.workspaceName}</span>
+              <strong>{activeNavItem?.label ?? pageIntro.title}</strong>
             </div>
-            <span className="badge neutral">{activeSurfaceCountLabel}</span>
-          </div>
 
-          <div className="surface-tabs" role="tablist" aria-label="Áreas disponibles">
-            {navItems.map((surface) => (
-              <button
-                key={surface.id}
-                type="button"
-                role="tab"
-                aria-selected={activeSurface === surface.id}
-                className={`surface-tab${activeSurface === surface.id ? ' active' : ''}`}
-                onClick={() => onSelectSurface(surface.id)}
-              >
-                <span className="surface-tab-eyebrow">{surface.eyebrow}</span>
-                <strong>{surface.label}</strong>
-                <small>{surface.description}</small>
-              </button>
-            ))}
-          </div>
-        </section>
+            <div className="app-shell-topbar-meta">
+              <div className="app-shell-topbar-account stack-tight" aria-label="Sesión activa">
+                <span className="summary-label">Sesión activa</span>
+                <strong>{account.email}</strong>
+              </div>
 
-        <section className="card app-shell-surface-frame stack-tight">
-          <div className="stack-tight app-shell-surface-intro">
-            <span className="hero-kicker">{intro.eyebrow}</span>
-            <h2>{intro.title}</h2>
-            <p>{intro.description}</p>
-          </div>
-        </section>
+              <div className="app-shell-topbar-badges">
+                <Badge>Expira: {account.sessionExpiryLabel}</Badge>
+              </div>
+            </div>
+          </header>
 
-        <div className="app-shell-surface-content">{children}</div>
+          <section className="app-shell-page-intro">
+            <div className="app-shell-page-intro-copy stack-tight">
+              <span className="hero-kicker">{pageIntro.eyebrow}</span>
+              <h1>{pageIntro.title}</h1>
+              <p>{pageIntro.description}</p>
+            </div>
+          </section>
+
+          <section className="app-shell-stage" aria-label={body.ariaLabel ?? `Contenido de ${pageIntro.title}`}>
+            <div className="app-shell-stage-frame">
+              <div className="app-shell-body-stage">{body.children}</div>
+            </div>
+          </section>
+        </div>
       </div>
     </main>
   );

--- a/web/src/app-shell/AppShell.types.ts
+++ b/web/src/app-shell/AppShell.types.ts
@@ -1,20 +1,52 @@
 import type { ReactNode } from 'react';
 import type { ShellNavItem, ShellSurfaceIntro, SurfaceId } from '../auth/actorCapabilities';
 
+export type AppShellBadge = {
+  label: string;
+  tone?: 'neutral' | 'info' | 'success' | 'error';
+};
+
 export type AppShellAccountSummary = {
   email: string;
   role: string;
   sessionExpiryLabel: string;
-  isAdmin: boolean;
+};
+
+export type AppShellHeader = {
+  productName: string;
+  workspaceName: string;
+  workspaceDescription: string;
+  logo?: {
+    src: string;
+    alt: string;
+  };
+  badges?: AppShellBadge[];
+};
+
+export type AppShellSidebar = {
+  eyebrow: string;
+  title: string;
+  description: string;
+};
+
+export type AppShellPageIntro = ShellSurfaceIntro & {
+  badges?: AppShellBadge[];
+  actions?: ReactNode;
+};
+
+export type AppShellBodySlot = {
+  ariaLabel?: string;
+  children: ReactNode;
 };
 
 export type AppShellProps = {
+  header: AppShellHeader;
   account: AppShellAccountSummary;
   activeSurface: SurfaceId;
-  activeSurfaceCountLabel: string;
-  intro: ShellSurfaceIntro;
+  sidebar: AppShellSidebar;
+  pageIntro: AppShellPageIntro;
+  body: AppShellBodySlot;
   navItems: ShellNavItem[];
   onLogout: () => void;
   onSelectSurface: (surfaceId: SurfaceId) => void;
-  children: ReactNode;
 };

--- a/web/src/auth/actorCapabilities.test.ts
+++ b/web/src/auth/actorCapabilities.test.ts
@@ -14,14 +14,14 @@ describe('deriveActorCapabilities', () => {
     expect(capabilities.directoryMode.kind).toBe('forbidden');
     expect(agendaShell.navItem).toEqual({
       id: 'agenda',
-      label: 'Mi agenda',
-      eyebrow: 'Atención semanal',
-      description: 'Tus turnos y disponibilidad operativa de la semana.',
+      label: 'Agenda',
+      eyebrow: 'Operación clínica',
+      description: 'Turnos del día.',
     });
     expect(patientsShell.intro).toEqual({
-      eyebrow: 'Seguimiento',
+      eyebrow: 'Relación asistencial',
       title: 'Pacientes',
-      description: 'Resumen clínico y encounters del paciente.',
+      description: 'Seguimiento clínico del panel activo.',
     });
   });
 
@@ -52,15 +52,15 @@ describe('deriveActorCapabilities', () => {
     expect(capabilities.directoryMode).toEqual({ kind: 'setup-shared' });
     expect(agendaShell.navItem.label).toBe('Agenda');
     expect(patientsShell.intro).toEqual({
-      eyebrow: 'Admisión',
+      eyebrow: 'Relación asistencial',
       title: 'Pacientes',
-      description: 'Búsqueda y selección para tareas administrativas.',
+      description: 'Seguimiento clínico del panel activo.',
     });
     expect(directoryShell.navItem).toEqual({
       id: 'directory',
       label: 'Directorio',
-      eyebrow: 'Base clínica',
-      description: 'Pacientes y profesionales para operar la clínica.',
+      eyebrow: 'Base operativa',
+      description: 'Base operativa.',
     });
   });
 

--- a/web/src/auth/actorCapabilities.ts
+++ b/web/src/auth/actorCapabilities.ts
@@ -43,6 +43,48 @@ export type ActorCapabilities = {
 const DOCTOR_ASSOCIATION_MESSAGE = 'Tu usuario doctor no tiene professional_id asociado.';
 const ROLE_ACCESS_MESSAGE = 'Tu rol no tiene acceso a esta superficie.';
 
+const SHELL_SURFACE_COPY: Record<SurfaceId, ShellSurfaceMetadata> = {
+  agenda: {
+    navItem: {
+      id: 'agenda',
+      label: 'Agenda',
+      eyebrow: 'Operación clínica',
+      description: 'Turnos del día.',
+    },
+    intro: {
+      eyebrow: 'Operación clínica',
+      title: 'Agenda',
+      description: 'Turnos y disponibilidad en una sola vista.',
+    },
+  },
+  patients: {
+    navItem: {
+      id: 'patients',
+      label: 'Pacientes',
+      eyebrow: 'Relación asistencial',
+      description: 'Seguimiento activo.',
+    },
+    intro: {
+      eyebrow: 'Relación asistencial',
+      title: 'Pacientes',
+      description: 'Seguimiento clínico del panel activo.',
+    },
+  },
+  directory: {
+    navItem: {
+      id: 'directory',
+      label: 'Directorio',
+      eyebrow: 'Base operativa',
+      description: 'Base operativa.',
+    },
+    intro: {
+      eyebrow: 'Base operativa',
+      title: 'Directorio',
+      description: 'Personas y equipos disponibles.',
+    },
+  },
+};
+
 export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
   const professionalId = user.professional_id?.trim() ?? '';
 
@@ -97,79 +139,7 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
 
 export function resolveShellSurfaceMetadata(
   surfaceId: SurfaceId,
-  capabilities: ActorCapabilities,
+  _capabilities: ActorCapabilities,
 ): ShellSurfaceMetadata {
-  if (surfaceId === 'agenda') {
-    return capabilities.agendaMode.kind === 'doctor-own'
-      ? {
-          navItem: {
-            id: 'agenda',
-            label: 'Mi agenda',
-            eyebrow: 'Atención semanal',
-            description: 'Tus turnos y disponibilidad operativa de la semana.',
-          },
-          intro: {
-            eyebrow: 'Atención semanal',
-            title: 'Mi agenda',
-            description: 'Tus turnos y disponibilidad operativa de la semana.',
-          },
-        }
-      : {
-          navItem: {
-            id: 'agenda',
-            label: 'Agenda',
-            eyebrow: 'Gestión semanal',
-            description: 'Tablero operativo para comparar y accionar toda la semana.',
-          },
-          intro: {
-            eyebrow: 'Gestión semanal',
-            title: 'Agenda',
-            description: 'Tablero operativo para comparar y accionar toda la semana.',
-          },
-        };
-  }
-
-  if (surfaceId === 'patients') {
-    return capabilities.patientsMode.kind === 'secretary-operational'
-      ? {
-          navItem: {
-            id: 'patients',
-            label: 'Pacientes',
-            eyebrow: 'Admisión',
-            description: 'Búsqueda y selección para tareas administrativas.',
-          },
-          intro: {
-            eyebrow: 'Admisión',
-            title: 'Pacientes',
-            description: 'Búsqueda y selección para tareas administrativas.',
-          },
-        }
-      : {
-          navItem: {
-            id: 'patients',
-            label: 'Pacientes',
-            eyebrow: 'Seguimiento',
-            description: 'Resumen clínico y encounters del paciente.',
-          },
-          intro: {
-            eyebrow: 'Seguimiento',
-            title: 'Pacientes',
-            description: 'Resumen clínico y encounters del paciente.',
-          },
-        };
-  }
-
-  return {
-    navItem: {
-      id: 'directory',
-      label: 'Directorio',
-      eyebrow: 'Base clínica',
-      description: 'Pacientes y profesionales para operar la clínica.',
-    },
-    intro: {
-      eyebrow: 'Base clínica',
-      title: 'Directorio',
-      description: 'Pacientes y profesionales para operar la clínica.',
-    },
-  };
+  return SHELL_SURFACE_COPY[surfaceId];
 }

--- a/web/src/features/directory/DirectoryDemo.tsx
+++ b/web/src/features/directory/DirectoryDemo.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import { type DirectoryMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
 import { createPatient, createProfessional, listPatients, listProfessionals } from '../../api/directory';
@@ -129,17 +130,15 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
 
   if (directoryMode.kind === 'forbidden') {
     return (
-      <section className="card stack" aria-live="polite">
-        <div className="hero-kicker">Directorio bloqueado</div>
-        <h2>Acceso denegado</h2>
-        <p>{directoryMode.message}</p>
-      </section>
+      <PageContainer>
+        <EmptyState eyebrow="Directorio bloqueado" title="Acceso denegado" description={directoryMode.message} />
+      </PageContainer>
     );
   }
 
   return (
-    <div className="stack">
-      <section className="card stack">
+    <PageContainer className="stack">
+      <SectionCard className="stack">
         <div className="status-bar">
           <span className="badge neutral">Pacientes: {patients.length}</span>
           <span className="badge neutral">Profesionales: {professionals.length}</span>
@@ -149,10 +148,10 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
           {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
         </div>
         <div className="inline-note">Alta rápida y listados claros para poblar la demo sin mezclar esta superficie con la operación diaria.</div>
-      </section>
+      </SectionCard>
 
       <div className="directory-grid">
-        <section className="card stack">
+        <SectionCard className="stack">
           <div className="section-header">
             <div>
               <h3>Pacientes</h3>
@@ -252,9 +251,9 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
               ))}
             </div>
           )}
-        </section>
+        </SectionCard>
 
-        <section className="card stack">
+        <SectionCard className="stack">
           <div className="section-header">
             <div>
               <h3>Profesionales</h3>
@@ -331,8 +330,8 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
               ))}
             </div>
           )}
-        </section>
+        </SectionCard>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/web/src/features/patients/PatientsWorkspace.tsx
+++ b/web/src/features/patients/PatientsWorkspace.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import { type PatientsMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
 import { createPatientEncounter, listPatientEncounters } from '../../api/clinical';
@@ -206,17 +207,15 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
 
   if (patientsMode.kind === 'forbidden') {
     return (
-      <section className="card stack" aria-live="polite">
-        <div className="hero-kicker">Pacientes bloqueado</div>
-        <h2>Acceso denegado</h2>
-        <p>{patientsMode.message}</p>
-      </section>
+      <PageContainer>
+        <EmptyState eyebrow="Pacientes bloqueado" title="Acceso denegado" description={patientsMode.message} />
+      </PageContainer>
     );
   }
 
   return (
-    <div className="stack">
-      <section className="card stack">
+    <PageContainer className="stack">
+      <SectionCard className="stack">
         <div className="status-bar">
           <span className="badge neutral">Pacientes activos: {activePatients.length}</span>
           <span className="badge neutral">Encounters visibles: {encounters.length}</span>
@@ -231,10 +230,10 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
             ? 'Elegí paciente, revisá encounters y registrá una evolución corta sin inventar una historia clínica completa.'
             : 'Este cuerpo mantiene foco operativo: búsqueda y selección para secretaría sin habilitar trabajo clínico.'}
         </div>
-      </section>
+      </SectionCard>
 
       <div className="patients-workspace-grid">
-        <section className="card stack patients-sidebar">
+        <SectionCard className="stack patients-sidebar">
           <div className="section-header">
             <div>
               <h3>Pacientes activos</h3>
@@ -275,10 +274,10 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
               })}
             </div>
           )}
-        </section>
+        </SectionCard>
 
         <div className="stack patients-main">
-          <section className="card stack">
+          <SectionCard className="stack">
             <div className="section-header">
               <div>
                 <h3>Resumen del paciente</h3>
@@ -330,9 +329,9 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
                 </div>
               </>
             )}
-          </section>
+          </SectionCard>
 
-          <section className="card stack">
+          <SectionCard className="stack">
             <div className="section-header">
               <div>
                 <h3>Encounters</h3>
@@ -384,9 +383,9 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
                 ))}
               </div>
             )}
-          </section>
+          </SectionCard>
 
-          <section className="card stack">
+          <SectionCard className="stack">
             <div className="section-header">
               <div>
                 <h3>Nueva nota / evolución</h3>
@@ -433,10 +432,10 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
                 {canAccessClinical ? 'Sin router, sin wizard, sin historia clínica completa.' : 'Modo operativo: sin escritura clínica.'}
               </span>
             </div>
-          </section>
+          </SectionCard>
         </div>
       </div>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/web/src/features/schedule/ScheduleDemo.tsx
+++ b/web/src/features/schedule/ScheduleDemo.tsx
@@ -3,6 +3,7 @@ import { cancelAppointment, createAppointment, createSlotsBulk, listOperationalW
 import { listPatients, listProfessionals } from '../../api/directory';
 import { type AgendaMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
+import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import type { Appointment, BulkCreateSlotsPayload, Slot } from '../../types/appointments';
 import type { Patient, Professional } from '../../types/directory';
 import {
@@ -324,17 +325,15 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
 
   if (agendaMode.kind === 'forbidden') {
     return (
-      <section className="card stack schedule-demo" aria-live="polite">
-        <div className="hero-kicker">Agenda bloqueada</div>
-        <h1>Acceso denegado</h1>
-        <p>{agendaMode.message}</p>
-      </section>
+      <PageContainer className="schedule-demo">
+        <EmptyState eyebrow="Agenda bloqueada" title="Acceso denegado" description={agendaMode.message} className="schedule-shell-empty" />
+      </PageContainer>
     );
   }
 
   return (
-    <div className="stack schedule-demo">
-      <section className="card schedule-overview stack">
+    <PageContainer className="stack schedule-demo">
+      <SectionCard className="schedule-overview stack">
         <div className="stack">
           <div className="schedule-hero-badges status-bar">
             <span className="badge neutral">Profesionales activos: {professionals.length}</span>
@@ -381,9 +380,9 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             </article>
           </div>
         </div>
-      </section>
+      </SectionCard>
 
-      <section className="card card-accent schedule-controls-card stack">
+      <SectionCard className="card-accent schedule-controls-card stack">
         <div className="schedule-controls-head">
           <div>
             <span className="summary-label">Contexto</span>
@@ -453,7 +452,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             </button>
           </div>
         </div>
-      </section>
+      </SectionCard>
 
       <div className="layout schedule-layout">
         <section className="stack schedule-main">
@@ -583,7 +582,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             </div>
           </section>
 
-          <section className="card schedule-booking-card stack">
+          <SectionCard className="schedule-booking-card stack">
             <div>
               <span className="summary-label">Reserva</span>
               <h2>Reservar turno</h2>
@@ -614,11 +613,11 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             <button className="button" type="button" onClick={() => void handleBookAppointment()} disabled={isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId || !selectedPatientId}>
               {isBooking ? 'Reservando...' : 'Reservar turno'}
             </button>
-          </section>
+          </SectionCard>
         </section>
 
         <aside className="schedule-sidebar stack">
-          <section className="card schedule-generator-card stack" aria-labelledby="generate-slots-title">
+          <SectionCard className="schedule-generator-card stack" aria-labelledby="generate-slots-title">
             <div className="stack-tight">
               <span className="summary-label schedule-dark-eyebrow">Soporte</span>
               <h2 id="generate-slots-title">Generar slots</h2>
@@ -664,9 +663,9 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             <button className="button schedule-generator-button" type="button" onClick={() => void handleCreateSlots()} disabled={isBootstrapping || isRefreshingAgenda || isCreatingSlots || !selectedProfessionalId || !selectedDate}>
               {isCreatingSlots ? 'Generando...' : 'Generar slots'}
             </button>
-          </section>
+          </SectionCard>
         </aside>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -31,6 +31,17 @@
   --radius-lg: 20px;
   --radius-md: 16px;
   --radius-sm: 12px;
+  --shell-max-width: 1240px;
+  --shell-sidebar-width: 280px;
+  --shell-stage-bg: linear-gradient(180deg, rgba(249, 249, 249, 0.98) 0%, rgba(243, 243, 243, 0.96) 100%);
+  --shell-ink: #1a1c1c;
+  --shell-muted: rgba(249, 249, 249, 0.72);
+  --shell-line: rgba(87, 0, 0, 0.14);
+  --shell-panel: rgba(87, 0, 0, 0.88);
+  --shell-panel-strong: rgba(128, 0, 0, 0.96);
+  --shell-panel-soft: rgba(115, 92, 0, 0.22);
+  --shell-stage-shadow: 0 24px 54px rgba(26, 28, 28, 0.08);
+  --shell-accent: #fed65b;
 }
 
 * {
@@ -60,9 +71,19 @@ button {
   cursor: pointer;
 }
 
+/* Foundation layout */
+
 .page {
   min-height: 100vh;
   padding: 32px 20px 56px;
+}
+
+.page-app-shell {
+  padding: 0;
+  background:
+    radial-gradient(circle at top left, rgba(254, 214, 91, 0.18), transparent 24%),
+    radial-gradient(circle at top right, rgba(128, 0, 0, 0.18), transparent 30%),
+    linear-gradient(180deg, #570000 0%, #800000 38%, #f3f3f3 38%, #f9f9f9 100%);
 }
 
 .page-centered {
@@ -71,14 +92,52 @@ button {
 }
 
 .shell {
-  max-width: 1160px;
+  max-width: var(--shell-max-width);
   margin: 0 auto;
 }
 
-.app-shell,
-.app-shell-frame {
+.foundation-page-container {
+  display: grid;
   gap: 20px;
 }
+
+.foundation-section-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.foundation-badge {
+  white-space: nowrap;
+}
+
+.foundation-action-bar,
+.foundation-content-split {
+  display: grid;
+  gap: 16px;
+}
+
+.foundation-empty-state {
+  min-height: 180px;
+  place-content: center;
+}
+
+.foundation-summary-tile {
+  min-height: 104px;
+}
+
+/* Shell */
+
+.app-shell,
+.app-shell-frame {
+  gap: 24px;
+}
+
+.app-shell-frame {
+  display: grid;
+  gap: 24px;
+  padding: 12px 0 20px;
+}
+
 .auth-shell {
   max-width: 560px;
 }
@@ -117,6 +176,8 @@ button {
 .summary-tile small,
 .overview-card small,
 .surface-tab small,
+.app-shell-nav-item small,
+.app-shell-sidebar-fact small,
 .slot-button small,
 .appointment-item small,
 .directory-item small {
@@ -140,7 +201,7 @@ button {
 }
 
 .hero-kicker {
-  color: var(--primary);
+  color: #735c00;
 }
 
 .summary-label,
@@ -152,7 +213,7 @@ button {
 
 .card {
   background: rgba(255, 255, 255, 0.94);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(87, 0, 0, 0.08);
   border-radius: var(--radius-lg);
   padding: 24px;
   box-shadow: var(--shadow-card);
@@ -185,12 +246,250 @@ button {
   gap: 18px;
 }
 
+.app-shell-topbar {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  padding: 22px 26px;
+  border: 1px solid var(--shell-line);
+  border-radius: 28px;
+  border-color: var(--shell-line);
+  background:
+    radial-gradient(circle at top left, rgba(110, 168, 254, 0.22), transparent 26%),
+    linear-gradient(180deg, rgba(11, 18, 32, 0.9) 0%, rgba(15, 23, 42, 0.84) 100%);
+  box-shadow: 0 26px 64px rgba(2, 6, 23, 0.3);
+  backdrop-filter: blur(18px);
+}
+
+.app-shell-brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.app-shell-brand-copy {
+  max-width: 44ch;
+}
+
+.app-shell-brand-wordmark {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 1.2rem;
+  letter-spacing: 0.01em;
+  color: #f9f9f9;
+}
+
+.app-shell-brand small {
+  color: var(--shell-muted);
+}
+
+.app-shell-brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #fed65b 0%, #735c00 100%);
+  box-shadow: 0 14px 28px rgba(26, 28, 28, 0.16);
+}
+
+.app-shell-brand-mark-fallback {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #570000;
+}
+
+.app-shell-brand-mark-image-wrap {
+  overflow: hidden;
+  padding: 8px;
+  background: rgba(249, 249, 249, 0.92);
+}
+
+.app-shell-brand-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.app-shell-topbar-meta {
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  justify-content: end;
+  align-items: center;
+  gap: 12px;
+}
+
+.app-shell-topbar .hero-kicker {
+  color: #fed65b;
+}
+
+.app-shell-topbar .badge.neutral {
+  background: rgba(249, 249, 249, 0.12);
+  color: #f9f9f9;
+  border-color: rgba(249, 249, 249, 0.14);
+}
+
+.app-shell-topbar .badge.info {
+  background: rgba(254, 214, 91, 0.16);
+  color: #fff7dd;
+  border-color: rgba(254, 214, 91, 0.2);
+}
+
+.app-shell-account {
+  display: grid;
+  gap: 2px;
+  min-width: 190px;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.42);
+  color: #f8fbff;
+}
+
+.app-shell-account strong,
+.app-shell-sidebar-copy h1 {
+  margin: 0;
+}
+
+.app-shell-account small,
+.app-shell-account .summary-label {
+  color: var(--shell-muted);
+}
+
+.app-shell-topbar .button-secondary {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f8fbff;
+}
+
+.app-shell-topbar .button-secondary:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.app-shell-workspace {
+  grid-template-columns: minmax(280px, var(--shell-sidebar-width)) minmax(0, 1fr);
+  align-items: start;
+  gap: 28px;
+}
+
+.app-shell-sidebar {
+  position: sticky;
+  top: 24px;
+  gap: 22px;
+  padding: 26px;
+  border: 1px solid var(--shell-line);
+  border-radius: 30px;
+  border-color: var(--shell-line);
+  background:
+    radial-gradient(circle at top left, rgba(254, 214, 91, 0.14), transparent 28%),
+    linear-gradient(180deg, var(--shell-panel) 0%, var(--shell-panel-strong) 100%);
+  box-shadow: 0 28px 72px rgba(43, 23, 24, 0.16);
+}
+
+.app-shell-sidebar .hero-kicker {
+  color: #c7dcff;
+}
+
+.app-shell-sidebar-copy h1 {
+  color: #f8fbff;
+}
+
+.app-shell-sidebar-copy p {
+  color: var(--shell-muted);
+}
+
+.app-shell-sidebar-spotlight {
+  padding: 18px;
+  border: 1px solid rgba(110, 168, 254, 0.22);
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(110, 168, 254, 0.12) 0%, rgba(15, 23, 42, 0.14) 100%);
+}
+
+.app-shell-sidebar-spotlight strong {
+  font-size: 1.1rem;
+  color: #f8fbff;
+}
+
+.app-shell-sidebar-spotlight p {
+  margin: 0;
+  color: var(--shell-muted);
+}
+
+.app-shell-sidebar-copy p,
+.app-shell-surface-intro p {
+  margin: 0;
+  max-width: 62ch;
+}
+
+.app-shell-sidebar-facts {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.app-shell-sidebar-fact {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 16px 18px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.app-shell-sidebar-fact dd {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+
+.app-shell-sidebar-fact strong {
+  color: #f8fbff;
+}
+
+.app-shell-sidebar-fact small,
+.app-shell-sidebar .summary-label {
+  color: var(--shell-muted);
+}
+
+.app-shell-main {
+  gap: 24px;
+  min-width: 0;
+}
+
+.app-shell-main > * {
+  min-width: 0;
+}
+
+.app-shell-stage-shell {
+  gap: 18px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 36px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.14) 0%, rgba(226, 232, 240, 0.3) 100%);
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.12);
+}
+
 .app-shell-header {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(237, 244, 255, 0.92) 100%);
 }
 
 .app-shell-nav {
   gap: 16px;
+}
+
+.app-shell-nav-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .app-shell-nav-header {
@@ -211,16 +510,140 @@ button {
 }
 
 .app-shell-surface-frame {
-  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  position: relative;
+  padding: 28px 30px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 28px;
+  border-color: rgba(148, 163, 184, 0.16);
+  background:
+    radial-gradient(circle at top right, rgba(110, 168, 254, 0.18), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(242, 247, 252, 0.96) 100%);
+  box-shadow: 0 24px 54px rgba(15, 23, 42, 0.1);
+}
+
+.app-shell-surface-intro-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.app-shell-surface-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 .app-shell-surface-content {
+  display: grid;
   gap: 20px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 34px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.52) 0%, rgba(226, 232, 240, 0.86) 100%),
+    var(--shell-stage-bg);
+  box-shadow: var(--shell-stage-shadow);
+}
+
+.app-shell-body-stage {
+  display: grid;
+  gap: 20px;
+  min-height: min(70vh, 920px);
+  padding: 22px;
+  border: 1px solid rgba(226, 232, 240, 0.92);
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.99) 0%, rgba(248, 250, 253, 0.98) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 20px 44px rgba(148, 163, 184, 0.18);
+}
+
+.app-shell-nav-item {
+  display: grid;
+  grid-template-columns: 3px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  min-height: 88px;
+  padding: 14px 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.24);
+  color: #f8fbff;
+  text-align: left;
+  transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
+}
+
+.app-shell-nav-item-bar {
+  width: 3px;
+  min-height: 56px;
+  border-radius: 999px;
+  background: rgba(191, 219, 254, 0.24);
+}
+
+.app-shell-nav-item-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.app-shell-nav-item-copy strong {
+  font-size: 1rem;
+  color: currentColor;
+}
+
+.app-shell-nav-item-meta {
+  align-self: start;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--shell-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.app-shell-nav-item:hover {
+  transform: translateX(2px);
+  border-color: rgba(110, 168, 254, 0.24);
+  background: rgba(15, 23, 42, 0.34);
+  box-shadow: 0 16px 28px rgba(2, 6, 23, 0.18);
+}
+
+.app-shell-nav-item.active {
+  border-color: rgba(110, 168, 254, 0.36);
+  background: linear-gradient(180deg, rgba(110, 168, 254, 0.18) 0%, rgba(15, 23, 42, 0.54) 100%);
+  box-shadow: 0 20px 34px rgba(2, 6, 23, 0.22);
+}
+
+.app-shell-nav-item.active .app-shell-nav-item-bar {
+  background: linear-gradient(180deg, #ffffff 0%, var(--shell-accent) 100%);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--shell-accent) 42%, transparent);
+}
+
+.app-shell-nav-item.active .app-shell-nav-item-meta {
+  background: color-mix(in srgb, var(--shell-accent) 22%, rgba(255, 255, 255, 0.12));
+  color: #ffffff;
+}
+
+.app-shell-nav-item.active .surface-tab-eyebrow,
+.app-shell-nav-item.active strong {
+  color: #ffffff;
+}
+
+.app-shell-nav-item .surface-tab-eyebrow,
+.app-shell-nav-item small {
+  color: var(--shell-muted);
 }
 
 .hero-copy {
   max-width: 700px;
 }
+
+/* Shared primitives */
 
 .hero-summary-grid,
 .overview-grid,
@@ -318,25 +741,34 @@ button {
 }
 
 .surface-tab {
-  gap: 6px;
-  min-height: 100px;
-  padding: 16px 18px;
-  border: 1px solid var(--border);
-  background: var(--bg-surface-muted);
-  color: var(--text);
+  gap: 8px;
+  min-height: 108px;
+  padding: 18px 18px 18px 20px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.38);
+  color: #f8fbff;
   text-align: left;
-  transition: border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
+  transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
 }
 
 .surface-tab strong {
   font-size: 1rem;
-  color: var(--text);
+  color: currentColor;
 }
 
 .inline-note-error {
   border: 1px solid rgba(153, 27, 27, 0.12);
   background: var(--error-bg);
   color: var(--error-text);
+}
+
+.foundation-inline-notice {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-surface-muted);
 }
 
 .button-secondary {
@@ -346,19 +778,47 @@ button {
 }
 
 .surface-tab:hover {
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-soft);
+  transform: translateY(-1px);
+  border-color: rgba(110, 168, 254, 0.28);
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.18);
 }
 
 .surface-tab.active {
-  border-color: rgba(37, 99, 235, 0.32);
-  background: linear-gradient(180deg, #ffffff 0%, #edf4ff 100%);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.08);
+  border-color: rgba(110, 168, 254, 0.42);
+  background: linear-gradient(180deg, rgba(110, 168, 254, 0.22) 0%, rgba(30, 41, 59, 0.9) 100%);
+  box-shadow: inset 3px 0 0 var(--shell-accent), 0 18px 36px rgba(2, 6, 23, 0.24);
 }
 
 .surface-tab.active .surface-tab-eyebrow,
 .surface-tab.active strong {
-  color: #1849a9;
+  color: #ffffff;
+}
+
+.surface-tab small,
+.surface-tab .surface-tab-eyebrow {
+  color: var(--shell-muted);
+}
+
+.app-shell-surface-agenda {
+  --shell-accent: #7dd3fc;
+}
+
+.app-shell-surface-patients {
+  --shell-accent: #a7f3d0;
+}
+
+.app-shell-surface-directory {
+  --shell-accent: #fde68a;
+}
+
+.app-shell-surface-frame .hero-kicker {
+  color: var(--shell-accent);
+}
+
+.app-shell-surface-meta .badge.info {
+  background: color-mix(in srgb, var(--shell-accent) 16%, white);
+  color: #1e3a5f;
+  border-color: color-mix(in srgb, var(--shell-accent) 28%, #dbeafe);
 }
 
 .status-bar,
@@ -411,6 +871,8 @@ button {
   grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
   gap: 20px;
 }
+
+/* Feature-local sections */
 
 .schedule-demo,
 .schedule-main,
@@ -993,7 +1455,339 @@ button {
   border-style: solid;
 }
 
+/* Corrective shell rewrite */
+
+.app-shell-surface-agenda {
+  --shell-accent: #60a5fa;
+}
+
+.app-shell-surface-patients {
+  --shell-accent: #34d399;
+}
+
+.app-shell-surface-directory {
+  --shell-accent: #c084fc;
+}
+
+.page-app-shell {
+  background:
+    radial-gradient(circle at 0 0, color-mix(in srgb, var(--shell-accent) 22%, transparent), transparent 24%),
+    linear-gradient(90deg, #07111f 0, #07111f min(26vw, 360px), #eef3f8 min(26vw, 360px), #f7f9fc 100%);
+}
+
+.app-shell-frame {
+  gap: 0;
+  padding: 0;
+}
+
+.app-shell-layout {
+  display: grid;
+  grid-template-columns: minmax(244px, 272px) minmax(0, 1fr);
+  min-height: 100vh;
+  width: 100%;
+  background: transparent;
+}
+
+.app-shell-rail {
+  display: grid;
+  align-content: start;
+  gap: 20px;
+  min-height: 100vh;
+  padding: 28px 20px 24px;
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--shell-accent) 14%, transparent), transparent 28%),
+    linear-gradient(180deg, #09111d 0%, #0c1523 100%);
+  border-right: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.app-shell-rail-brand-block,
+.app-shell-nav,
+.app-shell-rail-footer,
+.app-shell-topbar,
+.app-shell-page-intro,
+.app-shell-stage-frame {
+  min-width: 0;
+}
+
+.app-shell-brand {
+  align-items: flex-start;
+}
+
+.app-shell-rail-brand-block {
+  gap: 12px;
+}
+
+.app-shell-brand-copy {
+  gap: 6px;
+}
+
+.app-shell-brand-wordmark {
+  font-size: 1.22rem;
+}
+
+.app-shell-rail-description,
+.app-shell-rail-account small,
+.app-shell-page-intro-copy p,
+.app-shell-topbar-context span {
+  margin: 0;
+  color: var(--shell-muted);
+}
+
+.app-shell-page-intro-copy h1,
+.app-shell-topbar-context strong,
+.app-shell-rail-account strong {
+  margin: 0;
+}
+
+.app-shell-nav {
+  display: grid;
+  gap: 10px;
+}
+
+.app-shell-nav-list {
+  gap: 8px;
+}
+
+.app-shell-nav-item {
+  min-height: 72px;
+  padding: 14px 14px 14px 12px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.025);
+  border-color: rgba(148, 163, 184, 0.1);
+}
+
+.app-shell-nav-item:hover {
+  transform: translateX(4px);
+  border-color: color-mix(in srgb, var(--shell-accent) 28%, rgba(148, 163, 184, 0.18));
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.app-shell-nav-item.active {
+  border-color: color-mix(in srgb, var(--shell-accent) 38%, rgba(148, 163, 184, 0.18));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--shell-accent) 14%, rgba(255, 255, 255, 0.08)) 0%, rgba(255, 255, 255, 0.05) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.app-shell-nav-item-marker {
+  width: 3px;
+  align-self: stretch;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.24);
+}
+
+.app-shell-nav-item.active .app-shell-nav-item-marker {
+  background: linear-gradient(180deg, #ffffff 0%, var(--shell-accent) 100%);
+}
+
+.app-shell-rail-footer {
+  display: grid;
+  gap: 10px;
+  margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.app-shell-rail-account {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.app-shell-rail-account strong,
+.app-shell-topbar-context strong {
+  color: #f8fbff;
+}
+
+.app-shell-rail-logout {
+  width: 100%;
+  justify-content: center;
+  border-color: rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f8fbff;
+}
+
+.app-shell-rail-logout:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.app-shell-column {
+  display: grid;
+  align-content: start;
+  gap: 24px;
+  min-width: 0;
+  padding: 0 28px 28px;
+  background:
+    linear-gradient(180deg, #eff3f8 0%, #f7f9fc 100%);
+}
+
+.app-shell-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  padding: 20px 4px 18px;
+  border: 0;
+  border-bottom: 1px solid rgba(203, 213, 225, 0.92);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: blur(8px);
+}
+
+.app-shell-topbar-context {
+  gap: 4px;
+}
+
+.app-shell-topbar-meta,
+.app-shell-topbar-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.app-shell-topbar-meta {
+  justify-content: flex-end;
+}
+
+.app-shell-topbar-account {
+  gap: 2px;
+  padding-right: 14px;
+  border-right: 1px solid rgba(203, 213, 225, 0.9);
+}
+
+.app-shell-topbar-account strong {
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.app-shell-topbar-badges .badge {
+  background: rgba(15, 23, 42, 0.04);
+  color: #334155;
+  border-color: rgba(148, 163, 184, 0.18);
+}
+
+.app-shell-page-intro {
+  display: grid;
+  gap: 8px;
+  padding: 0 4px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.app-shell-page-intro-copy {
+  gap: 10px;
+  max-width: 40rem;
+}
+
+.app-shell-page-intro-copy h1 {
+  font-size: clamp(2.5rem, 4vw, 4rem);
+  line-height: 0.94;
+  color: #0f172a;
+}
+
+.app-shell-page-intro-copy p {
+  max-width: 32rem;
+  color: #52607a;
+}
+
+.app-shell-stage {
+  min-width: 0;
+}
+
+.app-shell-stage-frame {
+  padding: 12px;
+  border: 1px solid rgba(87, 0, 0, 0.08);
+  border-radius: 30px;
+  background: rgba(249, 249, 249, 0.74);
+  box-shadow: 0 18px 40px rgba(26, 28, 28, 0.08);
+}
+
+.app-shell-body-stage {
+  min-height: min(70vh, 920px);
+  padding: 16px;
+  border: 1px solid rgba(87, 0, 0, 0.06);
+  border-radius: 22px;
+  background: rgba(249, 249, 249, 0.98);
+}
+
+.app-shell-rail {
+  background:
+    radial-gradient(circle at top left, rgba(254, 214, 91, 0.18), transparent 28%),
+    linear-gradient(180deg, rgba(87, 0, 0, 0.98) 0%, rgba(128, 0, 0, 0.96) 100%);
+  border-right: 1px solid rgba(254, 214, 91, 0.14);
+}
+
+.app-shell-column {
+  background: linear-gradient(180deg, #f3f3f3 0%, #f9f9f9 100%);
+}
+
+.app-shell-topbar {
+  border-bottom: 1px solid rgba(87, 0, 0, 0.12);
+}
+
+.app-shell-topbar-account {
+  border-right: 1px solid rgba(87, 0, 0, 0.14);
+}
+
+.app-shell-topbar-account strong,
+.app-shell-page-intro-copy h1 {
+  color: #570000;
+}
+
+.app-shell-page-intro-copy p,
+.app-shell-topbar-badges .badge,
+.app-shell-topbar-context span {
+  color: #6a5657;
+}
+
+.app-shell-topbar-badges .badge {
+  background: rgba(254, 214, 91, 0.16);
+  border-color: rgba(115, 92, 0, 0.12);
+}
+
+.app-shell-nav-item {
+  background: rgba(249, 249, 249, 0.05);
+}
+
+.app-shell-nav-item:hover {
+  background: rgba(254, 214, 91, 0.08);
+}
+
+.app-shell-nav-item.active {
+  background: linear-gradient(180deg, rgba(254, 214, 91, 0.18) 0%, rgba(249, 249, 249, 0.08) 100%);
+}
+
+.app-shell-nav-item.active .surface-tab-eyebrow,
+.app-shell-nav-item.active strong,
+.app-shell-rail-account strong {
+  color: #f9f9f9;
+}
+
+.app-shell-topbar-context strong {
+  color: #570000;
+}
+
+.app-shell-surface-agenda {
+  --shell-accent: #fed65b;
+}
+
+.app-shell-surface-patients {
+  --shell-accent: #735c00;
+}
+
+.app-shell-surface-directory {
+  --shell-accent: #800000;
+}
+
 @media (max-width: 980px) {
+  .app-shell-layout,
+  .app-shell-workspace,
   .layout,
   .patients-workspace-grid,
   .directory-grid,
@@ -1004,6 +1798,34 @@ button {
   .schedule-primary-grid,
   .schedule-filters-grid {
     grid-template-columns: 1fr;
+  }
+
+  .app-shell-topbar-meta {
+    justify-content: stretch;
+  }
+
+  .app-shell-topbar-account {
+    padding-right: 0;
+    border-right: 0;
+  }
+
+  .app-shell-sidebar,
+  .app-shell-rail {
+    position: static;
+  }
+
+  .app-shell-layout {
+    min-height: auto;
+  }
+
+  .app-shell-rail {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid rgba(254, 214, 91, 0.14);
+  }
+
+  .app-shell-column {
+    padding: 0 24px 24px;
   }
 
   .schedule-sidebar {
@@ -1018,6 +1840,26 @@ button {
 @media (max-width: 720px) {
   .page {
     padding: 24px 16px 40px;
+  }
+
+  .page-app-shell {
+    padding: 0;
+  }
+
+  .app-shell-topbar,
+  .app-shell-page-intro,
+  .app-shell-surface-intro-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app-shell-surface-frame {
+    padding: 24px;
+  }
+
+  .app-shell-topbar-meta,
+  .app-shell-surface-meta {
+    justify-content: flex-start;
   }
 
   .card,
@@ -1036,6 +1878,19 @@ button {
 }
 
 @media (max-width: 560px) {
+  .app-shell-rail,
+  .app-shell-column,
+  .app-shell-topbar,
+  .app-shell-page-intro,
+  .app-shell-stage-frame {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .app-shell-account {
+    min-width: 0;
+  }
+
   .form-grid,
   .time-grid,
   .schedule-stat-grid,
@@ -1052,6 +1907,11 @@ button {
   .app-shell-surface-frame h2,
   .section-hero-card h2 {
     font-size: 1.8rem;
+  }
+
+  .app-shell-body-stage,
+  .app-shell-surface-content {
+    padding: 6px;
   }
 
   .schedule-week-header,


### PR DESCRIPTION
Closes #25

## Summary
- rewrite the authenticated shell posture so the app reads as a distinct workspace with a dominant rail, clearer top bar, stronger intro, and neutral content stage instead of a stacked-card dashboard
- preserve actor-driven surface visibility/default selection and mount existing feature bodies unchanged inside the new shell chrome
- align shell-level branding to the Amicus palette while avoiding invented feature actions, panels, or workflows

## Changes
| File | Change |
|------|--------|
| `web/src/app-shell/AppShell.tsx` | Rewrites the shell composition into a dominant-rail + topbar + intro + neutral stage structure |
| `web/src/app-shell/AppShell.types.ts` | Extends shell contract for shell-owned branding treatment without changing behavior semantics |
| `web/src/app-shell/AppShell.primitives.tsx` | Adds shell-focused primitive helpers used by the new shell composition |
| `web/src/App.tsx` | Adapts the app entrypoint to the new shell posture while preserving orchestration |
| `web/src/App.test.tsx` | Updates top-level assertions for the new shell structure and preserved actor behavior |
| `web/src/auth/actorCapabilities.ts` | Aligns shell-level copy/metadata to the new chrome while preserving visible-surface semantics |
| `web/src/auth/actorCapabilities.test.ts` | Updates shell metadata assertions after approved copy drift |
| `web/src/features/schedule/ScheduleDemo.tsx` | Keeps the feature mounted within the new shell stage without redesigning internal workflow logic |
| `web/src/features/patients/PatientsWorkspace.tsx` | Adapts mount/framing expectations to the shell breakthrough |
| `web/src/features/directory/DirectoryDemo.tsx` | Adapts mount/framing expectations to the shell breakthrough |
| `web/src/styles.css` | Rewrites shell posture/materials/branding and detaches the shell from the old boxed-card layout |

## Test Plan
- [x] `npx vitest run src/App.test.tsx src/auth/actorCapabilities.test.ts --reporter=verbose` in `web/`
- [x] `npm run typecheck` in `web/`
- [x] Verified the change stays shell-only and does not redesign agenda/patients/directory internals or change auth/permissions/workflows

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Added docs/contract updates where behavior changed
- [x] Used conventional commits only
- [x] No `Co-Authored-By` trailers added