### PR TITLE
feat(web): redesign agenda interior

### DIFF
--- a/web/src/features/schedule/ScheduleDemo.test.tsx
+++ b/web/src/features/schedule/ScheduleDemo.test.tsx
@@ -84,7 +84,7 @@ describe('ScheduleDemo weekly operational board', () => {
     );
 
     expect(screen.getByText('Agenda bloqueada')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Acceso denegado' })).toBeInTheDocument();
+    expect(screen.getByText('Acceso denegado')).toBeInTheDocument();
     expect(screen.getByText('Tu perfil no tiene permisos para usar esta agenda.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Actualizar/i })).not.toBeInTheDocument();
     expect(listProfessionalsMock).not.toHaveBeenCalled();
@@ -151,9 +151,48 @@ describe('ScheduleDemo weekly operational board', () => {
     expect(screen.queryByText(/Sáb/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Dom/i)).not.toBeInTheDocument();
     expect(screen.getAllByText('Sin actividad para este día').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Contexto de agenda')).not.toBeInTheDocument();
+    expect(screen.queryByText('Filtros de agenda')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
   });
 
-  it('uses the selected slot cell as the only booking selector and preserves supported actions only', async () => {
+  it('keeps a single compact context surface on constrained viewports', async () => {
+    const originalInnerWidth = window.innerWidth;
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 375,
+      writable: true,
+    });
+    window.dispatchEvent(new Event('resize'));
+
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    mockWeekSlices({
+      '2026-04-08': { slots: [availableSlot('slot-wed', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
+    });
+
+    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
+    expect(screen.getAllByText(/Semana UTC/i)).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Reservar turno' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Generar slots' })).toHaveLength(1);
+    expect(screen.queryByText('Contexto de agenda')).not.toBeInTheDocument();
+    expect(screen.queryByText('Filtros de agenda')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+      writable: true,
+    });
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  it('opens booking through a modal launched from the selected slot context', async () => {
     listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
     listPatientsMock.mockResolvedValue({ items: [activePatient()] });
     mockWeekRefreshes([
@@ -180,15 +219,26 @@ describe('ScheduleDemo weekly operational board', () => {
 
     const slotCell = await screen.findByRole('button', { name: /Mié 08\/04 .*10:00 - 10:30 UTC/i });
 
-    expect(screen.queryByLabelText('Slot a reservar')).not.toBeInTheDocument();
-    expect(screen.getByText('Elegí profesional y semana para cargar la operación visible sin salir del espacio actual.')).toBeInTheDocument();
-    expect(screen.getByText('Acción secundaria: cargá disponibilidad para el día seleccionado sin salir de esta vista.')).toBeInTheDocument();
+    const bookTrigger = screen.getByRole('button', { name: 'Reservar turno' });
+
+    expect(bookTrigger).toBeDisabled();
     expect(screen.queryByRole('button', { name: /Reprogramar/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Ver detalle/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
 
     fireEvent.click(slotCell);
-    fireEvent.click(screen.getByRole('button', { name: 'Reservar turno' }));
+
+    expect(bookTrigger).toBeEnabled();
+
+    fireEvent.click(bookTrigger);
+
+    const bookingDialog = await screen.findByRole('dialog', { name: /Reservar turno/i });
+
+    expect(within(bookingDialog).getByLabelText('Paciente')).toBeInTheDocument();
+    expect(within(bookingDialog).getByText(/Mié 08\/04/i)).toBeInTheDocument();
+
+    fireEvent.click(within(bookingDialog).getByRole('button', { name: 'Confirmar reserva' }));
 
     await waitFor(() => {
       expect(createAppointmentMock).toHaveBeenCalledWith({
@@ -199,11 +249,14 @@ describe('ScheduleDemo weekly operational board', () => {
     });
 
     expect(await screen.findByText('Turno reservado correctamente.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /Reservar turno/i })).not.toBeInTheDocument();
+    });
     expect(await screen.findByText('Juan Pérez')).toBeInTheDocument();
     expect(screen.getByText('Reservado')).toBeInTheDocument();
   });
 
-  it('lets the operator select a weekday card and keeps support actions bound to that selected day', async () => {
+  it('opens slot generation through a modal bound to the selected day', async () => {
     listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
     listPatientsMock.mockResolvedValue({ items: [activePatient()] });
     mockWeekRefreshes([
@@ -222,7 +275,17 @@ describe('ScheduleDemo weekly operational board', () => {
     expect(weekdayCard).toHaveAttribute('aria-pressed', 'true');
     expect(await screen.findAllByText('Sin actividad para este día')).not.toHaveLength(0);
 
+    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole('button', { name: 'Generar slots' }));
+
+    const generateDialog = await screen.findByRole('dialog', { name: /Generar slots/i });
+
+    expect(within(generateDialog).getByLabelText('Desde')).toBeInTheDocument();
+    expect(within(generateDialog).getByLabelText('Hasta')).toBeInTheDocument();
+    expect(within(generateDialog).getAllByText(/Mié 08\/04/i).length).toBeGreaterThan(0);
+
+    fireEvent.click(within(generateDialog).getByRole('button', { name: 'Confirmar generación' }));
 
     await waitFor(() => {
       expect(createSlotsBulkMock).toHaveBeenCalledWith({
@@ -235,6 +298,9 @@ describe('ScheduleDemo weekly operational board', () => {
     });
 
     expect(await screen.findByText('Se generaron 1 slot correctamente.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /Generar slots/i })).not.toBeInTheDocument();
+    });
     expect(await screen.findByRole('button', { name: /Mié 08\/04 .*09:00 - 09:30 UTC/i })).toBeInTheDocument();
   });
 
@@ -272,6 +338,39 @@ describe('ScheduleDemo weekly operational board', () => {
     expect(within(screen.getByTestId('board-cell-2026-04-08-09:00')).getByText('Cancelado')).toBeInTheDocument();
     expect(screen.queryByText(/Appointment:/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Slot:/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the redesign on existing agenda capabilities and backend contracts only', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    mockWeekSlices({
+      '2026-04-08': { slots: [availableSlot('slot-wed', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
+    });
+
+    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
+    expect(listSlotsMock).toHaveBeenCalledTimes(5);
+    expect(listAppointmentsMock).toHaveBeenCalledTimes(5);
+    expect(createAppointmentMock).not.toHaveBeenCalled();
+    expect(createSlotsBulkMock).not.toHaveBeenCalled();
+    expect(cancelAppointmentMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /Reprogramar/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Ver detalle/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actualizar agenda' }));
+
+    await waitFor(() => {
+      expect(listSlotsMock).toHaveBeenCalledTimes(10);
+      expect(listAppointmentsMock).toHaveBeenCalledTimes(10);
+    });
+
+    expect(createAppointmentMock).not.toHaveBeenCalled();
+    expect(createSlotsBulkMock).not.toHaveBeenCalled();
+    expect(cancelAppointmentMock).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/features/schedule/ScheduleDemo.tsx
+++ b/web/src/features/schedule/ScheduleDemo.tsx
@@ -45,6 +45,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
   const [slotStartTime, setSlotStartTime] = useState('09:00');
   const [slotEndTime, setSlotEndTime] = useState('12:00');
   const [slotDurationMinutes, setSlotDurationMinutes] = useState<BulkCreateSlotsPayload['slot_duration_minutes']>(30);
+  const [activeModal, setActiveModal] = useState<'book' | 'generate' | null>(null);
   const releasedSlotIdRef = useRef('');
 
   const isDoctorAgenda = agendaMode.kind === 'doctor-own';
@@ -90,15 +91,6 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
   );
   const selectedSlot = useMemo(() => slotById.get(selectedSlotId) ?? null, [selectedSlotId, slotById]);
   const selectedWeekDay = useMemo(() => days.find((day) => day.date === selectedDate) ?? null, [days, selectedDate]);
-  const weeklySummary = useMemo(
-    () => ({
-      available: days.reduce((total, day) => total + day.summary.available, 0),
-      booked: days.reduce((total, day) => total + day.summary.booked, 0),
-      cancelled: days.reduce((total, day) => total + day.summary.cancelled, 0),
-    }),
-    [days],
-  );
-
   const bootstrap = useCallback(async () => {
     if (agendaMode.kind === 'forbidden') {
       setProfessionals([]);
@@ -224,6 +216,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
         professional_id: selectedProfessionalId,
       });
 
+      setActiveModal(null);
       setSuccessMessage('Turno reservado correctamente.');
       await refreshAgenda();
     } catch (error) {
@@ -291,6 +284,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
         slot_duration_minutes: slotDurationMinutes,
       });
 
+      setActiveModal(null);
       setSuccessMessage(
         response.items.length > 0
           ? `Se generaron ${response.items.length} slot${response.items.length === 1 ? '' : 's'} correctamente.`
@@ -323,6 +317,12 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
     setSelectedSlotId('');
   }
 
+  const selectedSlotLabel = selectedSlot ? formatDateTimeRange(selectedSlot.start_time, selectedSlot.end_time) : 'Todavía sin horario seleccionado';
+  const selectedDayLabel = selectedWeekDay?.weekdayLabel ?? 'Sin día seleccionado';
+  const selectedDayLongLabel = selectedWeekDay ? formatLongDate(selectedWeekDay.date) : 'Elegí un día del tablero para operar.';
+  const isBookActionDisabled = isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId;
+  const isGenerateActionDisabled = isBootstrapping || isRefreshingAgenda || isCreatingSlots || !selectedProfessionalId || !selectedDate;
+
   if (agendaMode.kind === 'forbidden') {
     return (
       <PageContainer className="schedule-demo">
@@ -333,71 +333,28 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
 
   return (
     <PageContainer className="stack schedule-demo">
-      <SectionCard className="schedule-overview stack">
-        <div className="stack">
-          <div className="schedule-hero-badges status-bar">
-            <span className="badge neutral">Profesionales activos: {professionals.length}</span>
-            <span className="badge neutral">Pacientes activos: {patients.length}</span>
-            <span className="badge neutral">Disponibles semana: {weeklySummary.available}</span>
-          </div>
-
-          {(successMessage || errorMessage || accessDeniedMessage) && (
-            <div className="status-bar" aria-live="polite">
-              {successMessage ? <span className="badge success">{successMessage}</span> : null}
-              {errorMessage ? <span className="badge error">{errorMessage}</span> : null}
-              {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
-            </div>
-          )}
+      {(successMessage || errorMessage || accessDeniedMessage) && (
+        <div className="status-bar" aria-live="polite">
+          {successMessage ? <span className="badge success">{successMessage}</span> : null}
+          {errorMessage ? <span className="badge error">{errorMessage}</span> : null}
+          {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
         </div>
+      )}
 
-        <div className="schedule-hero-panel">
-          <div className="schedule-hero-panel-head">
-            <span className="summary-label">Contexto de agenda</span>
-            <strong>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name}` : 'Sin profesional'}</strong>
-            <small>{selectedProfessional?.specialty ?? 'Elegí un profesional para revisar la agenda.'}</small>
-          </div>
-
-          <div className="schedule-stat-grid">
-            <article className="schedule-stat-card">
-              <span className="summary-label">Semana UTC</span>
-              <strong>{formatLongDate(weekStart)}</strong>
-              <small>Tablero operativo de lunes a viernes.</small>
-            </article>
-            <article className="schedule-stat-card">
-              <span className="summary-label">Disponibles</span>
-              <strong>{weeklySummary.available}</strong>
-              <small>{weeklySummary.available > 0 ? 'Listos para reservar.' : 'Sin disponibilidad reservable.'}</small>
-            </article>
-            <article className="schedule-stat-card">
-              <span className="summary-label">Reservados</span>
-              <strong>{weeklySummary.booked}</strong>
-              <small>Turnos activos visibles.</small>
-            </article>
-            <article className="schedule-stat-card">
-              <span className="summary-label">Cancelados</span>
-              <strong>{weeklySummary.cancelled}</strong>
-              <small>Visibles para seguimiento.</small>
-            </article>
-          </div>
-        </div>
-      </SectionCard>
-
-      <SectionCard className="card-accent schedule-controls-card stack">
-        <div className="schedule-controls-head">
+      <SectionCard className="card-accent schedule-context-bar">
+        <div className="schedule-context-bar-main">
           <div>
-            <span className="summary-label">Contexto</span>
-            <h2>Filtros de agenda</h2>
-            <p className="helper">Elegí profesional y semana para cargar la operación visible sin salir del espacio actual.</p>
+            <span className="summary-label">Agenda</span>
+            <h2>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name}` : 'Sin profesional seleccionado'}</h2>
+            <p className="helper">{selectedProfessional?.specialty ?? 'Elegí un profesional para revisar la agenda visible.'}</p>
           </div>
-          <div className="schedule-controls-toolbar">
+          <div className="schedule-context-bar-week">
             <span className="badge info">UTC fijo para evitar corrimientos</span>
-            <button className="button secondary" type="button" onClick={() => void refreshAgenda()} disabled={isBootstrapping || isRefreshingAgenda}>
-              {isRefreshingAgenda ? 'Actualizando...' : 'Actualizar agenda'}
-            </button>
+            <span className="badge neutral">Semana UTC {formatLongDate(weekStart)}</span>
           </div>
         </div>
 
-        <div className="schedule-filters-grid">
+        <div className="schedule-context-bar-controls">
           <div className="field">
             <label htmlFor="professional">Profesional</label>
             {isDoctorAgenda ? (
@@ -425,247 +382,262 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             )}
           </div>
 
-          <div className="field">
-            <label htmlFor="date">Fecha</label>
-            <input
-              id="date"
-              type="date"
-              value={selectedDate}
-              onChange={(event) => {
-                const nextSelectedDate = mapDateToOperationalWeek(event.target.value);
+        </div>
 
-                clearReleasedSlotFeedback();
-                setSelectedDate(nextSelectedDate);
-                setWeekStart(getUtcWeekStart(nextSelectedDate));
-                setSelectedSlotId('');
-              }}
-            />
-            <small className="helper">La fecha define el día operativo seleccionado; la semana visible se acomoda en UTC alrededor de ese día.</small>
-          </div>
-
-          <div className="schedule-controls-toolbar">
-            <button className="button secondary" type="button" onClick={() => shiftWeek(-7)} disabled={isBootstrapping || isRefreshingAgenda}>
-              Semana anterior
-            </button>
-            <button className="button secondary" type="button" onClick={() => shiftWeek(7)} disabled={isBootstrapping || isRefreshingAgenda}>
-              Semana siguiente
-            </button>
-          </div>
+        <div className="schedule-context-bar-actions">
+          <button className="button secondary" type="button" onClick={() => shiftWeek(-7)} disabled={isBootstrapping || isRefreshingAgenda}>
+            Semana anterior
+          </button>
+          <button className="button secondary" type="button" onClick={() => shiftWeek(7)} disabled={isBootstrapping || isRefreshingAgenda}>
+            Semana siguiente
+          </button>
+          <button className="button secondary" type="button" onClick={() => void refreshAgenda()} disabled={isBootstrapping || isRefreshingAgenda}>
+            {isRefreshingAgenda ? 'Actualizando...' : 'Actualizar agenda'}
+          </button>
+          <button className="button" type="button" onClick={() => setActiveModal('book')} disabled={isBookActionDisabled}>
+            {isBooking ? 'Reservando...' : 'Reservar turno'}
+          </button>
+          <button className="button schedule-generator-button" type="button" onClick={() => setActiveModal('generate')} disabled={isGenerateActionDisabled}>
+            {isCreatingSlots ? 'Generando...' : 'Generar slots'}
+          </button>
         </div>
       </SectionCard>
 
-      <div className="layout schedule-layout">
-        <section className="stack schedule-main">
-          <section className="card stack">
-            <div className="section-header">
-              <div>
-                <span className="summary-label">Tablero</span>
-                <h2>Semana operativa</h2>
-                <p>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name} · foco actual ${formatLongDate(selectedDate)}` : 'Seleccioná un profesional para ver disponibilidad.'}</p>
-              </div>
+      <section className="card stack schedule-board-shell">
+        <div className="schedule-board-header">
+          <div>
+            <span className="summary-label">Tablero</span>
+            <h2>Agenda semanal operativa</h2>
+            <p>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name} · tablero operativo de lunes a viernes.` : 'Seleccioná un profesional para ver disponibilidad.'}</p>
+          </div>
+          <div className="schedule-board-toolbar">
+            <div className="inline-note">
+              <strong>Día seleccionado: {selectedDayLabel}</strong>
+              <span>{selectedDayLongLabel}</span>
             </div>
-
-            {releasedSlotId && releasedSlotLabel ? (
-              <div className="slot-grid-feedback" role="status">
-                <strong>Slot liberado</strong>
-                <span>{releasedSlotLabel} ya está otra vez disponible y quedó seleccionado para que se note el cambio.</span>
+            {selectedSlot ? (
+              <div className="inline-note">
+                <strong>Slot listo para reservar</strong>
+                <span>{selectedSlotLabel}</span>
               </div>
             ) : null}
+          </div>
+        </div>
 
-            <div className="schedule-week-board stack">
-              <div className="schedule-week-header" role="row">
-                <div className="summary-label schedule-week-axis">UTC</div>
-                {days.map((day) => (
-                  <button
-                    key={day.date}
-                    type="button"
-                    aria-pressed={day.date === selectedDate}
-                    className={`schedule-day-card${day.date === selectedDate ? ' selected' : ''}`}
-                    onClick={() => {
-                      setSelectedDate(day.date);
-                      setSelectedSlotId('');
-                    }}
-                  >
-                    <strong>{day.weekdayLabel}</strong>
-                    <small>{day.date === selectedDate ? 'Día seleccionado para operar' : 'Hacé click para operar este día'}</small>
-                    {day.slots.length === 0 && day.appointments.length === 0 ? <small>Sin actividad para este día</small> : null}
-                    <small>
-                      {day.summary.available} disp. · {day.summary.booked} reserv. · {day.summary.cancelled} canc.
-                    </small>
-                  </button>
-                ))}
-              </div>
+        {releasedSlotId && releasedSlotLabel ? (
+          <div className="slot-grid-feedback" role="status">
+            <strong>Slot liberado</strong>
+            <span>{releasedSlotLabel} ya está otra vez disponible y quedó seleccionado para que se note el cambio.</span>
+          </div>
+        ) : null}
 
-              {timeBands.length === 0 ? (
-                <div className="schedule-week-empty-grid">
-                  <div className="summary-label schedule-week-axis">UTC</div>
-                  {days.map((day) => (
-                    <div key={day.date} className="empty-state">
-                      <strong>{day.weekdayLabel}</strong>
-                      <span>Sin actividad para este día</span>
-                    </div>
-                  ))}
+        <div className="schedule-week-board stack">
+          <div className="schedule-week-header" role="row">
+            <div className="summary-label schedule-week-axis">UTC</div>
+            {days.map((day) => (
+              <button
+                key={day.date}
+                type="button"
+                aria-pressed={day.date === selectedDate}
+                className={`schedule-day-card${day.date === selectedDate ? ' selected' : ''}`}
+                onClick={() => {
+                  setSelectedDate(day.date);
+                  setSelectedSlotId('');
+                }}
+              >
+                <strong>{day.weekdayLabel}</strong>
+                <small>{day.date === selectedDate ? 'Día seleccionado para operar' : 'Hacé click para operar este día'}</small>
+                {day.slots.length === 0 && day.appointments.length === 0 ? <small>Sin actividad para este día</small> : null}
+                <small>
+                  {day.summary.available} disp. · {day.summary.booked} reserv. · {day.summary.cancelled} canc.
+                </small>
+              </button>
+            ))}
+          </div>
+
+          {timeBands.length === 0 ? (
+            <div className="schedule-week-empty-grid">
+              <div className="summary-label schedule-week-axis">UTC</div>
+              {days.map((day) => (
+                <div key={day.date} className="empty-state">
+                  <strong>{day.weekdayLabel}</strong>
+                  <span>Sin actividad para este día</span>
                 </div>
-              ) : (
-                timeBands.map((band) => (
-                  <div key={band} className={`schedule-week-row${focusedBand === band ? ' selected' : ''}`} role="row">
-                    <div className="summary-label">{band}</div>
-                    {days.map((day) => {
-                      const slot = day.slots.find((item) => formatTimeBand(item.start_time) === band) ?? null;
-                      const appointment = slot ? appointmentBySlotId.get(slot.id) ?? day.appointments.find((item) => item.slot_id === slot.id) ?? null : null;
-                      const patientName = appointment ? patientNameById.get(appointment.patient_id) ?? appointment.patient_id : '';
-                      const isSelectedSlot = slot?.id === selectedSlotId;
-                      const isReleasedSlot = slot?.id === releasedSlotId;
-                      const cellLabel = slot ? `${day.weekdayLabel} · ${formatDateTimeRange(slot.start_time, slot.end_time)}` : `${day.weekdayLabel} · ${band}`;
+              ))}
+            </div>
+          ) : (
+            timeBands.map((band) => (
+              <div key={band} className={`schedule-week-row${focusedBand === band ? ' selected' : ''}`} role="row">
+                <div className="summary-label">{band}</div>
+                {days.map((day) => {
+                  const slot = day.slots.find((item) => formatTimeBand(item.start_time) === band) ?? null;
+                  const appointment = slot ? appointmentBySlotId.get(slot.id) ?? day.appointments.find((item) => item.slot_id === slot.id) ?? null : null;
+                  const patientName = appointment ? patientNameById.get(appointment.patient_id) ?? appointment.patient_id : '';
+                  const isSelectedSlot = slot?.id === selectedSlotId;
+                  const isReleasedSlot = slot?.id === releasedSlotId;
+                  const cellLabel = slot ? `${day.weekdayLabel} · ${formatDateTimeRange(slot.start_time, slot.end_time)}` : `${day.weekdayLabel} · ${band}`;
 
-                      return (
-                        <div key={`${day.date}-${band}`} data-testid={`board-cell-${day.date}-${band}`} className={`card schedule-board-cell${day.date === selectedDate ? ' selected-day' : ''}`}>
-                          {slot?.status === 'available' ? (
-                            <div className="stack-tight">
-                              {appointment?.status === 'cancelled' ? (
-                                <>
-                                  <strong>{patientName}</strong>
-                                  <span className="pill cancelled">Cancelado</span>
-                                </>
-                              ) : null}
-                              <button
-                                type="button"
-                                aria-pressed={isSelectedSlot}
-                                className={`slot-button${isSelectedSlot ? ' selected' : ''}${isReleasedSlot ? ' released' : ''}`}
-                                onClick={() => {
-                                  setSelectedDate(day.date);
-                                  setSelectedSlotId(slot.id);
-                                  setFocusedBand(band);
-                                  if (slot.id !== releasedSlotId) {
-                                    setReleasedSlotId('');
-                                    setReleasedSlotLabel('');
-                                  }
-                                }}
-                              >
-                                <span className="slot-card-kicker">Horario disponible</span>
-                                <strong>{cellLabel}</strong>
-                                <span className="slot-note">{isReleasedSlot ? 'Se liberó recién' : 'Seleccioná este horario'}</span>
-                              </button>
-                            </div>
-                          ) : appointment ? (
-                            <div className="stack-tight">
+                  return (
+                    <div key={`${day.date}-${band}`} data-testid={`board-cell-${day.date}-${band}`} className={`card schedule-board-cell${day.date === selectedDate ? ' selected-day' : ''}`}>
+                      {slot?.status === 'available' ? (
+                        <div className="stack-tight">
+                          {appointment?.status === 'cancelled' ? (
+                            <>
                               <strong>{patientName}</strong>
-                              <small>{slot ? formatDateTimeRange(slot.start_time, slot.end_time) : 'Horario no disponible'}</small>
-                              {selectedProfessional ? (
-                                <small>
-                                  {selectedProfessional.first_name} {selectedProfessional.last_name} · {formatLongDate(day.date)}
-                                </small>
-                              ) : null}
-                              <span className={`pill${appointment.status === 'cancelled' ? ' cancelled' : ''}`}>{appointment.status === 'cancelled' ? 'Cancelado' : 'Reservado'}</span>
-                              <button
-                                className="button ghost"
-                                type="button"
-                                onClick={() => {
-                                  setSelectedDate(day.date);
-                                  setFocusedBand(band);
-                                  void handleCancelAppointment(appointment.id);
-                                }}
-                                disabled={appointment.status === 'cancelled' || cancellingAppointmentId === appointment.id}
-                              >
-                                {cancellingAppointmentId === appointment.id ? 'Cancelando...' : 'Cancelar'}
-                              </button>
-                            </div>
-                          ) : (
-                            <span className="helper">—</span>
-                          )}
+                              <span className="pill cancelled">Cancelado</span>
+                            </>
+                          ) : null}
+                          <button
+                            type="button"
+                            aria-pressed={isSelectedSlot}
+                            className={`slot-button${isSelectedSlot ? ' selected' : ''}${isReleasedSlot ? ' released' : ''}`}
+                            onClick={() => {
+                              setSelectedDate(day.date);
+                              setSelectedSlotId(slot.id);
+                              setFocusedBand(band);
+                              if (slot.id !== releasedSlotId) {
+                                setReleasedSlotId('');
+                                setReleasedSlotLabel('');
+                              }
+                            }}
+                          >
+                            <span className="slot-card-kicker">Horario disponible</span>
+                            <strong>{cellLabel}</strong>
+                            <span className="slot-note">{isReleasedSlot ? 'Se liberó recién' : 'Seleccioná este horario'}</span>
+                          </button>
                         </div>
-                      );
-                    })}
+                      ) : appointment ? (
+                        <div className="stack-tight">
+                          <strong>{patientName}</strong>
+                          <small>{slot ? formatDateTimeRange(slot.start_time, slot.end_time) : 'Horario no disponible'}</small>
+                          {selectedProfessional ? (
+                            <small>
+                              {selectedProfessional.first_name} {selectedProfessional.last_name} · {formatLongDate(day.date)}
+                            </small>
+                          ) : null}
+                          <span className={`pill${appointment.status === 'cancelled' ? ' cancelled' : ''}`}>{appointment.status === 'cancelled' ? 'Cancelado' : 'Reservado'}</span>
+                          <button
+                            className="button ghost"
+                            type="button"
+                            onClick={() => {
+                              setSelectedDate(day.date);
+                              setFocusedBand(band);
+                              void handleCancelAppointment(appointment.id);
+                            }}
+                            disabled={appointment.status === 'cancelled' || cancellingAppointmentId === appointment.id}
+                          >
+                            {cancellingAppointmentId === appointment.id ? 'Cancelando...' : 'Cancelar'}
+                          </button>
+                        </div>
+                      ) : (
+                        <span className="helper">—</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      {activeModal ? (
+        <div className="schedule-modal-backdrop" role="presentation">
+          <section className="card stack schedule-modal" role="dialog" aria-modal="true" aria-labelledby={`schedule-modal-title-${activeModal}`}>
+            <div className="schedule-modal-head">
+              <div>
+                <span className="summary-label">{activeModal === 'book' ? 'Reserva' : 'Disponibilidad'}</span>
+                <h2 id={`schedule-modal-title-${activeModal}`}>{activeModal === 'book' ? 'Reservar turno' : 'Generar slots'}</h2>
+                <p className="helper">{selectedDayLabel} · {selectedDayLongLabel}</p>
+              </div>
+              <button className="button ghost" type="button" onClick={() => setActiveModal(null)}>
+                Cerrar
+              </button>
+            </div>
+
+            {activeModal === 'book' ? (
+              <>
+                <div className="field">
+                  <label htmlFor="patient">Paciente</label>
+                  <select id="patient" value={selectedPatientId} onChange={(event) => setSelectedPatientId(event.target.value)} disabled={isBootstrapping || patients.length === 0}>
+                    {patients.length === 0 ? <option value="">No hay pacientes</option> : null}
+                    {patients.map((patient) => (
+                      <option key={patient.id} value={patient.id}>
+                        {patient.first_name} {patient.last_name} · doc {patient.document}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="inline-note" aria-live="polite">
+                  <strong>{selectedSlotLabel}</strong>
+                  <span>
+                    {selectedSlot
+                      ? `Paciente listo para reservar: ${selectedPatient ? `${selectedPatient.first_name} ${selectedPatient.last_name}` : 'seleccioná un paciente'}.`
+                      : 'Seleccioná un horario desde la grilla de disponibilidad para continuar.'}
+                  </span>
+                </div>
+
+                <div className="schedule-modal-actions">
+                  <button className="button ghost" type="button" onClick={() => setActiveModal(null)}>
+                    Cancelar
+                  </button>
+                  <button className="button" type="button" onClick={() => void handleBookAppointment()} disabled={isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId || !selectedPatientId}>
+                    {isBooking ? 'Reservando...' : 'Confirmar reserva'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="inline-note">
+                  <strong>{selectedDayLabel}</strong>
+                  <span>{selectedDayLongLabel}</span>
+                </div>
+
+                <div className="time-grid">
+                  <div className="field">
+                    <label htmlFor="slot-start-time">Desde</label>
+                    <input id="slot-start-time" type="time" value={slotStartTime} onChange={(event) => setSlotStartTime(event.target.value)} />
                   </div>
-                ))
-              )}
-            </div>
+
+                  <div className="field">
+                    <label htmlFor="slot-end-time">Hasta</label>
+                    <input id="slot-end-time" type="time" value={slotEndTime} onChange={(event) => setSlotEndTime(event.target.value)} />
+                  </div>
+                </div>
+
+                <div className="field">
+                  <label htmlFor="slot-duration">Duración del slot</label>
+                  <select id="slot-duration" value={slotDurationMinutes} onChange={(event) => setSlotDurationMinutes(Number(event.target.value) as BulkCreateSlotsPayload['slot_duration_minutes'])}>
+                    {[15, 20, 30, 60].map((duration) => (
+                      <option key={duration} value={duration}>
+                        {duration} minutos
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="schedule-generator-summary">
+                  <span>Ventana</span>
+                  <strong>
+                    {slotStartTime} → {slotEndTime}
+                  </strong>
+                  <small>{slotDurationMinutes} min por slot</small>
+                </div>
+
+                <div className="schedule-modal-actions">
+                  <button className="button ghost" type="button" onClick={() => setActiveModal(null)}>
+                    Cancelar
+                  </button>
+                  <button className="button schedule-generator-button" type="button" onClick={() => void handleCreateSlots()} disabled={isGenerateActionDisabled}>
+                    {isCreatingSlots ? 'Generando...' : 'Confirmar generación'}
+                  </button>
+                </div>
+              </>
+            )}
           </section>
-
-          <SectionCard className="schedule-booking-card stack">
-            <div>
-              <span className="summary-label">Reserva</span>
-              <h2>Reservar turno</h2>
-              <p className="helper">La reserva sigue arrancando desde la grilla principal: primero elegí un horario y después asignalo a un paciente.</p>
-            </div>
-
-            <div className="field">
-              <label htmlFor="patient">Paciente</label>
-              <select id="patient" value={selectedPatientId} onChange={(event) => setSelectedPatientId(event.target.value)} disabled={isBootstrapping || patients.length === 0}>
-                {patients.length === 0 ? <option value="">No hay pacientes</option> : null}
-                {patients.map((patient) => (
-                  <option key={patient.id} value={patient.id}>
-                    {patient.first_name} {patient.last_name} · doc {patient.document}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="inline-note" aria-live="polite">
-              <strong>{selectedSlot ? formatDateTimeRange(selectedSlot.start_time, selectedSlot.end_time) : 'Todavía sin horario seleccionado'}</strong>
-              <span>
-                {selectedSlot
-                  ? `Paciente listo para reservar: ${selectedPatient ? `${selectedPatient.first_name} ${selectedPatient.last_name}` : 'seleccioná un paciente'}.`
-                  : 'Seleccioná un horario desde la grilla de disponibilidad para continuar.'}
-              </span>
-            </div>
-
-            <button className="button" type="button" onClick={() => void handleBookAppointment()} disabled={isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId || !selectedPatientId}>
-              {isBooking ? 'Reservando...' : 'Reservar turno'}
-            </button>
-          </SectionCard>
-        </section>
-
-        <aside className="schedule-sidebar stack">
-          <SectionCard className="schedule-generator-card stack" aria-labelledby="generate-slots-title">
-            <div className="stack-tight">
-              <span className="summary-label schedule-dark-eyebrow">Soporte</span>
-              <h2 id="generate-slots-title">Generar slots</h2>
-              <p className="helper">Acción secundaria: cargá disponibilidad para el día seleccionado sin salir de esta vista.</p>
-            </div>
-
-            <div className="inline-note">
-              <strong>{selectedWeekDay?.weekdayLabel ?? 'Sin día seleccionado'}</strong>
-              <span>{selectedWeekDay ? formatLongDate(selectedWeekDay.date) : 'Elegí una fecha para cargar disponibilidad.'}</span>
-            </div>
-
-            <div className="time-grid">
-              <div className="field">
-                <label htmlFor="slot-start-time">Desde</label>
-                <input id="slot-start-time" type="time" value={slotStartTime} onChange={(event) => setSlotStartTime(event.target.value)} />
-              </div>
-
-              <div className="field">
-                <label htmlFor="slot-end-time">Hasta</label>
-                <input id="slot-end-time" type="time" value={slotEndTime} onChange={(event) => setSlotEndTime(event.target.value)} />
-              </div>
-            </div>
-
-            <div className="field">
-              <label htmlFor="slot-duration">Duración del slot</label>
-              <select id="slot-duration" value={slotDurationMinutes} onChange={(event) => setSlotDurationMinutes(Number(event.target.value) as BulkCreateSlotsPayload['slot_duration_minutes'])}>
-                {[15, 20, 30, 60].map((duration) => (
-                  <option key={duration} value={duration}>
-                    {duration} minutos
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="schedule-generator-summary">
-              <span>Ventana</span>
-              <strong>
-                {slotStartTime} → {slotEndTime}
-              </strong>
-              <small>{slotDurationMinutes} min por slot</small>
-            </div>
-
-            <button className="button schedule-generator-button" type="button" onClick={() => void handleCreateSlots()} disabled={isBootstrapping || isRefreshingAgenda || isCreatingSlots || !selectedProfessionalId || !selectedDate}>
-              {isCreatingSlots ? 'Generando...' : 'Generar slots'}
-            </button>
-          </SectionCard>
-        </aside>
-      </div>
+        </div>
+      ) : null}
     </PageContainer>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -894,79 +894,8 @@ button {
   --schedule-ghost-border: rgba(87, 0, 0, 0.12);
 }
 
-.schedule-overview {
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
-  gap: 24px;
-  align-items: start;
-}
-
-.schedule-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.95fr);
-  gap: 24px;
-  padding: 32px;
-  border-color: var(--schedule-ghost-border);
-  background:
-    radial-gradient(circle at top right, rgba(254, 214, 91, 0.14), transparent 34%),
-    linear-gradient(180deg, rgba(255, 251, 247, 0.98) 0%, rgba(247, 239, 235, 0.96) 100%);
-  box-shadow: 0 18px 38px rgba(43, 23, 24, 0.06);
-}
-
-.schedule-hero-copy {
-  align-content: start;
-}
-
-.schedule-hero-copy p {
-  max-width: 60ch;
-  color: var(--schedule-soft-text);
-}
-
-.schedule-hero-badges {
-  margin-top: 2px;
-}
-
-.schedule-hero-panel {
-  display: grid;
-  gap: 16px;
-  align-content: start;
-  padding: 22px;
-  border-radius: 24px;
-  border: 1px solid rgba(87, 0, 0, 0.08);
-  background: rgba(255, 252, 250, 0.82);
-  backdrop-filter: blur(18px);
-}
-
-.schedule-hero-panel-head {
-  display: grid;
-  gap: 4px;
-}
-
-.schedule-hero-panel-head strong {
-  font-size: 1.2rem;
-  color: var(--schedule-ink);
-}
-
-.schedule-stat-card {
-  display: grid;
-  gap: 4px;
-  padding: 14px;
-  border: 1px solid rgba(87, 0, 0, 0.06);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(250, 245, 241, 0.92) 100%);
-}
-
-.schedule-stat-card strong {
-  font-size: 1.02rem;
-  color: var(--schedule-ink);
-}
-
-.schedule-layout {
-  align-items: start;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
-}
-
-.schedule-controls-card,
-.schedule-booking-card,
+.schedule-context-bar,
+.schedule-board-shell,
 .schedule-slots-card,
 .schedule-appointments-card,
 .schedule-generator-card {
@@ -974,30 +903,85 @@ button {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(249, 244, 240, 0.96) 100%);
 }
 
-.schedule-controls-head,
-.schedule-controls-toolbar {
+.schedule-context-bar {
+  display: grid;
+  gap: 18px;
+  padding: 22px 24px;
+  border-color: var(--schedule-ghost-border);
+  box-shadow: 0 18px 38px rgba(43, 23, 24, 0.06);
+}
+
+.schedule-context-bar-main,
+.schedule-context-bar-actions,
+.schedule-board-header,
+.schedule-modal-head,
+.schedule-modal-actions {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
 }
 
-.schedule-controls-toolbar {
+.schedule-context-bar-main,
+.schedule-context-bar-actions,
+.schedule-board-toolbar,
+.schedule-modal-actions {
   flex-wrap: wrap;
 }
 
-.schedule-filters-grid,
-.schedule-primary-grid {
+.schedule-context-bar-week,
+.schedule-context-bar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.schedule-context-bar-controls {
+  max-width: 380px;
+}
+
+.schedule-context-bar-controls .field {
+  min-width: min(320px, 100%);
+  flex: 1 1 280px;
+}
+
+.schedule-board-shell {
+  gap: 22px;
+  padding: 26px;
+  min-width: 0;
+}
+
+.schedule-board-header {
+  align-items: flex-start;
+}
+
+.schedule-board-toolbar {
   display: grid;
-  gap: 18px;
+  gap: 12px;
+  justify-items: end;
 }
 
-.schedule-filters-grid {
-  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+.schedule-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(23, 32, 51, 0.44);
+  backdrop-filter: blur(6px);
+  z-index: 30;
 }
 
-.schedule-primary-grid {
-  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+.schedule-modal {
+  width: min(560px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  border-color: rgba(87, 0, 0, 0.12);
+}
+
+.schedule-modal-head {
+  align-items: center;
 }
 
 .patients-workspace-grid {


### PR DESCRIPTION
Closes #27

## Summary
- redesign the Agenda interior around the weekly board as the clear operational center instead of splitting attention across duplicated context and inline support regions
- consolidate context into one compact top bar and move high-intent actions (`Generate slots`, `Book appointment`) into modal/popup flows
- preserve current booking, cancellation, slot generation, UTC week behavior, and actor semantics while making the UI much calmer and more focused

## Changes
| File | Change |
|------|--------|
| `web/src/features/schedule/ScheduleDemo.tsx` | Rebuilds the Agenda interior into a board-first layout with compact context and modal entry points |
| `web/src/features/schedule/ScheduleDemo.test.tsx` | Adds/updates focused runtime coverage for compact context, modal triggers, guardrails, and preserved behavior |
| `web/src/styles.css` | Adjusts agenda-local layout and styling so the weekly board becomes the dominant visual surface |

## Test Plan
- [x] `npm test -- src/features/schedule/ScheduleDemo.test.tsx` in `web/`
- [x] `npm run typecheck` in `web/`
- [x] Verified no new scheduling capabilities, backend changes, or actor-permission changes were introduced in this pass

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Added docs/contract updates where behavior changed
- [x] Used conventional commits only
- [x] No `Co-Authored-By` trailers added