### PR TITLE
feat(web): add operational support flows and patient search

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -15,11 +15,33 @@ vi.mock('./features/auth/LoginScreen', () => ({
 }));
 
 vi.mock('./features/schedule/ScheduleDemo', () => ({
-  ScheduleDemo: ({ agendaMode }: { agendaMode: { kind: string } }) => <div>schedule:{agendaMode.kind}</div>,
+  ScheduleDemo: ({
+    agendaMode,
+    onOpenDirectorySupport,
+  }: {
+    agendaMode: { kind: string };
+    onOpenDirectorySupport?: () => void;
+  }) => (
+    <div>
+      <div>schedule:{agendaMode.kind}</div>
+      {onOpenDirectorySupport ? <button onClick={onOpenDirectorySupport}>schedule-open-directory</button> : null}
+    </div>
+  ),
 }));
 
 vi.mock('./features/patients/PatientsWorkspace', () => ({
-  PatientsWorkspace: ({ patientsMode }: { patientsMode: { kind: string } }) => <div>patients:{patientsMode.kind}</div>,
+  PatientsWorkspace: ({
+    patientsMode,
+    onOpenDirectorySupport,
+  }: {
+    patientsMode: { kind: string };
+    onOpenDirectorySupport?: () => void;
+  }) => (
+    <div>
+      <div>patients:{patientsMode.kind}</div>
+      {onOpenDirectorySupport ? <button onClick={onOpenDirectorySupport}>patients-open-directory</button> : null}
+    </div>
+  ),
 }));
 
 vi.mock('./features/directory/DirectoryDemo', () => ({
@@ -41,9 +63,9 @@ describe('App actor-aware shell', () => {
     expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
     const doctorNavButtons = screen.getAllByRole('button', { name: /Agenda|Pacientes/ });
     expect(doctorNavButtons).toHaveLength(2);
-    expect(doctorNavButtons[0]).toHaveTextContent('Operación clínica');
+    expect(doctorNavButtons[0]).toHaveTextContent('Práctica propia');
     expect(doctorNavButtons[0]).toHaveTextContent('Agenda');
-    expect(doctorNavButtons[1]).toHaveTextContent('Relación asistencial');
+    expect(doctorNavButtons[1]).toHaveTextContent('Seguimiento clínico');
     expect(doctorNavButtons[1]).toHaveTextContent('Pacientes');
     expect(screen.getByRole('button', { name: /Agenda/i })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByText('schedule:doctor-own')).toBeInTheDocument();
@@ -65,10 +87,13 @@ describe('App actor-aware shell', () => {
 
     const secretaryNavButtons = screen.getAllByRole('button', { name: /Agenda|Pacientes/ });
     expect(secretaryNavButtons).toHaveLength(2);
+    expect(secretaryNavButtons[0]).toHaveTextContent('Operación diaria');
+    expect(secretaryNavButtons[1]).toHaveTextContent('Atención operativa');
     expect(secretaryNavButtons[0]).toHaveTextContent('Agenda');
     expect(secretaryNavButtons[1]).toHaveTextContent('Pacientes');
     expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
     expect(screen.getByText('schedule:operational-shared')).toBeInTheDocument();
+    expect(screen.queryByText('directory:setup-secretary-support')).not.toBeInTheDocument();
   });
 
   it('keeps the unauthenticated login surface unchanged', () => {
@@ -115,10 +140,25 @@ describe('App actor-aware shell', () => {
 
     expect(screen.getByRole('navigation', { name: 'Áreas disponibles' })).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /Directorio/ })).toHaveLength(1);
-    expect(screen.getAllByRole('button', { name: /Directorio/ })[0]).toHaveTextContent('Base operativa');
+    expect(screen.getAllByRole('button', { name: /Directorio/ })[0]).toHaveTextContent('Puesta a punto');
     expect(screen.getAllByRole('button', { name: /Directorio/ })[0]).toHaveTextContent('Directorio');
     expect(screen.getByRole('heading', { name: 'Directorio' })).toBeInTheDocument();
-    expect(screen.getByText('directory:setup-shared')).toBeInTheDocument();
+    expect(screen.getByText('directory:setup-admin')).toBeInTheDocument();
+  });
+
+  it('lets secretary reach hidden directory support without adding sidebar symmetry', () => {
+    useAuthSessionMock.mockReturnValue(authSession({ role: 'secretary' }));
+
+    render(<App />);
+
+    expect(screen.getAllByRole('button', { name: /Agenda|Pacientes/ })).toHaveLength(2);
+    expect(screen.queryByText('directory:setup-secretary-support')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'schedule-open-directory' }));
+
+    expect(screen.getByText('directory:setup-secretary-support')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Agenda|Pacientes/ })).toHaveLength(2);
+    expect(screen.queryAllByRole('button', { name: /Directorio/ })).toHaveLength(0);
   });
 
   it('keeps authenticated shell navigation unchanged under the polished copy', () => {
@@ -176,7 +216,7 @@ describe('App actor-aware shell', () => {
 
     expect(screen.getAllByRole('button', { name: /Directorio/ })).toHaveLength(1);
     expect(screen.getByRole('button', { name: /Directorio/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('directory:setup-shared')).toBeInTheDocument();
+    expect(screen.getByText('directory:setup-admin')).toBeInTheDocument();
     expect(screen.queryByText('patients:doctor-clinical')).not.toBeInTheDocument();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ export default function App() {
     () => (auth.user ? deriveActorCapabilities(auth.user) : null),
     [auth.user],
   );
-  const availableSurfaces = useMemo(
+  const visibleSurfaces = useMemo(
     () =>
       capabilities
         ? capabilities.visibleSurfaces.map((surface) => ({
@@ -21,6 +21,10 @@ export default function App() {
             ...resolveShellSurfaceMetadata(surface, capabilities),
           }))
         : [],
+    [capabilities],
+  );
+  const reachableSurfaceIds = useMemo(
+    () => (capabilities ? [...new Set([...capabilities.visibleSurfaces, ...capabilities.supportSurfaces])] : []),
     [capabilities],
   );
   const [activeSurface, setActiveSurface] = useState<SurfaceId>('agenda');
@@ -31,13 +35,15 @@ export default function App() {
       return;
     }
 
-    if (!capabilities.visibleSurfaces.includes(activeSurface)) {
+    if (!reachableSurfaceIds.includes(activeSurface)) {
       setActiveSurface(capabilities.defaultSurface);
     }
-  }, [activeSurface, capabilities]);
+  }, [activeSurface, capabilities, reachableSurfaceIds]);
 
-  const normalizedActiveSurface = capabilities?.visibleSurfaces.includes(activeSurface) ? activeSurface : capabilities?.defaultSurface;
-  const activeSurfaceDefinition = availableSurfaces.find((surface) => surface.id === normalizedActiveSurface) ?? availableSurfaces[0];
+  const normalizedActiveSurface = reachableSurfaceIds.includes(activeSurface) ? activeSurface : capabilities?.defaultSurface;
+  const activeSurfaceDefinition = normalizedActiveSurface && capabilities
+    ? { id: normalizedActiveSurface, ...resolveShellSurfaceMetadata(normalizedActiveSurface, capabilities) }
+    : visibleSurfaces[0];
 
   if (auth.status === 'loading') {
     return (
@@ -57,13 +63,27 @@ export default function App() {
     return <LoginScreen errorMessage={auth.errorMessage} isSubmitting={auth.isSubmitting} onLogin={auth.login} />;
   }
 
+  const openSupportSurface = (surface: SurfaceId) => {
+    if (!reachableSurfaceIds.includes(surface)) {
+      return;
+    }
+
+    setActiveSurface(surface);
+  };
+
   const renderActiveSurface = () => {
     if (!capabilities) {
       return null;
     }
 
     if (normalizedActiveSurface === 'agenda') {
-      return <ScheduleDemo agendaMode={capabilities.agendaMode} onSessionInvalid={auth.logout} />;
+      return (
+        <ScheduleDemo
+          agendaMode={capabilities.agendaMode}
+          onSessionInvalid={auth.logout}
+          onOpenDirectorySupport={capabilities.supportSurfaces.includes('directory') ? () => openSupportSurface('directory') : undefined}
+        />
+      );
     }
 
     if (normalizedActiveSurface === 'directory') {
@@ -71,7 +91,13 @@ export default function App() {
     }
 
     if (normalizedActiveSurface === 'patients') {
-      return <PatientsWorkspace patientsMode={capabilities.patientsMode} onSessionInvalid={auth.logout} />;
+      return (
+        <PatientsWorkspace
+          patientsMode={capabilities.patientsMode}
+          onSessionInvalid={auth.logout}
+          onOpenDirectorySupport={capabilities.supportSurfaces.includes('directory') ? () => openSupportSurface('directory') : undefined}
+        />
+      );
     }
 
     return null;
@@ -106,7 +132,7 @@ export default function App() {
         ariaLabel: `Contenido de ${activeSurfaceDefinition?.intro.title ?? 'Agenda'}`,
         children: renderActiveSurface(),
       }}
-      navItems={availableSurfaces.map((surface) => surface.navItem)}
+      navItems={visibleSurfaces.map((surface) => surface.navItem)}
       onLogout={auth.logout}
       onSelectSurface={setActiveSurface}
     />

--- a/web/src/app-shell/AppShell.primitives.tsx
+++ b/web/src/app-shell/AppShell.primitives.tsx
@@ -39,7 +39,7 @@ export function EmptyState({ eyebrow, title, description, className }: EmptyStat
   return (
     <section className={joinClasses('foundation-empty-state empty-state', className)}>
       {eyebrow ? <span className="hero-kicker">{eyebrow}</span> : null}
-      <strong>{title}</strong>
+      <h2>{title}</h2>
       {description ? <span>{description}</span> : null}
     </section>
   );

--- a/web/src/auth/actorCapabilities.test.ts
+++ b/web/src/auth/actorCapabilities.test.ts
@@ -8,6 +8,7 @@ describe('deriveActorCapabilities', () => {
     const patientsShell = resolveShellSurfaceMetadata('patients', capabilities);
 
     expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
+    expect(capabilities.supportSurfaces).toEqual([]);
     expect(capabilities.defaultSurface).toBe('agenda');
     expect(capabilities.agendaMode).toEqual({ kind: 'doctor-own', professionalId: 'professional-1' });
     expect(capabilities.patientsMode).toEqual({ kind: 'doctor-clinical', professionalId: 'professional-1' });
@@ -15,13 +16,13 @@ describe('deriveActorCapabilities', () => {
     expect(agendaShell.navItem).toEqual({
       id: 'agenda',
       label: 'Agenda',
-      eyebrow: 'Operación clínica',
-      description: 'Turnos del día.',
+      eyebrow: 'Práctica propia',
+      description: 'Turnos de tu consultorio.',
     });
     expect(patientsShell.intro).toEqual({
-      eyebrow: 'Relación asistencial',
+      eyebrow: 'Seguimiento clínico',
       title: 'Pacientes',
-      description: 'Seguimiento clínico del panel activo.',
+      description: 'Resumen y encounters del panel clínico asociado a tu práctica.',
     });
   });
 
@@ -46,21 +47,22 @@ describe('deriveActorCapabilities', () => {
     const directoryShell = resolveShellSurfaceMetadata('directory', capabilities);
 
     expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
+    expect(capabilities.supportSurfaces).toEqual(['directory']);
     expect(capabilities.defaultSurface).toBe('agenda');
     expect(capabilities.agendaMode).toEqual({ kind: 'operational-shared' });
     expect(capabilities.patientsMode).toEqual({ kind: 'secretary-operational' });
-    expect(capabilities.directoryMode).toEqual({ kind: 'setup-shared' });
+    expect(capabilities.directoryMode).toEqual({ kind: 'setup-secretary-support' });
     expect(agendaShell.navItem.label).toBe('Agenda');
     expect(patientsShell.intro).toEqual({
-      eyebrow: 'Relación asistencial',
+      eyebrow: 'Atención operativa',
       title: 'Pacientes',
-      description: 'Seguimiento clínico del panel activo.',
+      description: 'Selección y verificación de datos sin exponer trabajo clínico.',
     });
     expect(directoryShell.navItem).toEqual({
       id: 'directory',
       label: 'Directorio',
-      eyebrow: 'Base operativa',
-      description: 'Base operativa.',
+      eyebrow: 'Soporte operativo',
+      description: 'Pacientes y consulta de profesionales.',
     });
   });
 
@@ -69,11 +71,16 @@ describe('deriveActorCapabilities', () => {
     const directoryShell = resolveShellSurfaceMetadata('directory', capabilities);
 
     expect(capabilities.visibleSurfaces).toEqual(['directory']);
+    expect(capabilities.supportSurfaces).toEqual([]);
     expect(capabilities.defaultSurface).toBe('directory');
-    expect(capabilities.directoryMode).toEqual({ kind: 'setup-shared' });
+    expect(capabilities.directoryMode).toEqual({ kind: 'setup-admin' });
     expect(capabilities.agendaMode.kind).toBe('forbidden');
     expect(capabilities.patientsMode.kind).toBe('forbidden');
-    expect(directoryShell.intro.title).toBe('Directorio');
+    expect(directoryShell.intro).toEqual({
+      eyebrow: 'Puesta a punto',
+      title: 'Directorio',
+      description: 'Base de preparación para dejar agenda y pacientes listos antes de operar.',
+    });
   });
 
   it('falls back to a blocked agenda-only shell for unknown roles', () => {

--- a/web/src/auth/actorCapabilities.ts
+++ b/web/src/auth/actorCapabilities.ts
@@ -12,7 +12,10 @@ export type PatientsMode =
   | { kind: 'secretary-operational' }
   | { kind: 'forbidden'; message: string };
 
-export type DirectoryMode = { kind: 'setup-shared' } | { kind: 'forbidden'; message: string };
+export type DirectoryMode =
+  | { kind: 'setup-admin' }
+  | { kind: 'setup-secretary-support' }
+  | { kind: 'forbidden'; message: string };
 
 export type ShellNavItem = {
   id: SurfaceId;
@@ -34,6 +37,7 @@ export type ShellSurfaceMetadata = {
 
 export type ActorCapabilities = {
   visibleSurfaces: SurfaceId[];
+  supportSurfaces: SurfaceId[];
   defaultSurface: SurfaceId;
   agendaMode: AgendaMode;
   patientsMode: PatientsMode;
@@ -43,48 +47,6 @@ export type ActorCapabilities = {
 const DOCTOR_ASSOCIATION_MESSAGE = 'Tu usuario doctor no tiene professional_id asociado.';
 const ROLE_ACCESS_MESSAGE = 'Tu rol no tiene acceso a esta superficie.';
 
-const SHELL_SURFACE_COPY: Record<SurfaceId, ShellSurfaceMetadata> = {
-  agenda: {
-    navItem: {
-      id: 'agenda',
-      label: 'Agenda',
-      eyebrow: 'Operación clínica',
-      description: 'Turnos del día.',
-    },
-    intro: {
-      eyebrow: 'Operación clínica',
-      title: 'Agenda',
-      description: 'Turnos y disponibilidad en una sola vista.',
-    },
-  },
-  patients: {
-    navItem: {
-      id: 'patients',
-      label: 'Pacientes',
-      eyebrow: 'Relación asistencial',
-      description: 'Seguimiento activo.',
-    },
-    intro: {
-      eyebrow: 'Relación asistencial',
-      title: 'Pacientes',
-      description: 'Seguimiento clínico del panel activo.',
-    },
-  },
-  directory: {
-    navItem: {
-      id: 'directory',
-      label: 'Directorio',
-      eyebrow: 'Base operativa',
-      description: 'Base operativa.',
-    },
-    intro: {
-      eyebrow: 'Base operativa',
-      title: 'Directorio',
-      description: 'Personas y equipos disponibles.',
-    },
-  },
-};
-
 export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
   const professionalId = user.professional_id?.trim() ?? '';
 
@@ -92,6 +54,7 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
     if (!professionalId) {
       return {
         visibleSurfaces: ['agenda', 'patients'],
+        supportSurfaces: [],
         defaultSurface: 'agenda',
         agendaMode: { kind: 'forbidden', message: DOCTOR_ASSOCIATION_MESSAGE },
         patientsMode: { kind: 'forbidden', message: DOCTOR_ASSOCIATION_MESSAGE },
@@ -101,6 +64,7 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
 
     return {
       visibleSurfaces: ['agenda', 'patients'],
+      supportSurfaces: [],
       defaultSurface: 'agenda',
       agendaMode: { kind: 'doctor-own', professionalId },
       patientsMode: { kind: 'doctor-clinical', professionalId },
@@ -111,25 +75,28 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
   if (user.role === 'secretary') {
     return {
       visibleSurfaces: ['agenda', 'patients'],
+      supportSurfaces: ['directory'],
       defaultSurface: 'agenda',
       agendaMode: { kind: 'operational-shared' },
       patientsMode: { kind: 'secretary-operational' },
-      directoryMode: { kind: 'setup-shared' },
+      directoryMode: { kind: 'setup-secretary-support' },
     };
   }
 
   if (user.role === 'admin') {
     return {
       visibleSurfaces: ['directory'],
+      supportSurfaces: [],
       defaultSurface: 'directory',
       agendaMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
       patientsMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
-      directoryMode: { kind: 'setup-shared' },
+      directoryMode: { kind: 'setup-admin' },
     };
   }
 
   return {
     visibleSurfaces: ['agenda'],
+    supportSurfaces: [],
     defaultSurface: 'agenda',
     agendaMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
     patientsMode: { kind: 'forbidden', message: ROLE_ACCESS_MESSAGE },
@@ -139,7 +106,147 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
 
 export function resolveShellSurfaceMetadata(
   surfaceId: SurfaceId,
-  _capabilities: ActorCapabilities,
+  capabilities: ActorCapabilities,
 ): ShellSurfaceMetadata {
-  return SHELL_SURFACE_COPY[surfaceId];
+  if (surfaceId === 'agenda') {
+    if (capabilities.agendaMode.kind === 'doctor-own') {
+      return {
+        navItem: {
+          id: 'agenda',
+          label: 'Agenda',
+          eyebrow: 'Práctica propia',
+          description: 'Turnos de tu consultorio.',
+        },
+        intro: {
+          eyebrow: 'Práctica propia',
+          title: 'Agenda',
+          description: 'Turnos y disponibilidad vinculados a tu professional_id.',
+        },
+      };
+    }
+
+    if (capabilities.agendaMode.kind === 'operational-shared') {
+      return {
+        navItem: {
+          id: 'agenda',
+          label: 'Agenda',
+          eyebrow: 'Operación diaria',
+          description: 'Turnos y coordinación.',
+        },
+        intro: {
+          eyebrow: 'Operación diaria',
+          title: 'Agenda',
+          description: 'Coordinación de turnos con foco operativo y sin trabajo clínico.',
+        },
+      };
+    }
+
+    return {
+      navItem: {
+        id: 'agenda',
+        label: 'Agenda',
+        eyebrow: 'Acceso restringido',
+        description: 'Superficie bloqueada.',
+      },
+      intro: {
+        eyebrow: 'Acceso restringido',
+        title: 'Agenda',
+        description: 'Esta superficie queda visible solo para comunicar el bloqueo actual.',
+      },
+    };
+  }
+
+  if (surfaceId === 'patients') {
+    if (capabilities.patientsMode.kind === 'doctor-clinical') {
+      return {
+        navItem: {
+          id: 'patients',
+          label: 'Pacientes',
+          eyebrow: 'Seguimiento clínico',
+          description: 'Panel de tus pacientes.',
+        },
+        intro: {
+          eyebrow: 'Seguimiento clínico',
+          title: 'Pacientes',
+          description: 'Resumen y encounters del panel clínico asociado a tu práctica.',
+        },
+      };
+    }
+
+    if (capabilities.patientsMode.kind === 'secretary-operational') {
+      return {
+        navItem: {
+          id: 'patients',
+          label: 'Pacientes',
+          eyebrow: 'Atención operativa',
+          description: 'Búsqueda y resumen.',
+        },
+        intro: {
+          eyebrow: 'Atención operativa',
+          title: 'Pacientes',
+          description: 'Selección y verificación de datos sin exponer trabajo clínico.',
+        },
+      };
+    }
+
+    return {
+      navItem: {
+        id: 'patients',
+        label: 'Pacientes',
+        eyebrow: 'Acceso restringido',
+        description: 'Superficie bloqueada.',
+      },
+      intro: {
+        eyebrow: 'Acceso restringido',
+        title: 'Pacientes',
+        description: 'Esta superficie queda visible solo para comunicar el bloqueo actual.',
+      },
+    };
+  }
+
+  if (capabilities.directoryMode.kind === 'setup-admin') {
+    return {
+      navItem: {
+        id: 'directory',
+        label: 'Directorio',
+        eyebrow: 'Puesta a punto',
+        description: 'Pacientes y profesionales.',
+      },
+      intro: {
+        eyebrow: 'Puesta a punto',
+        title: 'Directorio',
+        description: 'Base de preparación para dejar agenda y pacientes listos antes de operar.',
+      },
+    };
+  }
+
+  if (capabilities.directoryMode.kind === 'setup-secretary-support') {
+    return {
+      navItem: {
+        id: 'directory',
+        label: 'Directorio',
+        eyebrow: 'Soporte operativo',
+        description: 'Pacientes y consulta de profesionales.',
+      },
+      intro: {
+        eyebrow: 'Soporte operativo',
+        title: 'Directorio',
+        description: 'Soporte puntual para destrabar agenda y pacientes sin abrir configuración completa.',
+      },
+    };
+  }
+
+  return {
+    navItem: {
+      id: 'directory',
+      label: 'Directorio',
+      eyebrow: 'Acceso restringido',
+      description: 'Superficie bloqueada.',
+    },
+    intro: {
+      eyebrow: 'Acceso restringido',
+      title: 'Directorio',
+      description: 'Esta superficie no forma parte del alcance disponible para tu rol.',
+    },
+  };
 }

--- a/web/src/features/directory/DirectoryDemo.test.tsx
+++ b/web/src/features/directory/DirectoryDemo.test.tsx
@@ -25,15 +25,32 @@ describe('DirectoryDemo', () => {
     createProfessionalMock.mockReset();
   });
 
-  it('renders setup data for allowed actors', async () => {
+  it('renders admin setup data with patient and professional creation', async () => {
     listPatientsMock.mockResolvedValue({ items: [activePatient()] });
     listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
 
-    render(<DirectoryDemo directoryMode={{ kind: 'setup-shared' }} onSessionInvalid={vi.fn()} />);
+    render(<DirectoryDemo directoryMode={{ kind: 'setup-admin' }} onSessionInvalid={vi.fn()} />);
 
-    expect(await screen.findByText(/superficie de configuración liviana/i)).toBeInTheDocument();
+    expect(await screen.findByText(/superficie de puesta a punto/i)).toBeInTheDocument();
     expect(screen.getByText('Juan Pérez')).toBeInTheDocument();
     expect(screen.getByText('Ana Médica')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /crear paciente/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /crear profesional/i })).toBeInTheDocument();
+  });
+
+  it('keeps secretary support narrowed to patient creation plus professional listing', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+
+    render(<DirectoryDemo directoryMode={{ kind: 'setup-secretary-support' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByText(/superficie de soporte operativo/i)).toBeInTheDocument();
+    expect(screen.getByText('Juan Pérez')).toBeInTheDocument();
+    expect(screen.getByText('Ana Médica')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /crear paciente/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /crear profesional/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Nombre', { selector: '#professional-first-name' })).not.toBeInTheDocument();
+    expect(screen.getByText(/la creación queda reservada a administración/i)).toBeInTheDocument();
   });
 
   it('invalidates the session on 401 directory bootstrap failures', async () => {
@@ -41,7 +58,7 @@ describe('DirectoryDemo', () => {
     listProfessionalsMock.mockResolvedValue({ items: [] });
     const onSessionInvalid = vi.fn();
 
-    render(<DirectoryDemo directoryMode={{ kind: 'setup-shared' }} onSessionInvalid={onSessionInvalid} />);
+    render(<DirectoryDemo directoryMode={{ kind: 'setup-admin' }} onSessionInvalid={onSessionInvalid} />);
 
     await waitFor(() => {
       expect(onSessionInvalid).toHaveBeenCalledTimes(1);
@@ -53,7 +70,7 @@ describe('DirectoryDemo', () => {
     listProfessionalsMock.mockResolvedValue({ items: [] });
     const onSessionInvalid = vi.fn();
 
-    render(<DirectoryDemo directoryMode={{ kind: 'setup-shared' }} onSessionInvalid={onSessionInvalid} />);
+    render(<DirectoryDemo directoryMode={{ kind: 'setup-secretary-support' }} onSessionInvalid={onSessionInvalid} />);
 
     expect(await screen.findByText('Acceso denegado: No podés abrir el directorio.')).toBeInTheDocument();
     expect(onSessionInvalid).not.toHaveBeenCalled();

--- a/web/src/features/directory/DirectoryDemo.tsx
+++ b/web/src/features/directory/DirectoryDemo.tsx
@@ -36,6 +36,8 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
   const [errorMessage, setErrorMessage] = useState('');
   const [accessDeniedMessage, setAccessDeniedMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const isAdminSetup = directoryMode.kind === 'setup-admin';
+  const isSecretarySupport = directoryMode.kind === 'setup-secretary-support';
 
   const handleApiFailure = useCallback(
     (error: unknown, fallbackMessage: string, forbiddenFallbackMessage: string) => {
@@ -142,12 +144,16 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
         <div className="status-bar">
           <span className="badge neutral">Pacientes: {patients.length}</span>
           <span className="badge neutral">Profesionales: {professionals.length}</span>
-          <span className="badge info">Superficie de configuración liviana</span>
+          <span className="badge info">{isAdminSetup ? 'Superficie de puesta a punto' : 'Superficie de soporte operativo'}</span>
           {successMessage ? <span className="badge success">{successMessage}</span> : null}
           {errorMessage ? <span className="badge error">{errorMessage}</span> : null}
           {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
         </div>
-        <div className="inline-note">Alta rápida y listados claros para poblar la demo sin mezclar esta superficie con la operación diaria.</div>
+        <div className="inline-note">
+          {isAdminSetup
+            ? 'Alta rápida y listados claros para dejar la base operativa lista antes de usar la demo.'
+            : 'Soporte puntual para cargar pacientes y consultar profesionales sin abrir configuración completa.'}
+        </div>
       </SectionCard>
 
       <div className="directory-grid">
@@ -155,7 +161,11 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
           <div className="section-header">
             <div>
               <h3>Pacientes</h3>
-              <p>Formulario corto para cargar personas reales del demo y verlas enseguida en la lista.</p>
+              <p>
+                {isAdminSetup
+                  ? 'Formulario corto para dejar pacientes listos antes de la operación.'
+                  : 'Alta rápida para destrabar agenda y selección de pacientes cuando falta base operativa.'}
+              </p>
             </div>
             <span className="badge neutral">{patients.length} total</span>
           </div>
@@ -222,7 +232,9 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
             <button className="button" type="button" onClick={() => void handleCreatePatient()} disabled={isBootstrapping || isCreatingPatient}>
               {isCreatingPatient ? 'Guardando...' : 'Crear paciente'}
             </button>
-            <span className="helper helper-inline">Ideal para poblar rápido la agenda demo.</span>
+            <span className="helper helper-inline">
+              {isAdminSetup ? 'Ideal para poblar rápido agenda y pacientes.' : 'Disponible como ayuda operativa cuando falta un paciente.'}
+            </span>
           </div>
 
           {isBootstrapping ? (
@@ -257,51 +269,61 @@ export function DirectoryDemo({ directoryMode, onSessionInvalid }: DirectoryDemo
           <div className="section-header">
             <div>
               <h3>Profesionales</h3>
-              <p>Bloque liviano para cargar especialidades y dejar lista la agenda con datos de verdad.</p>
+              <p>
+                {isAdminSetup
+                  ? 'Bloque liviano para cargar especialidades y dejar lista la agenda con datos de verdad.'
+                  : 'Listado de referencia para operaciones compartidas. La creación queda reservada a administración.'}
+              </p>
             </div>
             <span className="badge neutral">{professionals.length} total</span>
           </div>
 
-          <div className="form-grid">
-            <div className="field">
-              <label htmlFor="professional-first-name">Nombre</label>
-              <input
-                id="professional-first-name"
-                value={professionalForm.first_name}
-                onChange={(event) => setProfessionalForm((current) => ({ ...current, first_name: event.target.value }))}
-              />
-            </div>
+          {isAdminSetup ? (
+            <>
+              <div className="form-grid">
+                <div className="field">
+                  <label htmlFor="professional-first-name">Nombre</label>
+                  <input
+                    id="professional-first-name"
+                    value={professionalForm.first_name}
+                    onChange={(event) => setProfessionalForm((current) => ({ ...current, first_name: event.target.value }))}
+                  />
+                </div>
 
-            <div className="field">
-              <label htmlFor="professional-last-name">Apellido</label>
-              <input
-                id="professional-last-name"
-                value={professionalForm.last_name}
-                onChange={(event) => setProfessionalForm((current) => ({ ...current, last_name: event.target.value }))}
-              />
-            </div>
+                <div className="field">
+                  <label htmlFor="professional-last-name">Apellido</label>
+                  <input
+                    id="professional-last-name"
+                    value={professionalForm.last_name}
+                    onChange={(event) => setProfessionalForm((current) => ({ ...current, last_name: event.target.value }))}
+                  />
+                </div>
 
-            <div className="field form-grid-span-full">
-              <label htmlFor="professional-specialty">Especialidad</label>
-              <input
-                id="professional-specialty"
-                value={professionalForm.specialty}
-                onChange={(event) => setProfessionalForm((current) => ({ ...current, specialty: event.target.value }))}
-              />
-            </div>
-          </div>
+                <div className="field form-grid-span-full">
+                  <label htmlFor="professional-specialty">Especialidad</label>
+                  <input
+                    id="professional-specialty"
+                    value={professionalForm.specialty}
+                    onChange={(event) => setProfessionalForm((current) => ({ ...current, specialty: event.target.value }))}
+                  />
+                </div>
+              </div>
 
-          <div className="toolbar">
-            <button
-              className="button"
-              type="button"
-              onClick={() => void handleCreateProfessional()}
-              disabled={isBootstrapping || isCreatingProfessional}
-            >
-              {isCreatingProfessional ? 'Guardando...' : 'Crear profesional'}
-            </button>
-            <span className="helper helper-inline">Después lo vas a poder elegir en Agenda.</span>
-          </div>
+              <div className="toolbar">
+                <button
+                  className="button"
+                  type="button"
+                  onClick={() => void handleCreateProfessional()}
+                  disabled={isBootstrapping || isCreatingProfessional}
+                >
+                  {isCreatingProfessional ? 'Guardando...' : 'Crear profesional'}
+                </button>
+                <span className="helper helper-inline">Después lo vas a poder elegir en Agenda.</span>
+              </div>
+            </>
+          ) : (
+            <div className="inline-note">Podés consultar profesionales ya cargados, pero el alta de profesionales sigue siendo una tarea de administración.</div>
+          )}
 
           {isBootstrapping ? (
             <div className="empty-state empty-state-soft">Cargando profesionales...</div>

--- a/web/src/features/patient-search/matching.test.ts
+++ b/web/src/features/patient-search/matching.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildPatientSearchIndex, filterPatients, normalizePatientSearchValue } from './matching';
+
+describe('patient search matching', () => {
+  it('normalizes accents and collapses whitespace', () => {
+    expect(normalizePatientSearchValue('  María   Pérez  ')).toBe('maria perez');
+  });
+
+  it('indexes full-name permutations and documents', () => {
+    const patient = makePatient({ first_name: 'Ana María', last_name: 'Gómez', document: '20-12345678-9' });
+
+    const index = buildPatientSearchIndex(patient);
+
+    expect(index).toContain('ana maria');
+    expect(index).toContain('gomez');
+    expect(index).toContain('ana maria gomez');
+    expect(index).toContain('gomez ana maria');
+    expect(index).toContain('20-12345678-9');
+  });
+
+  it('matches by name permutation and document substring', () => {
+    const patients = [
+      makePatient({ id: 'patient-1', first_name: 'Ana María', last_name: 'Gómez', document: '20123456' }),
+      makePatient({ id: 'patient-2', first_name: 'Juan', last_name: 'Pérez', document: '30999888' }),
+    ];
+
+    expect(filterPatients(patients, 'maria gomez').map((patient) => patient.id)).toEqual(['patient-1']);
+    expect(filterPatients(patients, 'gomez ana').map((patient) => patient.id)).toEqual(['patient-1']);
+    expect(filterPatients(patients, '9998').map((patient) => patient.id)).toEqual(['patient-2']);
+  });
+
+  it('returns all patients when query is empty', () => {
+    const patients = [makePatient({ id: 'patient-1' }), makePatient({ id: 'patient-2' })];
+
+    expect(filterPatients(patients, '')).toEqual(patients);
+    expect(filterPatients(patients, '   ')).toEqual(patients);
+  });
+});
+
+function makePatient(overrides: Partial<{ id: string; first_name: string; last_name: string; document: string }> = {}) {
+  return {
+    id: overrides.id ?? 'patient-1',
+    first_name: overrides.first_name ?? 'Juan',
+    last_name: overrides.last_name ?? 'Pérez',
+    document: overrides.document ?? '12345678',
+  };
+}

--- a/web/src/features/patient-search/matching.ts
+++ b/web/src/features/patient-search/matching.ts
@@ -1,0 +1,35 @@
+import type { Patient } from '../../types/directory';
+
+type SearchablePatient = Pick<Patient, 'first_name' | 'last_name' | 'document'>;
+
+export function normalizePatientSearchValue(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+export function buildPatientSearchIndex(patient: SearchablePatient) {
+  return [
+    patient.first_name,
+    patient.last_name,
+    `${patient.first_name} ${patient.last_name}`,
+    `${patient.last_name} ${patient.first_name}`,
+    patient.document,
+  ]
+    .map(normalizePatientSearchValue)
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function filterPatients<T extends SearchablePatient>(patients: T[], query: string) {
+  const normalizedQuery = normalizePatientSearchValue(query);
+
+  if (!normalizedQuery) {
+    return patients;
+  }
+
+  return patients.filter((patient) => buildPatientSearchIndex(patient).includes(normalizedQuery));
+}

--- a/web/src/features/patients/PatientsWorkspace.test.tsx
+++ b/web/src/features/patients/PatientsWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../../api/http';
 import { PatientsWorkspace } from './PatientsWorkspace';
@@ -43,8 +43,28 @@ describe('PatientsWorkspace', () => {
 
     expect(await screen.findByText(/modo operativo sin clinical encounters/i)).toBeInTheDocument();
     expect(screen.getByText(/encounters clínicos bloqueados/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /guardar nota/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /guardar nota/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/trabajo clínico oculto para secretaría/i)).toBeInTheDocument();
     expect(listPatientEncountersMock).not.toHaveBeenCalled();
+  });
+
+  it('offers directory support to secretary when no active patients exist', async () => {
+    listPatientsMock.mockResolvedValue({ items: [] });
+    const onOpenDirectorySupport = vi.fn();
+
+    render(
+      <PatientsWorkspace
+        patientsMode={{ kind: 'secretary-operational' }}
+        onSessionInvalid={vi.fn()}
+        onOpenDirectorySupport={onOpenDirectorySupport}
+      />,
+    );
+
+    expect(await screen.findByText(/no hay pacientes activos/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir soporte de directorio/i }));
+
+    expect(onOpenDirectorySupport).toHaveBeenCalledTimes(1);
   });
 
   it('keeps malformed doctor sessions active while showing the forbidden patients state', () => {
@@ -86,6 +106,103 @@ describe('PatientsWorkspace', () => {
     expect(await screen.findByText('No podés ver encounters.')).toBeInTheDocument();
     expect(onSessionInvalid).not.toHaveBeenCalled();
   });
+
+  it('filters the sidebar while retaining the selected patient outside visible results and restores the list when cleared', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'secretary-operational' }} onSessionInvalid={vi.fn()} />);
+
+    const searchInput = await screen.findByLabelText('Buscar paciente');
+
+    fireEvent.focus(searchInput);
+
+    expect(await screen.findByRole('option', { name: /Juan Pérez/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /María Gómez/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('option', { name: /María Gómez/i }));
+
+    expect(screen.getAllByText('María Gómez').length).toBeGreaterThan(0);
+
+    fireEvent.focus(searchInput);
+
+    fireEvent.change(searchInput, { target: { value: 'juan' } });
+
+    expect(screen.getByRole('option', { name: /Juan Pérez/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /María Gómez/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/Tenés seleccionado a María Gómez; el filtro actual lo ocultó de la lista./i)).toBeInTheDocument();
+    expect(screen.getAllByText('María Gómez').length).toBeGreaterThan(0);
+
+    fireEvent.change(searchInput, { target: { value: 'zzzz' } });
+
+    expect(screen.getByText(/No hay pacientes que coincidan con “zzzz”./i)).toBeInTheDocument();
+    expect(screen.getByText(/Limpiá el buscador para ver la lista completa./i)).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    expect(screen.getByRole('option', { name: /Juan Pérez/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /María Gómez/i })).toBeInTheDocument();
+  });
+
+  it('renders the patient options inside the top search control instead of a separate results panel', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'secretary-operational' }} onSessionInvalid={vi.fn()} />);
+
+    const searchControl = await screen.findByRole('group', { name: /buscador de pacientes/i });
+    const searchInput = within(searchControl).getByRole('searchbox', { name: /buscar paciente/i });
+
+    expect(within(searchControl).queryByRole('listbox', { name: /resultados de búsqueda de pacientes/i })).not.toBeInTheDocument();
+
+    fireEvent.focus(searchInput);
+
+    const resultsList = await within(searchControl).findByRole('listbox', { name: /resultados de búsqueda de pacientes/i });
+
+    expect(searchInput).toBeInTheDocument();
+    expect(resultsList).toBeInTheDocument();
+    expect(searchInput).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryByText(/lista corta para entrar rápido a una atención/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/este cuerpo mantiene foco operativo/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /resultados/i })).not.toBeInTheDocument();
+    expect(within(searchControl).getByText(/pacientes activos disponibles: 2/i)).toBeInTheDocument();
+    expect(within(resultsList).getByRole('option', { name: /Juan Pérez/i })).toBeInTheDocument();
+    expect(within(resultsList).getByRole('option', { name: /María Gómez/i })).toBeInTheDocument();
+
+    fireEvent.click(within(resultsList).getByRole('option', { name: /María Gómez/i }));
+
+    expect(screen.getAllByText('María Gómez').length).toBeGreaterThan(0);
+    expect(within(searchControl).queryByRole('listbox', { name: /resultados de búsqueda de pacientes/i })).not.toBeInTheDocument();
+    expect(searchInput).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('falls back to another active patient when the selected one disappears after refresh', async () => {
+    listPatientsMock.mockResolvedValueOnce({ items: [activePatient(), secondPatient()] }).mockResolvedValueOnce({
+      items: [activePatient(), inactiveSecondPatient()],
+    });
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'secretary-operational' }} onSessionInvalid={vi.fn()} />);
+
+    const searchInput = await screen.findByLabelText('Buscar paciente');
+
+    fireEvent.focus(searchInput);
+    fireEvent.click(await screen.findByRole('option', { name: /María Gómez/i }));
+
+    expect(screen.getByText(/^Paciente$/i)).toBeInTheDocument();
+    expect(screen.getByText('María Gómez')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('María Gómez')).not.toBeInTheDocument();
+    expect(screen.getByText(/Pacientes activos: 1/i)).toBeInTheDocument();
+
+    fireEvent.focus(searchInput);
+
+    expect(await screen.findByRole('option', { name: /Juan Pérez/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /María Gómez/i })).not.toBeInTheDocument();
+  });
 });
 
 function activePatient() {
@@ -100,6 +217,28 @@ function activePatient() {
     active: true,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function secondPatient() {
+  return {
+    id: 'patient-2',
+    first_name: 'María',
+    last_name: 'Gómez',
+    document: '20999111',
+    birth_date: '1991-02-02',
+    phone: '555-9876',
+    email: 'maria@example.com',
+    active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function inactiveSecondPatient() {
+  return {
+    ...secondPatient(),
+    active: false,
   };
 }
 

--- a/web/src/features/patients/PatientsWorkspace.tsx
+++ b/web/src/features/patients/PatientsWorkspace.tsx
@@ -1,14 +1,16 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type FocusEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import { type PatientsMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
 import { createPatientEncounter, listPatientEncounters } from '../../api/clinical';
 import { listPatients } from '../../api/directory';
 import type { CreateEncounterPayload, Encounter, Patient } from '../../types/clinical';
+import { filterPatients, normalizePatientSearchValue } from '../patient-search/matching';
 
 type PatientsWorkspaceProps = {
   patientsMode: PatientsMode;
   onSessionInvalid: () => void;
+  onOpenDirectorySupport?: () => void;
 };
 
 type EncounterFormState = {
@@ -21,10 +23,11 @@ const EMPTY_ENCOUNTER_FORM: EncounterFormState = {
   occurred_at: '',
 };
 
-export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWorkspaceProps) {
+export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirectorySupport }: PatientsWorkspaceProps) {
   const [patients, setPatients] = useState<Patient[]>([]);
   const [selectedPatientId, setSelectedPatientId] = useState('');
   const [encounters, setEncounters] = useState<Encounter[]>([]);
+  const [sidebarQuery, setSidebarQuery] = useState('');
   const [form, setForm] = useState<EncounterFormState>(EMPTY_ENCOUNTER_FORM);
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [isLoadingEncounters, setIsLoadingEncounters] = useState(false);
@@ -33,10 +36,24 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
   const [encountersError, setEncountersError] = useState('');
   const [formError, setFormError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const searchControlRef = useRef<HTMLDivElement | null>(null);
 
   const activePatients = useMemo(() => patients.filter((patient) => patient.active), [patients]);
+  const filteredPatients = useMemo(() => filterPatients(activePatients, sidebarQuery), [activePatients, sidebarQuery]);
   const selectedPatient = activePatients.find((patient) => patient.id === selectedPatientId) ?? null;
+  const isSelectedPatientHiddenByFilter = useMemo(
+    () => Boolean(selectedPatient && normalizePatientSearchValue(sidebarQuery) && !filteredPatients.some((patient) => patient.id === selectedPatient.id)),
+    [filteredPatients, selectedPatient, sidebarQuery],
+  );
+  const hasActiveSearchQuery = Boolean(normalizePatientSearchValue(sidebarQuery));
+  const shouldShowSearchDropdown =
+    !isBootstrapping &&
+    activePatients.length > 0 &&
+    isSearchOpen &&
+    (hasActiveSearchQuery || filteredPatients.length > 0 || isSelectedPatientHiddenByFilter);
   const canAccessClinical = patientsMode.kind === 'doctor-clinical';
+  const isSecretaryOperational = patientsMode.kind === 'secretary-operational';
   const clinicalDeniedMessage =
     patientsMode.kind === 'secretary-operational'
       ? 'Este perfil secretaría puede buscar y seleccionar pacientes, pero no ver ni registrar encounters clínicos.'
@@ -126,6 +143,12 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
   }, [bootstrap]);
 
   useEffect(() => {
+    if (isBootstrapping || activePatients.length === 0) {
+      setIsSearchOpen(false);
+    }
+  }, [activePatients.length, isBootstrapping]);
+
+  useEffect(() => {
     setSelectedPatientId((current) => {
       if (current && activePatients.some((patient) => patient.id === current)) {
         return current;
@@ -205,6 +228,19 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
     }
   }
 
+  function handleSearchBlur(event: FocusEvent<HTMLDivElement>) {
+    if (searchControlRef.current?.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+
+    setIsSearchOpen(false);
+  }
+
+  function handlePatientSelection(patientId: string) {
+    setSelectedPatientId(patientId);
+    setIsSearchOpen(false);
+  }
+
   if (patientsMode.kind === 'forbidden') {
     return (
       <PageContainer>
@@ -215,7 +251,7 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
 
   return (
     <PageContainer className="stack">
-      <SectionCard className="stack">
+      <SectionCard className="stack patient-search-surface">
         <div className="status-bar">
           <span className="badge neutral">Pacientes activos: {activePatients.length}</span>
           <span className="badge neutral">Encounters visibles: {encounters.length}</span>
@@ -225,20 +261,79 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
           {successMessage ? <span className="badge success">{successMessage}</span> : null}
           {patientsError ? <span className="badge error">{patientsError}</span> : null}
         </div>
-        <div className="inline-note">
-          {patientsMode.kind === 'doctor-clinical'
-            ? 'Elegí paciente, revisá encounters y registrá una evolución corta sin inventar una historia clínica completa.'
-            : 'Este cuerpo mantiene foco operativo: búsqueda y selección para secretaría sin habilitar trabajo clínico.'}
-        </div>
-      </SectionCard>
-
-      <div className="patients-workspace-grid">
-        <SectionCard className="stack patients-sidebar">
+        <div className="stack" role="group" aria-label="Buscador de pacientes">
           <div className="section-header">
-            <div>
-              <h3>Pacientes activos</h3>
-              <p>Lista corta para entrar rápido a una atención o resolver la agenda sin meter navegación extra.</p>
+            <div
+              ref={searchControlRef}
+              className="field patient-search-combobox"
+              style={{ flex: 1 }}
+              onFocus={() => setIsSearchOpen(true)}
+              onBlur={handleSearchBlur}
+            >
+              <label htmlFor="patients-sidebar-search">Buscar paciente</label>
+              <input
+                id="patients-sidebar-search"
+                type="search"
+                value={sidebarQuery}
+                onChange={(event) => {
+                  setSidebarQuery(event.target.value);
+                  setIsSearchOpen(true);
+                }}
+                placeholder="Nombre o documento"
+                disabled={isBootstrapping || activePatients.length === 0}
+                autoComplete="off"
+                aria-controls="patients-search-results"
+                aria-autocomplete="list"
+                aria-expanded={shouldShowSearchDropdown}
+                aria-haspopup="listbox"
+              />
+
+              {shouldShowSearchDropdown ? (
+                <div className="patient-search-dropdown" aria-live="polite">
+                  {filteredPatients.length === 0 ? (
+                    <div id="patients-search-results" className="empty-state empty-state-soft patient-search-feedback" role="status">
+                      <strong>No hay pacientes que coincidan con “{sidebarQuery.trim()}”.</strong>
+                      <span>Limpiá el buscador para ver la lista completa.</span>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="patient-search-feedback inline-note">
+                        <strong>
+                          {hasActiveSearchQuery
+                            ? `${filteredPatients.length} coincidencia${filteredPatients.length === 1 ? '' : 's'} visible${filteredPatients.length === 1 ? '' : 's'}`
+                            : `Pacientes activos disponibles: ${filteredPatients.length}`}
+                        </strong>
+                      </div>
+
+                      <ul id="patients-search-results" className="list compact-list patient-selector-list patient-search-results" role="listbox" aria-label="Resultados de búsqueda de pacientes">
+                        {filteredPatients.map((patient) => {
+                          const isSelected = patient.id === selectedPatientId;
+
+                          return (
+                            <li key={patient.id}>
+                              <button
+                                className={`patient-selector-card${isSelected ? ' selected' : ''}`}
+                                type="button"
+                                role="option"
+                                aria-selected={isSelected}
+                                onMouseDown={(event) => event.preventDefault()}
+                                onClick={() => handlePatientSelection(patient.id)}
+                              >
+                                <strong>
+                                  {patient.first_name} {patient.last_name}
+                                </strong>
+                                <small>Documento {patient.document}</small>
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </>
+                  )}
+                </div>
+              ) : null}
             </div>
+
             <button className="button secondary" type="button" onClick={() => void bootstrap()} disabled={isBootstrapping}>
               {isBootstrapping ? 'Actualizando...' : 'Actualizar'}
             </button>
@@ -250,38 +345,36 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
             <div className="empty-state">
               <strong>No hay pacientes activos</strong>
               <span>Cargalos desde Directorio para que esta vista tenga casos reales de demo.</span>
+              {isSecretaryOperational && onOpenDirectorySupport ? (
+                <button className="button secondary" type="button" onClick={onOpenDirectorySupport}>
+                  Abrir soporte de directorio
+                </button>
+              ) : null}
             </div>
           ) : (
-            <div className="list compact-list patient-selector-list">
-              {activePatients.map((patient) => {
-                const isSelected = patient.id === selectedPatientId;
+            <>
+              {isSelectedPatientHiddenByFilter ? (
+                <div className="inline-note" aria-live="polite">
+                  <strong>Tenés seleccionado a {selectedPatient?.first_name} {selectedPatient?.last_name}; el filtro actual lo ocultó de la lista.</strong>
+                </div>
+              ) : null}
 
-                return (
-                  <button
-                    key={patient.id}
-                    className={`patient-selector-card${isSelected ? ' selected' : ''}`}
-                    type="button"
-                    onClick={() => setSelectedPatientId(patient.id)}
-                  >
-                    <span className="surface-tab-eyebrow">Paciente</span>
-                    <strong>
-                      {patient.first_name} {patient.last_name}
-                    </strong>
-                    <small>Documento {patient.document}</small>
-                    <small>{patient.phone || 'Sin teléfono cargado'}</small>
-                  </button>
-                );
-              })}
-            </div>
+              {!shouldShowSearchDropdown && hasActiveSearchQuery && filteredPatients.length === 0 ? (
+                <div className="inline-note" aria-live="polite">
+                  <strong>No hay resultados visibles para el filtro actual.</strong>
+                </div>
+              ) : null}
+            </>
           )}
-        </SectionCard>
+        </div>
+      </SectionCard>
 
-        <div className="stack patients-main">
+      <div className="stack patients-main">
           <SectionCard className="stack">
             <div className="section-header">
               <div>
                 <h3>Resumen del paciente</h3>
-                <p>Ficha básica para contexto rápido antes de una tarea clínica u operativa.</p>
+                <p>{canAccessClinical ? 'Ficha básica para contexto rápido antes de una tarea clínica.' : 'Ficha básica para verificar datos sin abrir trabajo clínico.'}</p>
               </div>
               {selectedPatient ? <span className="pill">Activo</span> : null}
             </div>
@@ -337,14 +430,16 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
                 <h3>Encounters</h3>
                 <p>Listado descendente por fecha para ver la actividad clínica cuando el actor lo tiene habilitado.</p>
               </div>
-              <button
-                className="button secondary"
-                type="button"
-                onClick={() => (selectedPatientId ? void loadEncounters(selectedPatientId) : undefined)}
-                disabled={!selectedPatientId || !canAccessClinical || isLoadingEncounters}
-              >
-                {isLoadingEncounters ? 'Actualizando...' : 'Recargar'}
-              </button>
+              {canAccessClinical ? (
+                <button
+                  className="button secondary"
+                  type="button"
+                  onClick={() => (selectedPatientId ? void loadEncounters(selectedPatientId) : undefined)}
+                  disabled={!selectedPatientId || isLoadingEncounters}
+                >
+                  {isLoadingEncounters ? 'Actualizando...' : 'Recargar'}
+                </button>
+              ) : null}
             </div>
 
             {encountersError ? <div className="inline-note inline-note-error">{encountersError}</div> : null}
@@ -355,6 +450,11 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
               <div className="empty-state">
                 <strong>Encounters clínicos bloqueados</strong>
                 <span>{clinicalDeniedMessage}</span>
+                {isSecretaryOperational && activePatients.length === 0 && onOpenDirectorySupport ? (
+                  <button className="button secondary" type="button" onClick={onOpenDirectorySupport}>
+                    Abrir soporte de directorio
+                  </button>
+                ) : null}
               </div>
             ) : isLoadingEncounters ? (
               <div className="empty-state empty-state-soft">Cargando encounters...</div>
@@ -389,51 +489,59 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid }: PatientsWo
             <div className="section-header">
               <div>
                 <h3>Nueva nota / evolución</h3>
-                <p>Formulario corto para registrar una observación inicial solo cuando el actor tiene alcance clínico.</p>
+                <p>
+                  {canAccessClinical
+                    ? 'Formulario corto para registrar una observación inicial solo cuando el actor tiene alcance clínico.'
+                    : 'Secretaría no recibe formulario clínico en esta línea base.'}
+                </p>
               </div>
             </div>
 
-            <div className="form-grid">
-              <div className="field">
-                <label htmlFor="encounter-occurred-at">Fecha y hora</label>
-                <input
-                  id="encounter-occurred-at"
-                  type="datetime-local"
-                  value={form.occurred_at}
-                  onChange={(event) => setForm((current) => ({ ...current, occurred_at: event.target.value }))}
-                  disabled={!canAccessClinical}
-                />
+            {canAccessClinical ? (
+              <>
+                <div className="form-grid">
+                  <div className="field">
+                    <label htmlFor="encounter-occurred-at">Fecha y hora</label>
+                    <input
+                      id="encounter-occurred-at"
+                      type="datetime-local"
+                      value={form.occurred_at}
+                      onChange={(event) => setForm((current) => ({ ...current, occurred_at: event.target.value }))}
+                    />
+                  </div>
+
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="encounter-note">Nota breve</label>
+                    <textarea
+                      id="encounter-note"
+                      value={form.note}
+                      onChange={(event) => setForm((current) => ({ ...current, note: event.target.value }))}
+                      placeholder="Ej: Paciente compensado, tolera medicación, se indican controles en 72 h."
+                    />
+                  </div>
+                </div>
+
+                {formError ? <div className="inline-note inline-note-error">{formError}</div> : null}
+
+                <div className="toolbar">
+                  <button
+                    className="button"
+                    type="button"
+                    onClick={() => void handleCreateEncounter()}
+                    disabled={!selectedPatientId || isCreatingEncounter}
+                  >
+                    {isCreatingEncounter ? 'Guardando...' : 'Guardar nota'}
+                  </button>
+                  <span className="helper helper-inline">Sin router, sin wizard, sin historia clínica completa.</span>
+                </div>
+              </>
+            ) : (
+              <div className="empty-state">
+                <strong>Trabajo clínico oculto para secretaría</strong>
+                <span>Esta línea base deja solo lista y resumen de pacientes. La escritura clínica sigue reservada al actor médico.</span>
               </div>
-
-              <div className="field form-grid-span-full">
-                <label htmlFor="encounter-note">Nota breve</label>
-                <textarea
-                  id="encounter-note"
-                  value={form.note}
-                  onChange={(event) => setForm((current) => ({ ...current, note: event.target.value }))}
-                  placeholder="Ej: Paciente compensado, tolera medicación, se indican controles en 72 h."
-                  disabled={!canAccessClinical}
-                />
-              </div>
-            </div>
-
-            {formError ? <div className="inline-note inline-note-error">{formError}</div> : null}
-
-            <div className="toolbar">
-              <button
-                className="button"
-                type="button"
-                onClick={() => void handleCreateEncounter()}
-                disabled={!selectedPatientId || !canAccessClinical || isCreatingEncounter}
-              >
-                {isCreatingEncounter ? 'Guardando...' : 'Guardar nota'}
-              </button>
-              <span className="helper helper-inline">
-                {canAccessClinical ? 'Sin router, sin wizard, sin historia clínica completa.' : 'Modo operativo: sin escritura clínica.'}
-              </span>
-            </div>
+            )}
           </SectionCard>
-        </div>
       </div>
     </PageContainer>
   );

--- a/web/src/features/schedule/ScheduleDemo.test.tsx
+++ b/web/src/features/schedule/ScheduleDemo.test.tsx
@@ -64,6 +64,15 @@ vi.mock('../../api/directory', () => ({
   listProfessionals: listProfessionalsMock,
 }));
 
+vi.mock('./helpers', async () => {
+  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+
+  return {
+    ...actual,
+    formatDateInputValue: (date?: Date) => actual.formatDateInputValue(date ?? new Date('2026-04-08T12:00:00Z')),
+  };
+});
+
 describe('ScheduleDemo weekly operational board', () => {
   beforeEach(() => {
     cancelAppointmentMock.mockReset();

--- a/web/src/features/schedule/ScheduleDemo.test.tsx
+++ b/web/src/features/schedule/ScheduleDemo.test.tsx
@@ -122,6 +122,7 @@ describe('ScheduleDemo weekly operational board', () => {
     expect((await screen.findAllByText('Lun 06/04')).length).toBeGreaterThan(0);
 
     expect(screen.queryByRole('combobox', { name: 'Profesional' })).not.toBeInTheDocument();
+    expect(screen.getByText(/agenda clínica propia/i)).toBeInTheDocument();
     expect(listSlotsMock).toHaveBeenCalledTimes(5);
     expect(listSlotsMock.mock.calls.map(([filters]) => filters)).toEqual([
       { professional_id: 'professional-1', date: '2026-04-06' },
@@ -130,6 +131,28 @@ describe('ScheduleDemo weekly operational board', () => {
       { professional_id: 'professional-1', date: '2026-04-09' },
       { professional_id: 'professional-1', date: '2026-04-10' },
     ]);
+  });
+
+  it('offers secretary a hidden directory support entry when setup data is missing', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [] });
+    listPatientsMock.mockResolvedValue({ items: [] });
+    mockWeekSlices({});
+
+    const onOpenDirectorySupport = vi.fn();
+
+    render(
+      <ScheduleDemo
+        agendaMode={{ kind: 'operational-shared' }}
+        onSessionInvalid={vi.fn()}
+        onOpenDirectorySupport={onOpenDirectorySupport}
+      />,
+    );
+
+    expect(await screen.findByText(/faltan profesionales y pacientes para operar la agenda/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir soporte de directorio/i }));
+
+    expect(onOpenDirectorySupport).toHaveBeenCalledTimes(1);
   });
 
   it('shows a monday-friday weekly board with explicit empty weekdays', async () => {
@@ -194,7 +217,7 @@ describe('ScheduleDemo weekly operational board', () => {
 
   it('opens booking through a modal launched from the selected slot context', async () => {
     listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
     mockWeekRefreshes([
       {
         '2026-04-08': {
@@ -235,15 +258,18 @@ describe('ScheduleDemo weekly operational board', () => {
 
     const bookingDialog = await screen.findByRole('dialog', { name: /Reservar turno/i });
 
-    expect(within(bookingDialog).getByLabelText('Paciente')).toBeInTheDocument();
+    expect(within(bookingDialog).getByLabelText('Buscar paciente')).toBeInTheDocument();
     expect(within(bookingDialog).getByText(/Mié 08\/04/i)).toBeInTheDocument();
+
+    fireEvent.change(within(bookingDialog).getByLabelText('Buscar paciente'), { target: { value: 'maria' } });
+    fireEvent.click(within(bookingDialog).getByRole('button', { name: /María Gómez/i }));
 
     fireEvent.click(within(bookingDialog).getByRole('button', { name: 'Confirmar reserva' }));
 
     await waitFor(() => {
       expect(createAppointmentMock).toHaveBeenCalledWith({
         slot_id: 'slot-2',
-        patient_id: 'patient-1',
+        patient_id: 'patient-2',
         professional_id: 'professional-1',
       });
     });
@@ -254,6 +280,37 @@ describe('ScheduleDemo weekly operational board', () => {
     });
     expect(await screen.findByText('Juan Pérez')).toBeInTheDocument();
     expect(screen.getByText('Reservado')).toBeInTheDocument();
+  });
+
+  it('keeps the selected booking patient when the filter hides it and shows the empty-results state', async () => {
+    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
+    mockWeekSlices({
+      '2026-04-08': { slots: [availableSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
+    });
+
+    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0]);
+    fireEvent.click(await screen.findByRole('button', { name: /Mié 08\/04 .*10:00 - 10:30 UTC/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reservar turno' }));
+
+    const bookingDialog = await screen.findByRole('dialog', { name: /Reservar turno/i });
+    const searchInput = within(bookingDialog).getByLabelText('Buscar paciente');
+
+    fireEvent.change(searchInput, { target: { value: 'maria' } });
+    fireEvent.click(within(bookingDialog).getByRole('button', { name: /María Gómez/i }));
+
+    fireEvent.change(searchInput, { target: { value: 'juan' } });
+
+    expect(within(bookingDialog).getByText(/Paciente seleccionado: María Gómez. No aparece en estos resultados por el filtro actual./i)).toBeInTheDocument();
+    expect(within(bookingDialog).queryByRole('button', { name: /María Gómez/i })).not.toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: 'zzzz' } });
+
+    expect(within(bookingDialog).getByText(/No encontramos pacientes para “zzzz”./i)).toBeInTheDocument();
+    expect(within(bookingDialog).getByText(/Probá con nombre o documento./i)).toBeInTheDocument();
+    expect(within(bookingDialog).getByText(/Paciente seleccionado: María Gómez. No aparece en estos resultados por el filtro actual./i)).toBeInTheDocument();
   });
 
   it('opens slot generation through a modal bound to the selected day', async () => {
@@ -477,6 +534,21 @@ function activePatient() {
     birth_date: '1990-01-01',
     phone: '555-1234',
     email: 'juan@example.com',
+    active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function secondPatient() {
+  return {
+    id: 'patient-2',
+    first_name: 'María',
+    last_name: 'Gómez',
+    document: '20999111',
+    birth_date: '1991-02-02',
+    phone: '555-9876',
+    email: 'maria@example.com',
     active: true,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',

--- a/web/src/features/schedule/ScheduleDemo.tsx
+++ b/web/src/features/schedule/ScheduleDemo.tsx
@@ -6,6 +6,7 @@ import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolic
 import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import type { Appointment, BulkCreateSlotsPayload, Slot } from '../../types/appointments';
 import type { Patient, Professional } from '../../types/directory';
+import { filterPatients, normalizePatientSearchValue } from '../patient-search/matching';
 import {
   formatDateInputValue,
   formatDateTimeRange,
@@ -18,9 +19,10 @@ import {
 type ScheduleDemoProps = {
   agendaMode: AgendaMode;
   onSessionInvalid: () => void;
+  onOpenDirectorySupport?: () => void;
 };
 
-export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps) {
+export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupport }: ScheduleDemoProps) {
   const initialSelectedDate = mapDateToOperationalWeek(formatDateInputValue());
   const [professionals, setProfessionals] = useState<Professional[]>([]);
   const [patients, setPatients] = useState<Patient[]>([]);
@@ -32,6 +34,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
   const [timeBands, setTimeBands] = useState<string[]>([]);
   const [focusedBand, setFocusedBand] = useState('');
   const [selectedSlotId, setSelectedSlotId] = useState('');
+  const [bookingQuery, setBookingQuery] = useState('');
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [isRefreshingAgenda, setIsRefreshingAgenda] = useState(false);
   const [isCreatingSlots, setIsCreatingSlots] = useState(false);
@@ -78,6 +81,11 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
     [professionals, selectedProfessionalId],
   );
   const selectedPatient = useMemo(() => patients.find((patient) => patient.id === selectedPatientId) ?? null, [patients, selectedPatientId]);
+  const filteredBookingPatients = useMemo(() => filterPatients(patients, bookingQuery), [patients, bookingQuery]);
+  const isSelectedPatientHiddenByBookingFilter = useMemo(
+    () => Boolean(selectedPatient && normalizePatientSearchValue(bookingQuery) && !filteredBookingPatients.some((patient) => patient.id === selectedPatient.id)),
+    [bookingQuery, filteredBookingPatients, selectedPatient],
+  );
   const patientNameById = useMemo(
     () => new Map(patients.map((patient) => [patient.id, `${patient.first_name} ${patient.last_name}`])),
     [patients],
@@ -322,6 +330,13 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
   const selectedDayLongLabel = selectedWeekDay ? formatLongDate(selectedWeekDay.date) : 'Elegí un día del tablero para operar.';
   const isBookActionDisabled = isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId;
   const isGenerateActionDisabled = isBootstrapping || isRefreshingAgenda || isCreatingSlots || !selectedProfessionalId || !selectedDate;
+  const canOpenDirectorySupport = agendaMode.kind === 'operational-shared' && Boolean(onOpenDirectorySupport);
+  const isMissingOperationalSetup = agendaMode.kind === 'operational-shared' && !isBootstrapping && (professionals.length === 0 || patients.length === 0);
+  const missingOperationalSetupLabel = professionals.length === 0 && patients.length === 0
+    ? 'Faltan profesionales y pacientes para operar la agenda.'
+    : professionals.length === 0
+      ? 'Faltan profesionales activos para operar la agenda.'
+      : 'Faltan pacientes activos para poder reservar turnos.';
 
   if (agendaMode.kind === 'forbidden') {
     return (
@@ -346,7 +361,9 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
           <div>
             <span className="summary-label">Agenda</span>
             <h2>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name}` : 'Sin profesional seleccionado'}</h2>
-            <p className="helper">{selectedProfessional?.specialty ?? 'Elegí un profesional para revisar la agenda visible.'}</p>
+            <p className="helper">
+              {selectedProfessional?.specialty ?? (isDoctorAgenda ? 'Agenda propia fijada por tu asociación profesional.' : 'Elegí un profesional para revisar la agenda visible.')}
+            </p>
           </div>
           <div className="schedule-context-bar-week">
             <span className="badge info">UTC fijo para evitar corrimientos</span>
@@ -394,21 +411,52 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
           <button className="button secondary" type="button" onClick={() => void refreshAgenda()} disabled={isBootstrapping || isRefreshingAgenda}>
             {isRefreshingAgenda ? 'Actualizando...' : 'Actualizar agenda'}
           </button>
-          <button className="button" type="button" onClick={() => setActiveModal('book')} disabled={isBookActionDisabled}>
+          <button
+            className="button"
+            type="button"
+            onClick={() => {
+              setBookingQuery('');
+              setActiveModal('book');
+            }}
+            disabled={isBookActionDisabled}
+          >
             {isBooking ? 'Reservando...' : 'Reservar turno'}
           </button>
           <button className="button schedule-generator-button" type="button" onClick={() => setActiveModal('generate')} disabled={isGenerateActionDisabled}>
             {isCreatingSlots ? 'Generando...' : 'Generar slots'}
           </button>
         </div>
+
+        {isDoctorAgenda ? (
+          <div className="inline-note">
+            <strong>Agenda clínica propia</strong>
+            <span>Este tablero queda amarrado a tu professional_id y no expone agenda compartida.</span>
+          </div>
+        ) : null}
+
+        {isMissingOperationalSetup ? (
+          <div className="inline-note inline-note-error">
+            <strong>{missingOperationalSetupLabel}</strong>
+            <span>Usá el soporte de directorio para cargar la base mínima sin convertir esta vista en una configuración completa.</span>
+            {canOpenDirectorySupport ? (
+              <button className="button secondary" type="button" onClick={onOpenDirectorySupport}>
+                Abrir soporte de directorio
+              </button>
+            ) : null}
+          </div>
+        ) : null}
       </SectionCard>
 
       <section className="card stack schedule-board-shell">
         <div className="schedule-board-header">
           <div>
             <span className="summary-label">Tablero</span>
-            <h2>Agenda semanal operativa</h2>
-            <p>{selectedProfessional ? `${selectedProfessional.first_name} ${selectedProfessional.last_name} · tablero operativo de lunes a viernes.` : 'Seleccioná un profesional para ver disponibilidad.'}</p>
+            <h2>{isDoctorAgenda ? 'Agenda semanal propia' : 'Agenda semanal operativa'}</h2>
+            <p>
+              {selectedProfessional
+                ? `${selectedProfessional.first_name} ${selectedProfessional.last_name} · ${isDoctorAgenda ? 'tablero clínico propio de lunes a viernes.' : 'tablero operativo de lunes a viernes.'}`
+                : 'Seleccioná un profesional para ver disponibilidad.'}
+            </p>
           </div>
           <div className="schedule-board-toolbar">
             <div className="inline-note">
@@ -558,28 +606,70 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid }: ScheduleDemoProps
             {activeModal === 'book' ? (
               <>
                 <div className="field">
-                  <label htmlFor="patient">Paciente</label>
-                  <select id="patient" value={selectedPatientId} onChange={(event) => setSelectedPatientId(event.target.value)} disabled={isBootstrapping || patients.length === 0}>
-                    {patients.length === 0 ? <option value="">No hay pacientes</option> : null}
-                    {patients.map((patient) => (
-                      <option key={patient.id} value={patient.id}>
-                        {patient.first_name} {patient.last_name} · doc {patient.document}
-                      </option>
-                    ))}
-                  </select>
+                  <label htmlFor="booking-patient-search">Buscar paciente</label>
+                  <input
+                    id="booking-patient-search"
+                    type="search"
+                    value={bookingQuery}
+                    onChange={(event) => setBookingQuery(event.target.value)}
+                    placeholder="Nombre o documento"
+                    disabled={isBootstrapping || patients.length === 0}
+                  />
                 </div>
+
+                {patients.length === 0 ? (
+                  <div className="empty-state empty-state-soft">No hay pacientes activos para reservar.</div>
+                ) : filteredBookingPatients.length === 0 ? (
+                  <div className="empty-state empty-state-soft" aria-live="polite">
+                    <strong>No encontramos pacientes para “{bookingQuery.trim()}”.</strong>
+                    <span>Probá con nombre o documento.</span>
+                  </div>
+                ) : (
+                  <div className="list compact-list patient-selector-list" aria-label="Resultados de pacientes">
+                    {filteredBookingPatients.map((patient) => {
+                      const isSelected = patient.id === selectedPatientId;
+
+                      return (
+                        <button
+                          key={patient.id}
+                          className={`patient-selector-card${isSelected ? ' selected' : ''}`}
+                          type="button"
+                          aria-pressed={isSelected}
+                          onClick={() => setSelectedPatientId(patient.id)}
+                        >
+                          <span className="surface-tab-eyebrow">Paciente</span>
+                          <strong>
+                            {patient.first_name} {patient.last_name}
+                          </strong>
+                          <small>Documento {patient.document}</small>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
 
                 <div className="inline-note" aria-live="polite">
                   <strong>{selectedSlotLabel}</strong>
                   <span>
                     {selectedSlot
-                      ? `Paciente listo para reservar: ${selectedPatient ? `${selectedPatient.first_name} ${selectedPatient.last_name}` : 'seleccioná un paciente'}.`
+                      ? selectedPatient
+                        ? isSelectedPatientHiddenByBookingFilter
+                          ? `Paciente seleccionado: ${selectedPatient.first_name} ${selectedPatient.last_name}. No aparece en estos resultados por el filtro actual.`
+                          : `Paciente listo para reservar: ${selectedPatient.first_name} ${selectedPatient.last_name}.`
+                        : 'Seleccioná un paciente.'
                       : 'Seleccioná un horario desde la grilla de disponibilidad para continuar.'}
                   </span>
                 </div>
 
                 <div className="schedule-modal-actions">
-                  <button className="button ghost" type="button" onClick={() => setActiveModal(null)}>
+                  <button
+                    className="button ghost"
+                    type="button"
+                    onClick={() => {
+                      setBookingQuery('');
+                      setActiveModal(null);
+                    }}
+                  >
                     Cancelar
                   </button>
                   <button className="button" type="button" onClick={() => void handleBookAppointment()} disabled={isBootstrapping || isRefreshingAgenda || isBooking || !selectedSlotId || !selectedPatientId}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1000,10 +1000,46 @@ button {
   gap: 10px;
 }
 
+.patient-search-combobox {
+  position: relative;
+}
+
+.patient-search-surface {
+  overflow: visible;
+  z-index: 40;
+}
+
+.patient-search-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  z-index: 60;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(10px);
+}
+
+.patient-search-feedback {
+  margin: 0;
+}
+
+.patient-search-results {
+  max-height: min(320px, 50vh);
+  margin: 0;
+  padding-right: 2px;
+}
+
 .patient-selector-card {
   display: grid;
   gap: 4px;
-  padding: 16px;
+  width: 100%;
+  padding: 14px 16px;
   border: 1px solid #dfe6ee;
   border-radius: var(--radius-md);
   background: #fbfcfe;


### PR DESCRIPTION
Closes #29

## Summary
- add secretary-only directory support without exposing Directory as a regular sidebar surface
- extract reusable patient search matching and apply it across patients and agenda flows
- clarify actor-specific shell copy and tighten related workspace tests

## Changes
| File | Change |
|------|--------|
| web/src/auth/actorCapabilities.ts | Added support surfaces and role-specific shell metadata for doctor, secretary, and admin flows |
| web/src/App.tsx | Allowed hidden support surfaces to be opened from agenda and patients workspaces |
| web/src/features/patient-search/* | Added shared patient search matching utility and tests |
| web/src/features/patients/* | Reworked patient selection around the new combobox search UX |
| web/src/features/schedule/* | Added patient search and directory support entry points to booking flows, then stabilized date-sensitive tests |
| web/src/features/directory/* | Narrowed secretary access to operational support while preserving admin setup |
| web/src/styles.css | Styled the shared patient search combobox |

## Test Plan
- [x] Ran npm test in web
- [x] Ran npm run typecheck in web
- [x] Manually reviewed the affected functionality and diff grouping

## Contributor Checklist
- [x] Linked an approved issue
- [x] Conventional commit format used
- [x] No Co-Authored-By trailers added
