### PR TITLE
feat(appointments): complete schedule templates foundation

### DIFF
--- a/services/appointments-service/internal/appointments/repository.go
+++ b/services/appointments-service/internal/appointments/repository.go
@@ -3,6 +3,7 @@ package appointments
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -71,6 +72,44 @@ type Appointment struct {
 	CreatedAt      time.Time  `json:"created_at"`
 	UpdatedAt      time.Time  `json:"updated_at"`
 	CancelledAt    *time.Time `json:"cancelled_at,omitempty"`
+}
+
+type CreateTemplateParams struct {
+	ProfessionalID string          `json:"professional_id"`
+	EffectiveFrom  string          `json:"effective_from"`
+	Recurrence     json.RawMessage `json:"recurrence"`
+	CreatedBy      *string         `json:"created_by,omitempty"`
+	Reason         *string         `json:"reason,omitempty"`
+}
+
+type CreateScheduleBlockParams struct {
+	ProfessionalID string  `json:"professional_id"`
+	Scope          string  `json:"scope"`
+	BlockDate      *string `json:"block_date,omitempty"`
+	StartDate      *string `json:"start_date,omitempty"`
+	EndDate        *string `json:"end_date,omitempty"`
+	DayOfWeek      *int    `json:"day_of_week,omitempty"`
+	StartTime      string  `json:"start_time"`
+	EndTime        string  `json:"end_time"`
+	TemplateID     *string `json:"template_id,omitempty"`
+}
+
+type UpdateScheduleBlockParams struct {
+	ProfessionalID string  `json:"professional_id"`
+	Scope          string  `json:"scope"`
+	BlockDate      *string `json:"block_date,omitempty"`
+	StartDate      *string `json:"start_date,omitempty"`
+	EndDate        *string `json:"end_date,omitempty"`
+	DayOfWeek      *int    `json:"day_of_week,omitempty"`
+	StartTime      string  `json:"start_time"`
+	EndTime        string  `json:"end_time"`
+	TemplateID     *string `json:"template_id,omitempty"`
+}
+
+type ScheduleBlockFilters struct {
+	ProfessionalID string
+	TemplateID     string
+	Scope          string
 }
 
 func ValidateBulkCreateSlotsParams(params BulkCreateSlotsParams) error {
@@ -390,6 +429,295 @@ func (r *Repository) CancelAppointment(ctx context.Context, appointmentID string
 	return updated, nil
 }
 
+func (r *Repository) CreateTemplate(ctx context.Context, params CreateTemplateParams) (ScheduleTemplate, error) {
+	professionalID, effectiveFrom, recurrence, createdBy, reason, err := validateCreateTemplateParams(params)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	row := r.db.QueryRowContext(ctx, `
+		WITH upserted_template AS (
+			INSERT INTO schedule_templates (professional_id)
+			VALUES ($1)
+			ON CONFLICT (professional_id)
+			DO UPDATE SET updated_at = NOW()
+			RETURNING id, professional_id, created_at, updated_at
+		), inserted_version AS (
+			INSERT INTO schedule_template_versions (template_id, version_number, effective_from, recurrence, created_by, reason)
+			SELECT
+				t.id,
+				COALESCE((
+					SELECT MAX(version_number)
+					FROM schedule_template_versions
+					WHERE template_id = t.id
+				), 0) + 1,
+				$2,
+				$3,
+				$4,
+				$5
+			FROM upserted_template t
+			RETURNING id, template_id, version_number, effective_from, recurrence, created_at, created_by, reason
+		)
+		SELECT
+			t.id,
+			t.professional_id,
+			t.created_at,
+			t.updated_at,
+			v.id,
+			v.version_number,
+			v.effective_from,
+			v.recurrence,
+			v.created_at,
+			v.created_by,
+			v.reason
+		FROM upserted_template t
+		JOIN inserted_version v ON v.template_id = t.id
+	`, professionalID, effectiveFrom, recurrence, createdBy, reason)
+
+	template, err := scanTemplateWithVersion(row)
+	if err != nil {
+		if isConflictViolation(err) {
+			return ScheduleTemplate{}, ErrConflict
+		}
+		return ScheduleTemplate{}, err
+	}
+
+	return template, nil
+}
+
+func (r *Repository) GetTemplate(ctx context.Context, templateID string) (ScheduleTemplate, error) {
+	if _, err := uuid.Parse(strings.TrimSpace(templateID)); err != nil {
+		return ScheduleTemplate{}, ErrValidation
+	}
+
+	template, err := scanTemplate(r.db.QueryRowContext(ctx, `
+		SELECT id, professional_id, created_at, updated_at
+		FROM schedule_templates
+		WHERE id = $1
+	`, strings.TrimSpace(templateID)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScheduleTemplate{}, ErrNotFound
+	}
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	return template, nil
+}
+
+func (r *Repository) ListTemplateVersions(ctx context.Context, templateID string) ([]ScheduleTemplateVersion, error) {
+	if _, err := uuid.Parse(strings.TrimSpace(templateID)); err != nil {
+		return nil, ErrValidation
+	}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, template_id, version_number, effective_from, recurrence, created_at, created_by, reason
+		FROM schedule_template_versions
+		WHERE template_id = $1
+		ORDER BY effective_from DESC, version_number DESC
+	`, strings.TrimSpace(templateID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	versions := make([]ScheduleTemplateVersion, 0)
+	for rows.Next() {
+		version, scanErr := scanTemplateVersion(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		versions = append(versions, version)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return versions, nil
+}
+
+func (r *Repository) GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplateVersion, error) {
+	validatedProfessionalID, validatedEffectiveDate, err := validateActiveTemplateLookupParams(professionalID, effectiveDate)
+	if err != nil {
+		return ScheduleTemplateVersion{}, err
+	}
+
+	version, err := scanTemplateVersion(r.db.QueryRowContext(ctx, `
+		SELECT v.id, v.template_id, v.version_number, v.effective_from, v.recurrence, v.created_at, v.created_by, v.reason
+		FROM schedule_template_versions v
+		JOIN schedule_templates t ON t.id = v.template_id
+		WHERE t.professional_id = $1
+		  AND v.effective_from <= $2
+		ORDER BY v.effective_from DESC, v.version_number DESC
+		LIMIT 1
+	`, validatedProfessionalID, validatedEffectiveDate))
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScheduleTemplateVersion{}, ErrNotFound
+	}
+	if err != nil {
+		return ScheduleTemplateVersion{}, err
+	}
+
+	return version, nil
+}
+
+func (r *Repository) CreateScheduleBlock(ctx context.Context, params CreateScheduleBlockParams) (ScheduleBlock, error) {
+	validated, err := validateScheduleBlockParams(params.ProfessionalID, params.Scope, params.BlockDate, params.StartDate, params.EndDate, params.DayOfWeek, params.StartTime, params.EndTime, params.TemplateID)
+	if err != nil {
+		return ScheduleBlock{}, err
+	}
+
+	block, err := scanScheduleBlock(r.db.QueryRowContext(ctx, `
+		INSERT INTO schedule_blocks (professional_id, scope, block_date, start_date, end_date, day_of_week, start_time, end_time, template_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, professional_id, scope, block_date, start_date, end_date, day_of_week, TO_CHAR(start_time, 'HH24:MI'), TO_CHAR(end_time, 'HH24:MI'), template_id, created_at, updated_at
+	`, validated.professionalID, validated.scope, validated.blockDate, validated.startDate, validated.endDate, validated.dayOfWeek, validated.startTime, validated.endTime, validated.templateID))
+	if err != nil {
+		if isConflictViolation(err) {
+			return ScheduleBlock{}, ErrConflict
+		}
+		return ScheduleBlock{}, err
+	}
+
+	return block, nil
+}
+
+func (r *Repository) GetScheduleBlock(ctx context.Context, blockID string) (ScheduleBlock, error) {
+	if _, err := uuid.Parse(strings.TrimSpace(blockID)); err != nil {
+		return ScheduleBlock{}, ErrValidation
+	}
+
+	block, err := scanScheduleBlock(r.db.QueryRowContext(ctx, `
+		SELECT id, professional_id, scope, block_date, start_date, end_date, day_of_week, TO_CHAR(start_time, 'HH24:MI'), TO_CHAR(end_time, 'HH24:MI'), template_id, created_at, updated_at
+		FROM schedule_blocks
+		WHERE id = $1
+	`, strings.TrimSpace(blockID)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScheduleBlock{}, ErrNotFound
+	}
+	if err != nil {
+		return ScheduleBlock{}, err
+	}
+
+	return block, nil
+}
+
+func (r *Repository) ListScheduleBlocks(ctx context.Context, filters ScheduleBlockFilters) ([]ScheduleBlock, error) {
+	if err := validateScheduleBlockFilters(filters); err != nil {
+		return nil, err
+	}
+
+	baseQuery := `
+		SELECT id, professional_id, scope, block_date, start_date, end_date, day_of_week, TO_CHAR(start_time, 'HH24:MI'), TO_CHAR(end_time, 'HH24:MI'), template_id, created_at, updated_at
+		FROM schedule_blocks
+	`
+
+	where := make([]string, 0)
+	args := make([]any, 0)
+
+	if filters.ProfessionalID != "" {
+		where = append(where, fmt.Sprintf("professional_id = $%d", len(args)+1))
+		args = append(args, strings.TrimSpace(filters.ProfessionalID))
+	}
+	if filters.TemplateID != "" {
+		where = append(where, fmt.Sprintf("template_id = $%d", len(args)+1))
+		args = append(args, strings.TrimSpace(filters.TemplateID))
+	}
+	if filters.Scope != "" {
+		where = append(where, fmt.Sprintf("scope = $%d", len(args)+1))
+		args = append(args, strings.TrimSpace(filters.Scope))
+	}
+
+	query := baseQuery
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+	query += " ORDER BY COALESCE(block_date, start_date) NULLS LAST, day_of_week NULLS LAST, start_time, created_at"
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	blocks := make([]ScheduleBlock, 0)
+	for rows.Next() {
+		block, scanErr := scanScheduleBlock(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		blocks = append(blocks, block)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return blocks, nil
+}
+
+func (r *Repository) UpdateScheduleBlock(ctx context.Context, blockID string, params UpdateScheduleBlockParams) (ScheduleBlock, error) {
+	trimmedBlockID := strings.TrimSpace(blockID)
+	if _, err := uuid.Parse(trimmedBlockID); err != nil {
+		return ScheduleBlock{}, ErrValidation
+	}
+
+	validated, err := validateScheduleBlockParams(params.ProfessionalID, params.Scope, params.BlockDate, params.StartDate, params.EndDate, params.DayOfWeek, params.StartTime, params.EndTime, params.TemplateID)
+	if err != nil {
+		return ScheduleBlock{}, err
+	}
+
+	block, err := scanScheduleBlock(r.db.QueryRowContext(ctx, `
+		UPDATE schedule_blocks
+		SET professional_id = $2,
+			scope = $3,
+			block_date = $4,
+			start_date = $5,
+			end_date = $6,
+			day_of_week = $7,
+			start_time = $8,
+			end_time = $9,
+			template_id = $10,
+			updated_at = NOW()
+		WHERE id = $1
+		RETURNING id, professional_id, scope, block_date, start_date, end_date, day_of_week, TO_CHAR(start_time, 'HH24:MI'), TO_CHAR(end_time, 'HH24:MI'), template_id, created_at, updated_at
+	`, trimmedBlockID, validated.professionalID, validated.scope, validated.blockDate, validated.startDate, validated.endDate, validated.dayOfWeek, validated.startTime, validated.endTime, validated.templateID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScheduleBlock{}, ErrNotFound
+	}
+	if err != nil {
+		if isConflictViolation(err) {
+			return ScheduleBlock{}, ErrConflict
+		}
+		return ScheduleBlock{}, err
+	}
+
+	return block, nil
+}
+
+func (r *Repository) DeleteScheduleBlock(ctx context.Context, blockID string) error {
+	trimmedBlockID := strings.TrimSpace(blockID)
+	if _, err := uuid.Parse(trimmedBlockID); err != nil {
+		return ErrValidation
+	}
+
+	var deletedID string
+	err := r.db.QueryRowContext(ctx, `
+		DELETE FROM schedule_blocks
+		WHERE id = $1
+		RETURNING id
+	`, trimmedBlockID).Scan(&deletedID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func parseBulkSlotInputs(params BulkCreateSlotsParams) (string, time.Time, time.Time, time.Duration, error) {
 	professionalID := strings.TrimSpace(params.ProfessionalID)
 	if _, err := uuid.Parse(professionalID); err != nil {
@@ -444,6 +772,222 @@ func validateAppointmentParams(params CreateAppointmentParams) error {
 	return nil
 }
 
+func validateCreateTemplateParams(params CreateTemplateParams) (string, time.Time, json.RawMessage, *string, *string, error) {
+	professionalID := strings.TrimSpace(params.ProfessionalID)
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return "", time.Time{}, nil, nil, nil, ErrValidation
+	}
+
+	effectiveFrom, err := time.Parse("2006-01-02", strings.TrimSpace(params.EffectiveFrom))
+	if err != nil {
+		return "", time.Time{}, nil, nil, nil, ErrValidation
+	}
+
+	recurrence := make(json.RawMessage, len(params.Recurrence))
+	copy(recurrence, params.Recurrence)
+	if !json.Valid(recurrence) {
+		return "", time.Time{}, nil, nil, nil, ErrValidation
+	}
+
+	var recurrencePayload map[string]any
+	if err := json.Unmarshal(recurrence, &recurrencePayload); err != nil || recurrencePayload == nil {
+		return "", time.Time{}, nil, nil, nil, ErrValidation
+	}
+
+	createdBy, err := normalizeOptionalUUID(params.CreatedBy)
+	if err != nil {
+		return "", time.Time{}, nil, nil, nil, err
+	}
+
+	reason := normalizeOptionalString(params.Reason)
+
+	return professionalID, effectiveFrom, recurrence, createdBy, reason, nil
+}
+
+func validateActiveTemplateLookupParams(professionalIDValue, effectiveDateValue string) (string, time.Time, error) {
+	professionalID := strings.TrimSpace(professionalIDValue)
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return "", time.Time{}, ErrValidation
+	}
+
+	effectiveDate, err := time.Parse("2006-01-02", strings.TrimSpace(effectiveDateValue))
+	if err != nil {
+		return "", time.Time{}, ErrValidation
+	}
+
+	return professionalID, effectiveDate, nil
+}
+
+type validatedScheduleBlockParams struct {
+	professionalID string
+	scope          string
+	blockDate      *time.Time
+	startDate      *time.Time
+	endDate        *time.Time
+	dayOfWeek      *int
+	startTime      string
+	endTime        string
+	templateID     *string
+}
+
+func validateScheduleBlockParams(professionalIDValue, scopeValue string, blockDateValue, startDateValue, endDateValue *string, dayOfWeekValue *int, startTimeValue, endTimeValue string, templateIDValue *string) (validatedScheduleBlockParams, error) {
+	professionalID := strings.TrimSpace(professionalIDValue)
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return validatedScheduleBlockParams{}, ErrValidation
+	}
+
+	scope := strings.TrimSpace(scopeValue)
+	if scope != "single" && scope != "range" && scope != "template" {
+		return validatedScheduleBlockParams{}, ErrValidation
+	}
+
+	blockDate, err := normalizeOptionalDate(blockDateValue)
+	if err != nil {
+		return validatedScheduleBlockParams{}, err
+	}
+	startDate, err := normalizeOptionalDate(startDateValue)
+	if err != nil {
+		return validatedScheduleBlockParams{}, err
+	}
+	endDate, err := normalizeOptionalDate(endDateValue)
+	if err != nil {
+		return validatedScheduleBlockParams{}, err
+	}
+
+	startTime, err := normalizeClockString(startTimeValue)
+	if err != nil {
+		return validatedScheduleBlockParams{}, err
+	}
+	endTime, err := normalizeClockString(endTimeValue)
+	if err != nil {
+		return validatedScheduleBlockParams{}, err
+	}
+	if startTime >= endTime {
+		return validatedScheduleBlockParams{}, ErrValidation
+	}
+
+	templateID, err := normalizeOptionalUUID(templateIDValue)
+	if err != nil {
+		return validatedScheduleBlockParams{}, err
+	}
+
+	var dayOfWeek *int
+	if dayOfWeekValue != nil {
+		day := *dayOfWeekValue
+		if day < 1 || day > 7 {
+			return validatedScheduleBlockParams{}, ErrValidation
+		}
+		dayOfWeek = &day
+	}
+
+	switch scope {
+	case "single":
+		if blockDate == nil || startDate != nil || endDate != nil || dayOfWeek != nil || templateID != nil {
+			return validatedScheduleBlockParams{}, ErrValidation
+		}
+	case "range":
+		if blockDate != nil || startDate == nil || endDate == nil || dayOfWeek != nil || templateID != nil {
+			return validatedScheduleBlockParams{}, ErrValidation
+		}
+		if startDate.After(*endDate) {
+			return validatedScheduleBlockParams{}, ErrValidation
+		}
+	case "template":
+		if blockDate != nil || startDate != nil || endDate != nil || dayOfWeek == nil || templateID == nil {
+			return validatedScheduleBlockParams{}, ErrValidation
+		}
+	}
+
+	return validatedScheduleBlockParams{
+		professionalID: professionalID,
+		scope:          scope,
+		blockDate:      blockDate,
+		startDate:      startDate,
+		endDate:        endDate,
+		dayOfWeek:      dayOfWeek,
+		startTime:      startTime,
+		endTime:        endTime,
+		templateID:     templateID,
+	}, nil
+}
+
+func validateScheduleBlockFilters(filters ScheduleBlockFilters) error {
+	if filters.ProfessionalID != "" {
+		if _, err := uuid.Parse(strings.TrimSpace(filters.ProfessionalID)); err != nil {
+			return ErrValidation
+		}
+	}
+	if filters.TemplateID != "" {
+		if _, err := uuid.Parse(strings.TrimSpace(filters.TemplateID)); err != nil {
+			return ErrValidation
+		}
+	}
+	if filters.Scope != "" {
+		scope := strings.TrimSpace(filters.Scope)
+		if scope != "single" && scope != "range" && scope != "template" {
+			return ErrValidation
+		}
+	}
+
+	return nil
+}
+
+func normalizeOptionalDate(value *string) (*time.Time, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return nil, ErrValidation
+	}
+
+	return &parsed, nil
+}
+
+func normalizeClockString(value string) (string, error) {
+	parsed, err := time.Parse("15:04", strings.TrimSpace(value))
+	if err != nil {
+		return "", ErrValidation
+	}
+
+	return parsed.Format("15:04"), nil
+}
+
+func normalizeOptionalUUID(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, nil
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return nil, ErrValidation
+	}
+
+	return &trimmed, nil
+}
+
+func normalizeOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+
+	return &trimmed
+}
+
 func isConflictViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) {
@@ -478,6 +1022,14 @@ type appointmentScanner interface {
 	Scan(dest ...any) error
 }
 
+type templateScanner interface {
+	Scan(dest ...any) error
+}
+
+type scheduleBlockScanner interface {
+	Scan(dest ...any) error
+}
+
 func scanAppointment(scanner appointmentScanner) (Appointment, error) {
 	var appointment Appointment
 	var cancelledAt sql.NullTime
@@ -498,4 +1050,149 @@ func scanAppointment(scanner appointmentScanner) (Appointment, error) {
 		appointment.CancelledAt = &cancelledAt.Time
 	}
 	return appointment, nil
+}
+
+func scanTemplate(scanner templateScanner) (ScheduleTemplate, error) {
+	var template ScheduleTemplate
+	err := scanner.Scan(
+		&template.ID,
+		&template.ProfessionalID,
+		&template.CreatedAt,
+		&template.UpdatedAt,
+	)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	return template, nil
+}
+
+func scanTemplateVersion(scanner templateScanner) (ScheduleTemplateVersion, error) {
+	var (
+		version           ScheduleTemplateVersion
+		recurrence        []byte
+		createdBy, reason sql.NullString
+	)
+
+	err := scanner.Scan(
+		&version.ID,
+		&version.TemplateID,
+		&version.VersionNumber,
+		&version.EffectiveFrom,
+		&recurrence,
+		&version.CreatedAt,
+		&createdBy,
+		&reason,
+	)
+	if err != nil {
+		return ScheduleTemplateVersion{}, err
+	}
+
+	version.Recurrence = make(json.RawMessage, len(recurrence))
+	copy(version.Recurrence, recurrence)
+	if createdBy.Valid {
+		version.CreatedBy = &createdBy.String
+	}
+	if reason.Valid {
+		version.Reason = &reason.String
+	}
+
+	return version, nil
+}
+
+func scanTemplateWithVersion(scanner templateScanner) (ScheduleTemplate, error) {
+	template, err := scanTemplateVersionJoin(scanner)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	return template, nil
+}
+
+func scanScheduleBlock(scanner scheduleBlockScanner) (ScheduleBlock, error) {
+	var (
+		block                         ScheduleBlock
+		blockDate, startDate, endDate sql.NullTime
+		dayOfWeek                     sql.NullInt64
+		templateID                    sql.NullString
+	)
+
+	err := scanner.Scan(
+		&block.ID,
+		&block.ProfessionalID,
+		&block.Scope,
+		&blockDate,
+		&startDate,
+		&endDate,
+		&dayOfWeek,
+		&block.StartTime,
+		&block.EndTime,
+		&templateID,
+		&block.CreatedAt,
+		&block.UpdatedAt,
+	)
+	if err != nil {
+		return ScheduleBlock{}, err
+	}
+
+	if blockDate.Valid {
+		date := blockDate.Time
+		block.BlockDate = &date
+	}
+	if startDate.Valid {
+		date := startDate.Time
+		block.StartDate = &date
+	}
+	if endDate.Valid {
+		date := endDate.Time
+		block.EndDate = &date
+	}
+	if dayOfWeek.Valid {
+		day := int(dayOfWeek.Int64)
+		block.DayOfWeek = &day
+	}
+	if templateID.Valid {
+		block.TemplateID = &templateID.String
+	}
+
+	return block, nil
+}
+
+func scanTemplateVersionJoin(scanner templateScanner) (ScheduleTemplate, error) {
+	var (
+		template          ScheduleTemplate
+		version           ScheduleTemplateVersion
+		recurrence        []byte
+		createdBy, reason sql.NullString
+	)
+
+	err := scanner.Scan(
+		&template.ID,
+		&template.ProfessionalID,
+		&template.CreatedAt,
+		&template.UpdatedAt,
+		&version.ID,
+		&version.VersionNumber,
+		&version.EffectiveFrom,
+		&recurrence,
+		&version.CreatedAt,
+		&createdBy,
+		&reason,
+	)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	version.TemplateID = template.ID
+	version.Recurrence = make(json.RawMessage, len(recurrence))
+	copy(version.Recurrence, recurrence)
+	if createdBy.Valid {
+		version.CreatedBy = &createdBy.String
+	}
+	if reason.Valid {
+		version.Reason = &reason.String
+	}
+	template.Versions = []ScheduleTemplateVersion{version}
+
+	return template, nil
 }

--- a/services/appointments-service/internal/appointments/repository_postgres_integration_helpers_test.go
+++ b/services/appointments-service/internal/appointments/repository_postgres_integration_helpers_test.go
@@ -92,7 +92,7 @@ func resetAppointmentsSchema(t *testing.T, db *sql.DB) {
 func applyAppointmentsMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
 
-	for _, migration := range []string{"001_init.sql", "002_prevent_availability_slot_overlaps.sql", "003_allow_rebooking_cancelled_slots.sql"} {
+	for _, migration := range []string{"001_init.sql", "002_prevent_availability_slot_overlaps.sql", "003_allow_rebooking_cancelled_slots.sql", "004_schedule_templates.sql", "005_schedule_blocks.sql"} {
 		contents := readAppointmentsMigrationFile(t, migration)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -184,6 +184,21 @@ func countAppointments(t *testing.T, db *sql.DB) int {
 	var total int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM appointments`).Scan(&total); err != nil {
 		t.Fatalf("count appointments: %v", err)
+	}
+
+	return total
+}
+
+func countRows(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var total int
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
+	if err := db.QueryRowContext(ctx, query).Scan(&total); err != nil {
+		t.Fatalf("count rows in %s: %v", table, err)
 	}
 
 	return total

--- a/services/appointments-service/internal/appointments/repository_postgres_integration_test.go
+++ b/services/appointments-service/internal/appointments/repository_postgres_integration_test.go
@@ -2,10 +2,224 @@ package appointments
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
 )
+
+func TestRepositoryIntegrationScheduleBlockLifecyclePersistsScopedBlocks(t *testing.T) {
+	repo, db := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440140"
+	createdTemplate, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+		ProfessionalID: professionalID,
+		EffectiveFrom:  "2026-05-01",
+		Recurrence:     json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}}`),
+	})
+	if err != nil {
+		t.Fatalf("create template for schedule block: %v", err)
+	}
+
+	created, err := repo.CreateScheduleBlock(ctx, CreateScheduleBlockParams{
+		ProfessionalID: professionalID,
+		Scope:          "single",
+		BlockDate:      stringPtr("2026-05-05"),
+		StartTime:      "09:00",
+		EndTime:        "12:00",
+	})
+	if err != nil {
+		t.Fatalf("create schedule block: %v", err)
+	}
+	if created.BlockDate == nil || created.BlockDate.Format("2006-01-02") != "2026-05-05" {
+		t.Fatalf("created block_date = %v, want 2026-05-05", created.BlockDate)
+	}
+
+	updated, err := repo.UpdateScheduleBlock(ctx, created.ID, UpdateScheduleBlockParams{
+		ProfessionalID: professionalID,
+		Scope:          "template",
+		DayOfWeek:      intPtr(1),
+		StartTime:      "10:00",
+		EndTime:        "11:00",
+		TemplateID:     &createdTemplate.ID,
+	})
+	if err != nil {
+		t.Fatalf("update schedule block: %v", err)
+	}
+	if updated.Scope != "template" {
+		t.Fatalf("updated scope = %q, want template", updated.Scope)
+	}
+	if updated.TemplateID == nil || *updated.TemplateID != createdTemplate.ID {
+		t.Fatalf("updated template_id = %v, want %q", updated.TemplateID, createdTemplate.ID)
+	}
+	if updated.DayOfWeek == nil || *updated.DayOfWeek != 1 {
+		t.Fatalf("updated day_of_week = %v, want 1", updated.DayOfWeek)
+	}
+
+	persisted, err := repo.GetScheduleBlock(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get schedule block: %v", err)
+	}
+	if persisted.Scope != "template" {
+		t.Fatalf("persisted scope = %q, want template", persisted.Scope)
+	}
+	if persisted.StartTime != "10:00" || persisted.EndTime != "11:00" {
+		t.Fatalf("persisted time range = %s-%s, want 10:00-11:00", persisted.StartTime, persisted.EndTime)
+	}
+
+	blocks, err := repo.ListScheduleBlocks(ctx, ScheduleBlockFilters{ProfessionalID: professionalID})
+	if err != nil {
+		t.Fatalf("list schedule blocks: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("listed blocks len = %d, want 1", len(blocks))
+	}
+	if blocks[0].ID != created.ID {
+		t.Fatalf("listed block id = %q, want %q", blocks[0].ID, created.ID)
+	}
+
+	if got := countRows(t, db, "schedule_blocks"); got != 1 {
+		t.Fatalf("schedule blocks persisted = %d, want 1", got)
+	}
+
+	if err := repo.DeleteScheduleBlock(ctx, created.ID); err != nil {
+		t.Fatalf("delete schedule block: %v", err)
+	}
+	if got := countRows(t, db, "schedule_blocks"); got != 0 {
+		t.Fatalf("schedule blocks persisted after delete = %d, want 0", got)
+	}
+
+	_, err = repo.GetScheduleBlock(ctx, created.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("post-delete get err = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func TestRepositoryIntegrationCreateTemplatePersistsTemplateAndVersions(t *testing.T) {
+	repo, db := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440100"
+	createdBy := "550e8400-e29b-41d4-a716-446655440101"
+	firstReason := "initial rollout"
+	secondReason := "winter hours"
+
+	firstRecurrence := json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}}`)
+	created, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+		ProfessionalID: professionalID,
+		EffectiveFrom:  "2026-05-01",
+		Recurrence:     firstRecurrence,
+		CreatedBy:      &createdBy,
+		Reason:         &firstReason,
+	})
+	if err != nil {
+		t.Fatalf("create initial template: %v", err)
+	}
+	if len(created.Versions) != 1 {
+		t.Fatalf("created versions len = %d, want 1", len(created.Versions))
+	}
+	if created.Versions[0].VersionNumber != 1 {
+		t.Fatalf("initial version number = %d, want 1", created.Versions[0].VersionNumber)
+	}
+
+	secondRecurrence := json.RawMessage(`{"monday":{"start_time":"08:00","end_time":"12:00","slot_duration_minutes":30},"wednesday":{"start_time":"10:00","end_time":"13:00","slot_duration_minutes":30}}`)
+	updated, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+		ProfessionalID: professionalID,
+		EffectiveFrom:  "2026-06-01",
+		Recurrence:     secondRecurrence,
+		Reason:         &secondReason,
+	})
+	if err != nil {
+		t.Fatalf("create second template version: %v", err)
+	}
+	if updated.ID != created.ID {
+		t.Fatalf("updated template id = %q, want %q", updated.ID, created.ID)
+	}
+	if updated.Versions[0].VersionNumber != 2 {
+		t.Fatalf("second version number = %d, want 2", updated.Versions[0].VersionNumber)
+	}
+
+	persistedTemplate, err := repo.GetTemplate(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get template: %v", err)
+	}
+	if persistedTemplate.ProfessionalID != professionalID {
+		t.Fatalf("persisted professional_id = %q, want %q", persistedTemplate.ProfessionalID, professionalID)
+	}
+
+	versions, err := repo.ListTemplateVersions(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("list template versions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("persisted versions len = %d, want 2", len(versions))
+	}
+	if versions[0].VersionNumber != 2 || versions[1].VersionNumber != 1 {
+		t.Fatalf("persisted version order = [%d %d], want [2 1]", versions[0].VersionNumber, versions[1].VersionNumber)
+	}
+	if versions[1].CreatedBy == nil || *versions[1].CreatedBy != createdBy {
+		t.Fatalf("persisted created_by = %v, want %q", versions[1].CreatedBy, createdBy)
+	}
+	if versions[0].Reason == nil || *versions[0].Reason != secondReason {
+		t.Fatalf("persisted reason = %v, want %q", versions[0].Reason, secondReason)
+	}
+	if got := countRows(t, db, "schedule_templates"); got != 1 {
+		t.Fatalf("templates persisted = %d, want 1", got)
+	}
+	if got := countRows(t, db, "schedule_template_versions"); got != 2 {
+		t.Fatalf("template versions persisted = %d, want 2", got)
+	}
+}
+
+func TestRepositoryIntegrationGetActiveTemplateSelectsLatestApplicableVersion(t *testing.T) {
+	repo, _ := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440102"
+
+	first, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+		ProfessionalID: professionalID,
+		EffectiveFrom:  "2026-05-01",
+		Recurrence:     json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}}`),
+	})
+	if err != nil {
+		t.Fatalf("create first template version: %v", err)
+	}
+
+	second, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+		ProfessionalID: professionalID,
+		EffectiveFrom:  "2026-06-01",
+		Recurrence:     json.RawMessage(`{"monday":{"start_time":"08:00","end_time":"12:00","slot_duration_minutes":30}}`),
+	})
+	if err != nil {
+		t.Fatalf("create second template version: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("template family id = %q, want %q", second.ID, first.ID)
+	}
+
+	mayVersion, err := repo.GetActiveTemplate(ctx, professionalID, "2026-05-31")
+	if err != nil {
+		t.Fatalf("get active template for may: %v", err)
+	}
+	if mayVersion.VersionNumber != 1 {
+		t.Fatalf("may version number = %d, want 1", mayVersion.VersionNumber)
+	}
+
+	juneVersion, err := repo.GetActiveTemplate(ctx, professionalID, "2026-06-01")
+	if err != nil {
+		t.Fatalf("get active template for june boundary: %v", err)
+	}
+	if juneVersion.VersionNumber != 2 {
+		t.Fatalf("june version number = %d, want 2", juneVersion.VersionNumber)
+	}
+
+	_, err = repo.GetActiveTemplate(ctx, professionalID, "2026-04-30")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("pre-history err = %v, want %v", err, ErrNotFound)
+	}
+}
 
 func TestRepositoryIntegrationCreateSlotsBulkRejectsOverlapInPostgres(t *testing.T) {
 	repo, db := newPostgresIntegrationRepository(t)

--- a/services/appointments-service/internal/appointments/repository_test.go
+++ b/services/appointments-service/internal/appointments/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -201,6 +202,393 @@ func TestGetAppointmentByIDReturnsValidationOnBadID(t *testing.T) {
 	}
 }
 
+func TestCreateTemplateCreatesInitialTemplateVersion(t *testing.T) {
+	t.Parallel()
+
+	recurrence := json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}}`)
+	now := time.Date(2026, time.April, 15, 10, 0, 0, 0, time.UTC)
+	createdBy := "550e8400-e29b-41d4-a716-446655440099"
+	reason := "initial weekly template"
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newTemplateVersionJoinRow(
+			"550e8400-e29b-41d4-a716-446655440010",
+			"550e8400-e29b-41d4-a716-446655440000",
+			now,
+			now,
+			"550e8400-e29b-41d4-a716-446655440020",
+			1,
+			time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+			recurrence,
+			now,
+			&createdBy,
+			&reason,
+		),
+	}}))
+
+	template, err := repo.CreateTemplate(context.Background(), CreateTemplateParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440000",
+		EffectiveFrom:  "2026-05-01",
+		Recurrence:     recurrence,
+		CreatedBy:      &createdBy,
+		Reason:         &reason,
+	})
+	if err != nil {
+		t.Fatalf("CreateTemplate error = %v", err)
+	}
+	if template.ID != "550e8400-e29b-41d4-a716-446655440010" {
+		t.Fatalf("template id = %q, want template id", template.ID)
+	}
+	if template.ProfessionalID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("professional_id = %q, want own agenda id", template.ProfessionalID)
+	}
+	if len(template.Versions) != 1 {
+		t.Fatalf("versions len = %d, want 1", len(template.Versions))
+	}
+	if template.Versions[0].VersionNumber != 1 {
+		t.Fatalf("version number = %d, want 1", template.Versions[0].VersionNumber)
+	}
+	if string(template.Versions[0].Recurrence) != string(recurrence) {
+		t.Fatalf("recurrence = %s, want %s", template.Versions[0].Recurrence, recurrence)
+	}
+	if template.Versions[0].CreatedBy == nil || *template.Versions[0].CreatedBy != createdBy {
+		t.Fatalf("created_by = %v, want %q", template.Versions[0].CreatedBy, createdBy)
+	}
+}
+
+func TestGetTemplateReturnsNotFoundWhenTemplateMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{err: sql.ErrNoRows}}))
+
+	_, err := repo.GetTemplate(context.Background(), "550e8400-e29b-41d4-a716-446655440010")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func TestCreateTemplateRejectsInvalidRecurrencePayload(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, nil))
+
+	_, err := repo.CreateTemplate(context.Background(), CreateTemplateParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440000",
+		EffectiveFrom:  "2026-05-01",
+		Recurrence:     json.RawMessage(`[]`),
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+}
+
+func TestGetTemplateReturnsTemplate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 15, 10, 0, 0, 0, time.UTC)
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: []driver.Value{"550e8400-e29b-41d4-a716-446655440010", "550e8400-e29b-41d4-a716-446655440000", now, now},
+	}}))
+
+	template, err := repo.GetTemplate(context.Background(), "550e8400-e29b-41d4-a716-446655440010")
+	if err != nil {
+		t.Fatalf("GetTemplate error = %v", err)
+	}
+	if template.ProfessionalID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("professional_id = %q, want own agenda id", template.ProfessionalID)
+	}
+	if !template.CreatedAt.Equal(now) {
+		t.Fatalf("created_at = %s, want %s", template.CreatedAt, now)
+	}
+}
+
+func TestListTemplateVersionsReturnsOrderedVersions(t *testing.T) {
+	t.Parallel()
+
+	firstCreatedBy := "550e8400-e29b-41d4-a716-446655440099"
+	secondReason := "hours extended"
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		rows: [][]driver.Value{
+			newTemplateVersionRow(
+				"550e8400-e29b-41d4-a716-446655440021",
+				"550e8400-e29b-41d4-a716-446655440010",
+				2,
+				time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+				json.RawMessage(`{"monday":{"start_time":"08:00","end_time":"12:00","slot_duration_minutes":30}}`),
+				time.Date(2026, time.April, 20, 10, 0, 0, 0, time.UTC),
+				nil,
+				&secondReason,
+			),
+			newTemplateVersionRow(
+				"550e8400-e29b-41d4-a716-446655440020",
+				"550e8400-e29b-41d4-a716-446655440010",
+				1,
+				time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+				json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}}`),
+				time.Date(2026, time.April, 15, 10, 0, 0, 0, time.UTC),
+				&firstCreatedBy,
+				nil,
+			),
+		},
+	}}))
+
+	versions, err := repo.ListTemplateVersions(context.Background(), "550e8400-e29b-41d4-a716-446655440010")
+	if err != nil {
+		t.Fatalf("ListTemplateVersions error = %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("versions len = %d, want 2", len(versions))
+	}
+	if versions[0].VersionNumber != 2 || versions[1].VersionNumber != 1 {
+		t.Fatalf("version order = [%d %d], want [2 1]", versions[0].VersionNumber, versions[1].VersionNumber)
+	}
+	if versions[1].CreatedBy == nil || *versions[1].CreatedBy != firstCreatedBy {
+		t.Fatalf("created_by = %v, want %q", versions[1].CreatedBy, firstCreatedBy)
+	}
+	if versions[0].Reason == nil || *versions[0].Reason != secondReason {
+		t.Fatalf("reason = %v, want %q", versions[0].Reason, secondReason)
+	}
+}
+
+func TestListTemplateVersionsReturnsValidationOnBadTemplateID(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, nil))
+
+	_, err := repo.ListTemplateVersions(context.Background(), "bad-id")
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+}
+
+func TestGetActiveTemplateReturnsLatestVersionForEffectiveDate(t *testing.T) {
+	t.Parallel()
+
+	secondReason := "winter hours"
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newTemplateVersionRow(
+			"550e8400-e29b-41d4-a716-446655440021",
+			"550e8400-e29b-41d4-a716-446655440010",
+			2,
+			time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+			json.RawMessage(`{"monday":{"start_time":"08:00","end_time":"12:00","slot_duration_minutes":30}}`),
+			time.Date(2026, time.April, 20, 10, 0, 0, 0, time.UTC),
+			nil,
+			&secondReason,
+		),
+	}}))
+
+	version, err := repo.GetActiveTemplate(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "2026-06-01")
+	if err != nil {
+		t.Fatalf("GetActiveTemplate error = %v", err)
+	}
+	if version.VersionNumber != 2 {
+		t.Fatalf("version number = %d, want 2", version.VersionNumber)
+	}
+	if version.Reason == nil || *version.Reason != secondReason {
+		t.Fatalf("reason = %v, want %q", version.Reason, secondReason)
+	}
+	if version.TemplateID != "550e8400-e29b-41d4-a716-446655440010" {
+		t.Fatalf("template_id = %q, want template id", version.TemplateID)
+	}
+}
+
+func TestGetActiveTemplateReturnsNotFoundWhenNoVersionApplies(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{err: sql.ErrNoRows}}))
+
+	_, err := repo.GetActiveTemplate(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "2026-04-30")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func TestGetActiveTemplateReturnsValidationOnBadInputs(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, nil))
+
+	_, err := repo.GetActiveTemplate(context.Background(), "bad-id", "2026-06-01")
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("bad professional id err = %v, want %v", err, ErrValidation)
+	}
+
+	_, err = repo.GetActiveTemplate(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "06-01-2026")
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("bad effective date err = %v, want %v", err, ErrValidation)
+	}
+}
+
+func TestCreateScheduleBlockReturnsSingleScopeBlock(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 15, 12, 0, 0, 0, time.UTC)
+	blockDate := time.Date(2026, time.May, 5, 0, 0, 0, 0, time.UTC)
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newScheduleBlockRow(
+			"550e8400-e29b-41d4-a716-446655440301",
+			"550e8400-e29b-41d4-a716-446655440300",
+			"single",
+			&blockDate,
+			nil,
+			nil,
+			nil,
+			"09:00",
+			"12:00",
+			nil,
+			now,
+			now,
+		),
+	}}))
+
+	block, err := repo.CreateScheduleBlock(context.Background(), CreateScheduleBlockParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440300",
+		Scope:          "single",
+		BlockDate:      stringPtr("2026-05-05"),
+		StartTime:      "09:00",
+		EndTime:        "12:00",
+	})
+	if err != nil {
+		t.Fatalf("CreateScheduleBlock error = %v", err)
+	}
+	if block.Scope != "single" {
+		t.Fatalf("scope = %q, want single", block.Scope)
+	}
+	if block.BlockDate == nil || !block.BlockDate.Equal(blockDate) {
+		t.Fatalf("block_date = %v, want %s", block.BlockDate, blockDate)
+	}
+	if block.StartTime != "09:00" || block.EndTime != "12:00" {
+		t.Fatalf("time range = %s-%s, want 09:00-12:00", block.StartTime, block.EndTime)
+	}
+	if block.TemplateID != nil {
+		t.Fatalf("template_id = %v, want nil", block.TemplateID)
+	}
+}
+
+func TestCreateScheduleBlockRejectsInvalidTemplateScope(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, nil))
+
+	_, err := repo.CreateScheduleBlock(context.Background(), CreateScheduleBlockParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440300",
+		Scope:          "template",
+		DayOfWeek:      intPtr(1),
+		StartTime:      "10:00",
+		EndTime:        "11:00",
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+}
+
+func TestListScheduleBlocksReturnsOrderedBlocks(t *testing.T) {
+	t.Parallel()
+
+	firstDate := time.Date(2026, time.May, 8, 0, 0, 0, 0, time.UTC)
+	secondDate := time.Date(2026, time.May, 5, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, time.April, 15, 12, 0, 0, 0, time.UTC)
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		rows: [][]driver.Value{
+			newScheduleBlockRow("550e8400-e29b-41d4-a716-446655440302", "550e8400-e29b-41d4-a716-446655440300", "range", nil, &firstDate, &firstDate, nil, "13:00", "15:00", nil, now, now),
+			newScheduleBlockRow("550e8400-e29b-41d4-a716-446655440301", "550e8400-e29b-41d4-a716-446655440300", "single", &secondDate, nil, nil, nil, "09:00", "12:00", nil, now, now),
+		},
+	}}))
+
+	blocks, err := repo.ListScheduleBlocks(context.Background(), ScheduleBlockFilters{ProfessionalID: "550e8400-e29b-41d4-a716-446655440300"})
+	if err != nil {
+		t.Fatalf("ListScheduleBlocks error = %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("blocks len = %d, want 2", len(blocks))
+	}
+	if blocks[0].Scope != "range" || blocks[1].Scope != "single" {
+		t.Fatalf("block scopes = [%s %s], want [range single]", blocks[0].Scope, blocks[1].Scope)
+	}
+}
+
+func TestUpdateScheduleBlockReturnsTemplateScopeBlock(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 12, 0, 0, 0, time.UTC)
+	templateID := "550e8400-e29b-41d4-a716-446655440399"
+	dayOfWeek := 1
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newScheduleBlockRow(
+			"550e8400-e29b-41d4-a716-446655440301",
+			"550e8400-e29b-41d4-a716-446655440300",
+			"template",
+			nil,
+			nil,
+			nil,
+			&dayOfWeek,
+			"10:00",
+			"11:00",
+			&templateID,
+			now,
+			now,
+		),
+	}}))
+
+	block, err := repo.UpdateScheduleBlock(context.Background(), "550e8400-e29b-41d4-a716-446655440301", UpdateScheduleBlockParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440300",
+		Scope:          "template",
+		DayOfWeek:      &dayOfWeek,
+		StartTime:      "10:00",
+		EndTime:        "11:00",
+		TemplateID:     &templateID,
+	})
+	if err != nil {
+		t.Fatalf("UpdateScheduleBlock error = %v", err)
+	}
+	if block.DayOfWeek == nil || *block.DayOfWeek != 1 {
+		t.Fatalf("day_of_week = %v, want 1", block.DayOfWeek)
+	}
+	if block.TemplateID == nil || *block.TemplateID != templateID {
+		t.Fatalf("template_id = %v, want %q", block.TemplateID, templateID)
+	}
+}
+
+func TestDeleteScheduleBlockReturnsNotFoundWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{err: sql.ErrNoRows}}))
+
+	err := repo.DeleteScheduleBlock(context.Background(), "550e8400-e29b-41d4-a716-446655440301")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func stringPtr(value string) *string { return &value }
+
+func intPtr(value int) *int { return &value }
+
+func newScheduleBlockRow(id, professionalID, scope string, blockDate, startDate, endDate *time.Time, dayOfWeek *int, startTime, endTime string, templateID *string, createdAt, updatedAt time.Time) []driver.Value {
+	var blockDateValue any
+	if blockDate != nil {
+		blockDateValue = *blockDate
+	}
+
+	var startDateValue any
+	if startDate != nil {
+		startDateValue = *startDate
+	}
+
+	var endDateValue any
+	if endDate != nil {
+		endDateValue = *endDate
+	}
+
+	var dayOfWeekValue any
+	if dayOfWeek != nil {
+		dayOfWeekValue = int64(*dayOfWeek)
+	}
+
+	return []driver.Value{id, professionalID, scope, blockDateValue, startDateValue, endDateValue, dayOfWeekValue, startTime, endTime, nullableStringValue(templateID), createdAt, updatedAt}
+}
+
 func newScriptedDB(t *testing.T, results []scriptedQueryResult) *sql.DB {
 	t.Helper()
 
@@ -227,6 +615,22 @@ func newAppointmentRow(id, slotID, professionalID, patientID, status string, cre
 		cancelled = *cancelledAt
 	}
 	return []driver.Value{id, slotID, professionalID, patientID, status, createdAt, updatedAt, cancelled}
+}
+
+func newTemplateVersionJoinRow(templateID, professionalID string, templateCreatedAt, templateUpdatedAt time.Time, versionID string, versionNumber int, effectiveFrom time.Time, recurrence json.RawMessage, versionCreatedAt time.Time, createdBy, reason *string) []driver.Value {
+	return []driver.Value{templateID, professionalID, templateCreatedAt, templateUpdatedAt, versionID, versionNumber, effectiveFrom, []byte(recurrence), versionCreatedAt, nullableStringValue(createdBy), nullableStringValue(reason)}
+}
+
+func newTemplateVersionRow(id, templateID string, versionNumber int, effectiveFrom time.Time, recurrence json.RawMessage, createdAt time.Time, createdBy, reason *string) []driver.Value {
+	return []driver.Value{id, templateID, versionNumber, effectiveFrom, []byte(recurrence), createdAt, nullableStringValue(createdBy), nullableStringValue(reason)}
+}
+
+func nullableStringValue(value *string) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
 }
 
 type scriptedDriver struct {
@@ -267,7 +671,12 @@ func (c *scriptedConn) QueryContext(context.Context, string, []driver.NamedValue
 		return nil, result.err
 	}
 
-	return &scriptedRows{row: result.row}, nil
+	rows := result.rows
+	if len(rows) == 0 && result.row != nil {
+		rows = [][]driver.Value{result.row}
+	}
+
+	return &scriptedRows{rows: rows}, nil
 }
 
 type scriptedTx struct{}
@@ -276,31 +685,36 @@ func (scriptedTx) Commit() error   { return nil }
 func (scriptedTx) Rollback() error { return nil }
 
 type scriptedQueryResult struct {
-	row []driver.Value
-	err error
+	row  []driver.Value
+	rows [][]driver.Value
+	err  error
 }
 
 type scriptedRows struct {
-	row  []driver.Value
-	read bool
+	rows  [][]driver.Value
+	index int
 }
 
 func (r *scriptedRows) Columns() []string {
-	switch len(r.row) {
-	case 8:
-		return []string{"id", "slot_id", "professional_id", "patient_id", "status", "created_at", "updated_at", "cancelled_at"}
-	default:
-		return []string{"id", "professional_id", "start_time", "end_time", "status", "created_at", "updated_at"}
+	if len(r.rows) == 0 {
+		return []string{}
 	}
+
+	columns := make([]string, len(r.rows[0]))
+	for i := range columns {
+		columns[i] = fmt.Sprintf("col_%d", i)
+	}
+
+	return columns
 }
 
 func (r *scriptedRows) Close() error { return nil }
 
 func (r *scriptedRows) Next(dest []driver.Value) error {
-	if r.read {
+	if r.index >= len(r.rows) {
 		return io.EOF
 	}
-	copy(dest, r.row)
-	r.read = true
+	copy(dest, r.rows[r.index])
+	r.index++
 	return nil
 }

--- a/services/appointments-service/internal/appointments/schedule_blocks_migration_integration_test.go
+++ b/services/appointments-service/internal/appointments/schedule_blocks_migration_integration_test.go
@@ -1,0 +1,99 @@
+package appointments
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRepositoryIntegrationScheduleBlocksMigrationCreatesScopedConstraints(t *testing.T) {
+	_, db := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440130"
+	templateID := "550e8400-e29b-41d4-a716-446655440131"
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO schedule_templates (id, professional_id)
+		VALUES ($1, $2)
+	`, templateID, professionalID); err != nil {
+		t.Fatalf("seed schedule template: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name: "single scope",
+			query: `
+				INSERT INTO schedule_blocks (professional_id, scope, block_date, start_time, end_time)
+				VALUES ($1, 'single', '2026-05-05', '09:00', '12:00')
+			`,
+			args: []any{professionalID},
+		},
+		{
+			name: "range scope",
+			query: `
+				INSERT INTO schedule_blocks (professional_id, scope, start_date, end_date, start_time, end_time)
+				VALUES ($1, 'range', '2026-05-06', '2026-05-10', '13:00', '15:00')
+			`,
+			args: []any{professionalID},
+		},
+		{
+			name: "template scope",
+			query: `
+				INSERT INTO schedule_blocks (professional_id, scope, day_of_week, start_time, end_time, template_id)
+				VALUES ($1, 'template', 1, '10:00', '11:00', $2)
+			`,
+			args: []any{professionalID, templateID},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.ExecContext(ctx, tc.query, tc.args...); err != nil {
+				t.Fatalf("insert %s block: %v", tc.name, err)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name: "invalid scope value",
+			query: `
+				INSERT INTO schedule_blocks (professional_id, scope, block_date, start_time, end_time)
+				VALUES ($1, 'weekly', '2026-05-12', '09:00', '12:00')
+			`,
+			args: []any{professionalID},
+		},
+		{
+			name: "single scope without date",
+			query: `
+				INSERT INTO schedule_blocks (professional_id, scope, start_time, end_time)
+				VALUES ($1, 'single', '09:00', '12:00')
+			`,
+			args: []any{professionalID},
+		},
+		{
+			name: "template scope without template reference",
+			query: `
+				INSERT INTO schedule_blocks (professional_id, scope, day_of_week, start_time, end_time)
+				VALUES ($1, 'template', 1, '10:00', '11:00')
+			`,
+			args: []any{professionalID},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.ExecContext(ctx, tc.query, tc.args...); err == nil {
+				t.Fatalf("expected %s insert to fail", tc.name)
+			}
+		})
+	}
+
+	if got := countRows(t, db, "schedule_blocks"); got != 3 {
+		t.Fatalf("schedule blocks persisted = %d, want 3", got)
+	}
+}

--- a/services/appointments-service/internal/appointments/schedule_models.go
+++ b/services/appointments-service/internal/appointments/schedule_models.go
@@ -1,0 +1,40 @@
+package appointments
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type ScheduleTemplate struct {
+	ID             string                    `json:"id"`
+	ProfessionalID string                    `json:"professional_id"`
+	CreatedAt      time.Time                 `json:"created_at"`
+	UpdatedAt      time.Time                 `json:"updated_at"`
+	Versions       []ScheduleTemplateVersion `json:"versions,omitempty"`
+}
+
+type ScheduleTemplateVersion struct {
+	ID            string          `json:"id"`
+	TemplateID    string          `json:"template_id"`
+	VersionNumber int             `json:"version_number"`
+	EffectiveFrom time.Time       `json:"effective_from"`
+	Recurrence    json.RawMessage `json:"recurrence"`
+	CreatedAt     time.Time       `json:"created_at"`
+	CreatedBy     *string         `json:"created_by,omitempty"`
+	Reason        *string         `json:"reason,omitempty"`
+}
+
+type ScheduleBlock struct {
+	ID             string     `json:"id"`
+	ProfessionalID string     `json:"professional_id"`
+	Scope          string     `json:"scope"`
+	BlockDate      *time.Time `json:"block_date,omitempty"`
+	StartDate      *time.Time `json:"start_date,omitempty"`
+	EndDate        *time.Time `json:"end_date,omitempty"`
+	DayOfWeek      *int       `json:"day_of_week,omitempty"`
+	StartTime      string     `json:"start_time"`
+	EndTime        string     `json:"end_time"`
+	TemplateID     *string    `json:"template_id,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}

--- a/services/appointments-service/internal/appointments/schedule_models_test.go
+++ b/services/appointments-service/internal/appointments/schedule_models_test.go
@@ -1,0 +1,69 @@
+package appointments
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestScheduleTemplateModelMatchesSchemaContract(t *testing.T) {
+	t.Parallel()
+
+	templateType := reflect.TypeOf(ScheduleTemplate{})
+
+	assertField(t, templateType, "ID", reflect.TypeOf(""), "id")
+	assertField(t, templateType, "ProfessionalID", reflect.TypeOf(""), "professional_id")
+	assertField(t, templateType, "CreatedAt", reflect.TypeOf(time.Time{}), "created_at")
+	assertField(t, templateType, "UpdatedAt", reflect.TypeOf(time.Time{}), "updated_at")
+	assertField(t, templateType, "Versions", reflect.TypeOf([]ScheduleTemplateVersion{}), "versions,omitempty")
+}
+
+func TestScheduleTemplateVersionModelMatchesSchemaContract(t *testing.T) {
+	t.Parallel()
+
+	versionType := reflect.TypeOf(ScheduleTemplateVersion{})
+
+	assertField(t, versionType, "ID", reflect.TypeOf(""), "id")
+	assertField(t, versionType, "TemplateID", reflect.TypeOf(""), "template_id")
+	assertField(t, versionType, "VersionNumber", reflect.TypeOf(0), "version_number")
+	assertField(t, versionType, "EffectiveFrom", reflect.TypeOf(time.Time{}), "effective_from")
+	assertField(t, versionType, "Recurrence", reflect.TypeOf(json.RawMessage{}), "recurrence")
+	assertField(t, versionType, "CreatedAt", reflect.TypeOf(time.Time{}), "created_at")
+	assertField(t, versionType, "CreatedBy", reflect.TypeOf((*string)(nil)), "created_by,omitempty")
+	assertField(t, versionType, "Reason", reflect.TypeOf((*string)(nil)), "reason,omitempty")
+}
+
+func TestScheduleBlockModelMatchesSchemaContract(t *testing.T) {
+	t.Parallel()
+
+	blockType := reflect.TypeOf(ScheduleBlock{})
+
+	assertField(t, blockType, "ID", reflect.TypeOf(""), "id")
+	assertField(t, blockType, "ProfessionalID", reflect.TypeOf(""), "professional_id")
+	assertField(t, blockType, "Scope", reflect.TypeOf(""), "scope")
+	assertField(t, blockType, "BlockDate", reflect.TypeOf((*time.Time)(nil)), "block_date,omitempty")
+	assertField(t, blockType, "StartDate", reflect.TypeOf((*time.Time)(nil)), "start_date,omitempty")
+	assertField(t, blockType, "EndDate", reflect.TypeOf((*time.Time)(nil)), "end_date,omitempty")
+	assertField(t, blockType, "DayOfWeek", reflect.TypeOf((*int)(nil)), "day_of_week,omitempty")
+	assertField(t, blockType, "StartTime", reflect.TypeOf(""), "start_time")
+	assertField(t, blockType, "EndTime", reflect.TypeOf(""), "end_time")
+	assertField(t, blockType, "TemplateID", reflect.TypeOf((*string)(nil)), "template_id,omitempty")
+	assertField(t, blockType, "CreatedAt", reflect.TypeOf(time.Time{}), "created_at")
+	assertField(t, blockType, "UpdatedAt", reflect.TypeOf(time.Time{}), "updated_at")
+}
+
+func assertField(t *testing.T, typ reflect.Type, name string, wantType reflect.Type, wantJSONTag string) {
+	t.Helper()
+
+	field, ok := typ.FieldByName(name)
+	if !ok {
+		t.Fatalf("missing field %s", name)
+	}
+	if field.Type != wantType {
+		t.Fatalf("field %s type = %v, want %v", name, field.Type, wantType)
+	}
+	if got := field.Tag.Get("json"); got != wantJSONTag {
+		t.Fatalf("field %s json tag = %q, want %q", name, got, wantJSONTag)
+	}
+}

--- a/services/appointments-service/internal/appointments/service.go
+++ b/services/appointments-service/internal/appointments/service.go
@@ -1,0 +1,49 @@
+package appointments
+
+import "context"
+
+type scheduleRepository interface {
+	GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplateVersion, error)
+	GetTemplate(ctx context.Context, templateID string) (ScheduleTemplate, error)
+	ListTemplateVersions(ctx context.Context, templateID string) ([]ScheduleTemplateVersion, error)
+}
+
+type ScheduleService struct {
+	repo scheduleRepository
+}
+
+func NewScheduleService(repo scheduleRepository) *ScheduleService {
+	return &ScheduleService{repo: repo}
+}
+
+func (s *ScheduleService) GetSchedule(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplate, error) {
+	activeVersion, err := s.repo.GetActiveTemplate(ctx, professionalID, effectiveDate)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	template, err := s.repo.GetTemplate(ctx, activeVersion.TemplateID)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	template.Versions = []ScheduleTemplateVersion{activeVersion}
+
+	return template, nil
+}
+
+func (s *ScheduleService) ListTemplateVersions(ctx context.Context, templateID string) (ScheduleTemplate, error) {
+	template, err := s.repo.GetTemplate(ctx, templateID)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	versions, err := s.repo.ListTemplateVersions(ctx, templateID)
+	if err != nil {
+		return ScheduleTemplate{}, err
+	}
+
+	template.Versions = versions
+
+	return template, nil
+}

--- a/services/appointments-service/internal/appointments/service_test.go
+++ b/services/appointments-service/internal/appointments/service_test.go
@@ -1,0 +1,280 @@
+package appointments
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestScheduleServiceGetScheduleReturnsActiveTemplateForDate(t *testing.T) {
+	t.Parallel()
+
+	activeVersion := ScheduleTemplateVersion{
+		ID:            "550e8400-e29b-41d4-a716-446655440021",
+		TemplateID:    "550e8400-e29b-41d4-a716-446655440010",
+		VersionNumber: 2,
+		EffectiveFrom: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+	}
+	baseTemplate := ScheduleTemplate{
+		ID:             activeVersion.TemplateID,
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440000",
+		CreatedAt:      time.Date(2026, time.April, 1, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, time.April, 20, 12, 0, 0, 0, time.UTC),
+		Versions: []ScheduleTemplateVersion{{
+			ID:            "550e8400-e29b-41d4-a716-446655440020",
+			TemplateID:    activeVersion.TemplateID,
+			VersionNumber: 1,
+		}},
+	}
+
+	repo := &stubScheduleRepository{
+		getActiveTemplateFn: func(_ context.Context, professionalID string, effectiveDate string) (ScheduleTemplateVersion, error) {
+			if professionalID != "550e8400-e29b-41d4-a716-446655440000" {
+				t.Fatalf("professionalID = %q, want expected professional", professionalID)
+			}
+			if effectiveDate != "2026-06-15" {
+				t.Fatalf("effectiveDate = %q, want %q", effectiveDate, "2026-06-15")
+			}
+			return activeVersion, nil
+		},
+		getTemplateFn: func(_ context.Context, templateID string) (ScheduleTemplate, error) {
+			if templateID != activeVersion.TemplateID {
+				t.Fatalf("templateID = %q, want active version template id", templateID)
+			}
+			return baseTemplate, nil
+		},
+	}
+
+	service := NewScheduleService(repo)
+
+	template, err := service.GetSchedule(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "2026-06-15")
+	if err != nil {
+		t.Fatalf("GetSchedule error = %v", err)
+	}
+	if repo.getActiveTemplateCalls != 1 {
+		t.Fatalf("GetActiveTemplate calls = %d, want 1", repo.getActiveTemplateCalls)
+	}
+	if repo.getTemplateCalls != 1 {
+		t.Fatalf("GetTemplate calls = %d, want 1", repo.getTemplateCalls)
+	}
+	if template.ID != activeVersion.TemplateID {
+		t.Fatalf("template id = %q, want %q", template.ID, activeVersion.TemplateID)
+	}
+	if len(template.Versions) != 1 {
+		t.Fatalf("versions len = %d, want 1", len(template.Versions))
+	}
+	if template.Versions[0].VersionNumber != activeVersion.VersionNumber {
+		t.Fatalf("version number = %d, want %d", template.Versions[0].VersionNumber, activeVersion.VersionNumber)
+	}
+}
+
+func TestScheduleServiceGetSchedulePropagatesLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		repoErr error
+	}{
+		{name: "validation", repoErr: ErrValidation},
+		{name: "not found", repoErr: ErrNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &stubScheduleRepository{
+				getActiveTemplateFn: func(context.Context, string, string) (ScheduleTemplateVersion, error) {
+					return ScheduleTemplateVersion{}, tt.repoErr
+				},
+			}
+
+			service := NewScheduleService(repo)
+
+			_, err := service.GetSchedule(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "2026-06-15")
+			if !errors.Is(err, tt.repoErr) {
+				t.Fatalf("err = %v, want %v", err, tt.repoErr)
+			}
+			if repo.getTemplateCalls != 0 {
+				t.Fatalf("GetTemplate calls = %d, want 0", repo.getTemplateCalls)
+			}
+		})
+	}
+}
+
+func TestScheduleServiceGetSchedulePropagatesTemplateLoadError(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubScheduleRepository{
+		getActiveTemplateFn: func(context.Context, string, string) (ScheduleTemplateVersion, error) {
+			return ScheduleTemplateVersion{
+				TemplateID: "550e8400-e29b-41d4-a716-446655440010",
+			}, nil
+		},
+		getTemplateFn: func(context.Context, string) (ScheduleTemplate, error) {
+			return ScheduleTemplate{}, ErrNotFound
+		},
+	}
+
+	service := NewScheduleService(repo)
+
+	_, err := service.GetSchedule(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "2026-06-15")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want %v", err, ErrNotFound)
+	}
+	if repo.getTemplateCalls != 1 {
+		t.Fatalf("GetTemplate calls = %d, want 1", repo.getTemplateCalls)
+	}
+}
+
+func TestScheduleServiceListTemplateVersionsReturnsTemplateHistory(t *testing.T) {
+	t.Parallel()
+
+	templateID := "550e8400-e29b-41d4-a716-446655440010"
+	template := ScheduleTemplate{
+		ID:             templateID,
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440000",
+	}
+	versions := []ScheduleTemplateVersion{{
+		ID:            "550e8400-e29b-41d4-a716-446655440021",
+		TemplateID:    templateID,
+		VersionNumber: 2,
+		EffectiveFrom: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+	}, {
+		ID:            "550e8400-e29b-41d4-a716-446655440020",
+		TemplateID:    templateID,
+		VersionNumber: 1,
+		EffectiveFrom: time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+	}}
+
+	repo := &stubScheduleRepository{
+		getTemplateFn: func(_ context.Context, gotTemplateID string) (ScheduleTemplate, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("templateID = %q, want %q", gotTemplateID, templateID)
+			}
+			return template, nil
+		},
+		listTemplateVersionsFn: func(_ context.Context, gotTemplateID string) ([]ScheduleTemplateVersion, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("templateID = %q, want %q", gotTemplateID, templateID)
+			}
+			return versions, nil
+		},
+	}
+
+	service := NewScheduleService(repo)
+
+	got, err := service.ListTemplateVersions(context.Background(), templateID)
+	if err != nil {
+		t.Fatalf("ListTemplateVersions error = %v", err)
+	}
+	if repo.getTemplateCalls != 1 {
+		t.Fatalf("GetTemplate calls = %d, want 1", repo.getTemplateCalls)
+	}
+	if repo.listTemplateVersionsCalls != 1 {
+		t.Fatalf("ListTemplateVersions calls = %d, want 1", repo.listTemplateVersionsCalls)
+	}
+	if got.ID != template.ID {
+		t.Fatalf("template id = %q, want %q", got.ID, template.ID)
+	}
+	if len(got.Versions) != len(versions) {
+		t.Fatalf("versions len = %d, want %d", len(got.Versions), len(versions))
+	}
+	if got.Versions[0].VersionNumber != 2 || got.Versions[1].VersionNumber != 1 {
+		t.Fatalf("version order = [%d %d], want [2 1]", got.Versions[0].VersionNumber, got.Versions[1].VersionNumber)
+	}
+}
+
+func TestScheduleServiceListTemplateVersionsPropagatesErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		getTemplateErr          error
+		listTemplateVersionsErr error
+		wantGetTemplateCalls    int
+		wantListTemplateCalls   int
+	}{
+		{
+			name:                  "template lookup validation error",
+			getTemplateErr:        ErrValidation,
+			wantGetTemplateCalls:  1,
+			wantListTemplateCalls: 0,
+		},
+		{
+			name:                    "list versions error",
+			listTemplateVersionsErr: ErrNotFound,
+			wantGetTemplateCalls:    1,
+			wantListTemplateCalls:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &stubScheduleRepository{
+				getTemplateFn: func(context.Context, string) (ScheduleTemplate, error) {
+					if tt.getTemplateErr != nil {
+						return ScheduleTemplate{}, tt.getTemplateErr
+					}
+					return ScheduleTemplate{ID: "550e8400-e29b-41d4-a716-446655440010"}, nil
+				},
+				listTemplateVersionsFn: func(context.Context, string) ([]ScheduleTemplateVersion, error) {
+					return nil, tt.listTemplateVersionsErr
+				},
+			}
+
+			service := NewScheduleService(repo)
+
+			_, err := service.ListTemplateVersions(context.Background(), "550e8400-e29b-41d4-a716-446655440010")
+			wantErr := tt.getTemplateErr
+			if wantErr == nil {
+				wantErr = tt.listTemplateVersionsErr
+			}
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("err = %v, want %v", err, wantErr)
+			}
+			if repo.getTemplateCalls != tt.wantGetTemplateCalls {
+				t.Fatalf("GetTemplate calls = %d, want %d", repo.getTemplateCalls, tt.wantGetTemplateCalls)
+			}
+			if repo.listTemplateVersionsCalls != tt.wantListTemplateCalls {
+				t.Fatalf("ListTemplateVersions calls = %d, want %d", repo.listTemplateVersionsCalls, tt.wantListTemplateCalls)
+			}
+		})
+	}
+}
+
+type stubScheduleRepository struct {
+	getActiveTemplateFn       func(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplateVersion, error)
+	getTemplateFn             func(ctx context.Context, templateID string) (ScheduleTemplate, error)
+	listTemplateVersionsFn    func(ctx context.Context, templateID string) ([]ScheduleTemplateVersion, error)
+	getActiveTemplateCalls    int
+	getTemplateCalls          int
+	listTemplateVersionsCalls int
+}
+
+func (s *stubScheduleRepository) GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplateVersion, error) {
+	s.getActiveTemplateCalls++
+	if s.getActiveTemplateFn == nil {
+		return ScheduleTemplateVersion{}, nil
+	}
+	return s.getActiveTemplateFn(ctx, professionalID, effectiveDate)
+}
+
+func (s *stubScheduleRepository) GetTemplate(ctx context.Context, templateID string) (ScheduleTemplate, error) {
+	s.getTemplateCalls++
+	if s.getTemplateFn == nil {
+		return ScheduleTemplate{}, nil
+	}
+	return s.getTemplateFn(ctx, templateID)
+}
+
+func (s *stubScheduleRepository) ListTemplateVersions(ctx context.Context, templateID string) ([]ScheduleTemplateVersion, error) {
+	s.listTemplateVersionsCalls++
+	if s.listTemplateVersionsFn == nil {
+		return nil, nil
+	}
+	return s.listTemplateVersionsFn(ctx, templateID)
+}

--- a/services/appointments-service/internal/http/server.go
+++ b/services/appointments-service/internal/http/server.go
@@ -11,6 +11,7 @@ import (
 
 	"clinic-platform/services/appointments-service/internal/appointments"
 	"clinic-platform/services/appointments-service/internal/directory"
+	"github.com/google/uuid"
 )
 
 type Config struct {
@@ -29,10 +30,22 @@ type Server struct {
 type appointmentsRepository interface {
 	CreateSlotsBulk(ctx context.Context, params appointments.BulkCreateSlotsParams) ([]appointments.AvailabilitySlot, error)
 	ListSlots(ctx context.Context, filters appointments.SlotFilters) ([]appointments.AvailabilitySlot, error)
+	CreateTemplate(ctx context.Context, params appointments.CreateTemplateParams) (appointments.ScheduleTemplate, error)
+	GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (appointments.ScheduleTemplateVersion, error)
+	GetTemplate(ctx context.Context, templateID string) (appointments.ScheduleTemplate, error)
+	ListTemplateVersions(ctx context.Context, templateID string) ([]appointments.ScheduleTemplateVersion, error)
 	CreateAppointment(ctx context.Context, params appointments.CreateAppointmentParams) (appointments.Appointment, error)
 	ListAppointments(ctx context.Context, filters appointments.AppointmentFilters) ([]appointments.Appointment, error)
 	GetAppointmentByID(ctx context.Context, appointmentID string) (appointments.Appointment, error)
 	CancelAppointment(ctx context.Context, appointmentID string) (appointments.Appointment, error)
+}
+
+type createScheduleRequest struct {
+	ProfessionalID string          `json:"professional_id"`
+	EffectiveFrom  string          `json:"effective_from"`
+	Recurrence     json.RawMessage `json:"recurrence"`
+	CreatedBy      *string         `json:"created_by,omitempty"`
+	Reason         *string         `json:"reason,omitempty"`
 }
 
 type directoryLookup interface {
@@ -69,6 +82,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/info", s.info)
 	s.mux.HandleFunc("/slots", s.slots)
 	s.mux.HandleFunc("/slots/bulk", s.bulkSlots)
+	s.mux.HandleFunc("/schedules", s.schedules)
+	s.mux.HandleFunc("/schedules/versions", s.scheduleVersions)
 	s.mux.HandleFunc("/appointments", s.appointments)
 	s.mux.HandleFunc("/appointments/", s.appointmentByIDAction)
 }
@@ -163,6 +178,26 @@ func (s *Server) appointments(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) schedules(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getSchedule(w, r)
+	case http.MethodPost:
+		s.createSchedule(w, r)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
+	}
+}
+
+func (s *Server) scheduleVersions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	s.getScheduleVersions(w, r)
+}
+
 func (s *Server) appointmentByIDAction(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPatch {
 		writeMethodNotAllowed(w, http.MethodPatch)
@@ -235,6 +270,140 @@ func (s *Server) listSlots(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"items": slots})
+}
+
+func (s *Server) createSchedule(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+	if actor.Role == "secretary" {
+		writeError(w, http.StatusForbidden, "insufficient role")
+		return
+	}
+
+	var request createScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	request.ProfessionalID, ok = enforceProfessionalScope(actor, request.ProfessionalID)
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	params := appointments.CreateTemplateParams{
+		ProfessionalID: request.ProfessionalID,
+		EffectiveFrom:  request.EffectiveFrom,
+		Recurrence:     request.Recurrence,
+		CreatedBy:      request.CreatedBy,
+		Reason:         request.Reason,
+	}
+	if err := validateCreateScheduleRequest(params); errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid schedule request")
+		return
+	}
+
+	professionalExists, err := s.dir.ProfessionalExists(r.Context(), params.ProfessionalID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+	if !professionalExists {
+		writeError(w, http.StatusBadRequest, "professional not found")
+		return
+	}
+
+	template, err := s.repo.CreateTemplate(r.Context(), params)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid schedule request")
+		return
+	}
+	if errors.Is(err, appointments.ErrConflict) {
+		writeError(w, http.StatusConflict, "schedule version already exists for effective date")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create schedule")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, template)
+}
+
+func (s *Server) getSchedule(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	professionalID, ok := enforceProfessionalScope(actor, r.URL.Query().Get("professional_id"))
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	effectiveDate := strings.TrimSpace(r.URL.Query().Get("effective_date"))
+	schedule, err := appointments.NewScheduleService(s.repo).GetSchedule(r.Context(), professionalID, effectiveDate)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid schedule filters")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "schedule not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load schedule")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, schedule)
+}
+
+func (s *Server) getScheduleVersions(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	templateID := strings.TrimSpace(r.URL.Query().Get("template_id"))
+	template, err := s.repo.GetTemplate(r.Context(), templateID)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid schedule filters")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "schedule not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load schedule versions")
+		return
+	}
+
+	if _, ok := enforceProfessionalScope(actor, template.ProfessionalID); !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	versions, err := s.repo.ListTemplateVersions(r.Context(), templateID)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid schedule filters")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "schedule not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load schedule versions")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"items": versions})
 }
 
 func (s *Server) createAppointment(w http.ResponseWriter, r *http.Request) {
@@ -337,6 +506,28 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 	w.WriteHeader(status)
 
 	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func validateCreateScheduleRequest(params appointments.CreateTemplateParams) error {
+	if _, err := uuid.Parse(strings.TrimSpace(params.ProfessionalID)); err != nil {
+		return appointments.ErrValidation
+	}
+	if _, err := time.Parse("2006-01-02", strings.TrimSpace(params.EffectiveFrom)); err != nil {
+		return appointments.ErrValidation
+	}
+	if !json.Valid(params.Recurrence) {
+		return appointments.ErrValidation
+	}
+	var recurrence map[string]any
+	if err := json.Unmarshal(params.Recurrence, &recurrence); err != nil || recurrence == nil {
+		return appointments.ErrValidation
+	}
+	if params.CreatedBy != nil {
+		if _, err := uuid.Parse(strings.TrimSpace(*params.CreatedBy)); err != nil {
+			return appointments.ErrValidation
+		}
+	}
+	return nil
 }
 
 func writeUnauthorized(w http.ResponseWriter) {

--- a/services/appointments-service/internal/http/server_test.go
+++ b/services/appointments-service/internal/http/server_test.go
@@ -302,6 +302,476 @@ func TestCancelAppointmentReturnsAppointment(t *testing.T) {
 	}
 }
 
+func TestCreateSchedulePostScenarios(t *testing.T) {
+	const (
+		validProfessionalID = "550e8400-e29b-41d4-a716-446655440002"
+		validCreatedBy      = "550e8400-e29b-41d4-a716-446655440099"
+	)
+
+	validBody := `{"professional_id":"` + validProfessionalID + `","effective_from":"2026-05-01","recurrence":{"days":[1,3],"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30},"created_by":"` + validCreatedBy + `","reason":"extended hours"}`
+	createdAt := time.Date(2026, time.April, 10, 9, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(5 * time.Minute)
+	createdBy := validCreatedBy
+	createdTemplate := appointments.ScheduleTemplate{
+		ID:             "550e8400-e29b-41d4-a716-446655440010",
+		ProfessionalID: validProfessionalID,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+		Versions: []appointments.ScheduleTemplateVersion{{
+			ID:            "550e8400-e29b-41d4-a716-446655440011",
+			TemplateID:    "550e8400-e29b-41d4-a716-446655440010",
+			VersionNumber: 1,
+			EffectiveFrom: time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+			Recurrence:    json.RawMessage(`{"days":[1,3],"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}`),
+			CreatedAt:     createdAt,
+			CreatedBy:     &createdBy,
+			Reason:        ptrToString("extended hours"),
+		}},
+	}
+
+	doctorProfessionalID := validProfessionalID
+
+	tests := []struct {
+		name                  string
+		body                  string
+		directory             stubDirectoryLookup
+		repoErr               error
+		repoTemplate          appointments.ScheduleTemplate
+		wantStatus            int
+		wantError             string
+		wantTemplate          *appointments.ScheduleTemplate
+		wantProfessionalCalls int
+		wantCreateRepoCalls   int
+	}{
+		{
+			name:                "invalid json body returns bad request",
+			body:                `{"professional_id":`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid json body",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name: "secretary cannot create schedules",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "secretary", Active: true},
+			},
+			wantStatus:          http.StatusForbidden,
+			wantError:           "insufficient role",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name:                "invalid request returns bad request",
+			body:                `{"professional_id":"not-a-uuid","effective_from":"2026-05-01","recurrence":{"days":[1]}}`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid schedule request",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name: "doctor scope is enforced before create",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				currentUser:        directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+				professionalExists: true,
+			},
+			repoTemplate:          createdTemplate,
+			wantStatus:            http.StatusCreated,
+			wantTemplate:          &createdTemplate,
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "directory failure returns service unavailable",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalErr: directory.ErrUnavailable,
+			},
+			wantStatus:            http.StatusServiceUnavailable,
+			wantError:             "directory service unavailable",
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   0,
+		},
+		{
+			name: "missing professional returns bad request",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: false,
+			},
+			wantStatus:            http.StatusBadRequest,
+			wantError:             "professional not found",
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   0,
+		},
+		{
+			name: "repo validation error returns bad request",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+			},
+			repoErr:               appointments.ErrValidation,
+			wantStatus:            http.StatusBadRequest,
+			wantError:             "invalid schedule request",
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "repo conflict returns conflict",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+			},
+			repoErr:               appointments.ErrConflict,
+			wantStatus:            http.StatusConflict,
+			wantError:             "schedule version already exists for effective date",
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "success returns created schedule",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+			},
+			repoTemplate:          createdTemplate,
+			wantStatus:            http.StatusCreated,
+			wantTemplate:          &createdTemplate,
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.directory
+			repo := &stubAppointmentsRepository{
+				createTemplateFn: func(_ context.Context, params appointments.CreateTemplateParams) (appointments.ScheduleTemplate, error) {
+					if params.ProfessionalID != validProfessionalID {
+						t.Fatalf("professional_id = %q, want %q", params.ProfessionalID, validProfessionalID)
+					}
+					if params.EffectiveFrom != "2026-05-01" {
+						t.Fatalf("effective_from = %q, want %q", params.EffectiveFrom, "2026-05-01")
+					}
+					if string(params.Recurrence) != `{"days":[1,3],"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}` {
+						t.Fatalf("recurrence = %s, want expected recurrence", params.Recurrence)
+					}
+					if params.CreatedBy == nil || *params.CreatedBy != validCreatedBy {
+						t.Fatalf("created_by = %v, want %q", params.CreatedBy, validCreatedBy)
+					}
+					if params.Reason == nil || *params.Reason != "extended hours" {
+						t.Fatalf("reason = %v, want %q", params.Reason, "extended hours")
+					}
+					return tt.repoTemplate, tt.repoErr
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &dir)
+			recorder := httptest.NewRecorder()
+			request := newAuthenticatedRequest(http.MethodPost, "/schedules", bytes.NewBufferString(tt.body))
+
+			server.ServeHTTP(recorder, request)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if dir.professionalCalls != tt.wantProfessionalCalls {
+				t.Fatalf("ProfessionalExists calls = %d, want %d", dir.professionalCalls, tt.wantProfessionalCalls)
+			}
+			if repo.createTemplateCalls != tt.wantCreateRepoCalls {
+				t.Fatalf("CreateTemplate calls = %d, want %d", repo.createTemplateCalls, tt.wantCreateRepoCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.ScheduleTemplate
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != tt.wantTemplate.ID || response.ProfessionalID != tt.wantTemplate.ProfessionalID || len(response.Versions) != len(tt.wantTemplate.Versions) {
+				t.Fatalf("response = %+v, want %+v", response, *tt.wantTemplate)
+			}
+		})
+	}
+}
+
+func TestGetScheduleScenarios(t *testing.T) {
+	const validProfessionalID = "550e8400-e29b-41d4-a716-446655440002"
+
+	schedule := appointments.ScheduleTemplate{
+		ID:             "550e8400-e29b-41d4-a716-446655440010",
+		ProfessionalID: validProfessionalID,
+		CreatedAt:      time.Date(2026, time.April, 1, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, time.April, 20, 12, 0, 0, 0, time.UTC),
+		Versions: []appointments.ScheduleTemplateVersion{{
+			ID:            "550e8400-e29b-41d4-a716-446655440011",
+			TemplateID:    "550e8400-e29b-41d4-a716-446655440010",
+			VersionNumber: 2,
+			EffectiveFrom: time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+			Recurrence:    json.RawMessage(`{"days":[1,3],"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}`),
+		}},
+	}
+
+	doctorProfessionalID := validProfessionalID
+
+	tests := []struct {
+		name                 string
+		target               string
+		directory            stubDirectoryLookup
+		repoErr              error
+		repoSchedule         appointments.ScheduleTemplate
+		wantStatus           int
+		wantError            string
+		wantSchedule         *appointments.ScheduleTemplate
+		wantGetActiveCalls   int
+		wantGetTemplateCalls int
+	}{
+		{
+			name:               "invalid filters return bad request",
+			target:             "/schedules?professional_id=not-a-uuid&effective_date=2026-05-10",
+			wantStatus:         http.StatusBadRequest,
+			wantError:          "invalid schedule filters",
+			wantGetActiveCalls: 1,
+		},
+		{
+			name:   "doctor scope is enforced for get",
+			target: "/schedules?effective_date=2026-05-10",
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+			},
+			repoSchedule:         schedule,
+			wantStatus:           http.StatusOK,
+			wantSchedule:         &schedule,
+			wantGetActiveCalls:   1,
+			wantGetTemplateCalls: 1,
+		},
+		{
+			name:               "missing effective date returns bad request",
+			target:             "/schedules?professional_id=" + validProfessionalID,
+			wantStatus:         http.StatusBadRequest,
+			wantError:          "invalid schedule filters",
+			wantGetActiveCalls: 1,
+		},
+		{
+			name:               "not found returns not found",
+			target:             "/schedules?professional_id=" + validProfessionalID + "&effective_date=2026-05-10",
+			repoErr:            appointments.ErrNotFound,
+			wantStatus:         http.StatusNotFound,
+			wantError:          "schedule not found",
+			wantGetActiveCalls: 1,
+		},
+		{
+			name:                 "success returns schedule",
+			target:               "/schedules?professional_id=" + validProfessionalID + "&effective_date=2026-05-10",
+			repoSchedule:         schedule,
+			wantStatus:           http.StatusOK,
+			wantSchedule:         &schedule,
+			wantGetActiveCalls:   1,
+			wantGetTemplateCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubAppointmentsRepository{
+				getActiveTemplateFn: func(_ context.Context, professionalID string, effectiveDate string) (appointments.ScheduleTemplateVersion, error) {
+					if effectiveDate != "2026-05-10" {
+						return appointments.ScheduleTemplateVersion{}, appointments.ErrValidation
+					}
+					if professionalID != validProfessionalID {
+						return appointments.ScheduleTemplateVersion{}, appointments.ErrValidation
+					}
+					if tt.repoErr != nil {
+						return appointments.ScheduleTemplateVersion{}, tt.repoErr
+					}
+					return appointments.ScheduleTemplateVersion{TemplateID: tt.repoSchedule.ID}, nil
+				},
+				getTemplateFn: func(_ context.Context, templateID string) (appointments.ScheduleTemplate, error) {
+					if tt.repoErr != nil {
+						return appointments.ScheduleTemplate{}, tt.repoErr
+					}
+					if templateID != tt.repoSchedule.ID {
+						t.Fatalf("templateID = %q, want %q", templateID, tt.repoSchedule.ID)
+					}
+					return tt.repoSchedule, nil
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &tt.directory)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, tt.target, nil))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if repo.getActiveTemplateCalls != tt.wantGetActiveCalls {
+				t.Fatalf("GetActiveTemplate calls = %d, want %d", repo.getActiveTemplateCalls, tt.wantGetActiveCalls)
+			}
+			if repo.getTemplateCalls != tt.wantGetTemplateCalls {
+				t.Fatalf("GetTemplate calls = %d, want %d", repo.getTemplateCalls, tt.wantGetTemplateCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.ScheduleTemplate
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != tt.wantSchedule.ID || response.ProfessionalID != tt.wantSchedule.ProfessionalID || len(response.Versions) != 1 {
+				t.Fatalf("response = %+v, want %+v", response, *tt.wantSchedule)
+			}
+		})
+	}
+}
+
+func TestGetScheduleVersionsScenarios(t *testing.T) {
+	const validTemplateID = "550e8400-e29b-41d4-a716-446655440010"
+	const validProfessionalID = "550e8400-e29b-41d4-a716-446655440002"
+
+	versions := []appointments.ScheduleTemplateVersion{{
+		ID:            "550e8400-e29b-41d4-a716-446655440021",
+		TemplateID:    validTemplateID,
+		VersionNumber: 2,
+		EffectiveFrom: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		Recurrence:    json.RawMessage(`{"days":[1,3],"start_time":"08:00","end_time":"12:00","slot_duration_minutes":30}`),
+	}, {
+		ID:            "550e8400-e29b-41d4-a716-446655440020",
+		TemplateID:    validTemplateID,
+		VersionNumber: 1,
+		EffectiveFrom: time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+		Recurrence:    json.RawMessage(`{"days":[1,3],"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30}`),
+	}}
+	template := appointments.ScheduleTemplate{ID: validTemplateID, ProfessionalID: validProfessionalID, Versions: versions}
+	doctorProfessionalID := validProfessionalID
+	otherProfessionalID := "550e8400-e29b-41d4-a716-446655440099"
+
+	tests := []struct {
+		name                 string
+		target               string
+		directory            stubDirectoryLookup
+		repoTemplate         appointments.ScheduleTemplate
+		getTemplateErr       error
+		listVersionsErr      error
+		wantStatus           int
+		wantError            string
+		wantVersionCount     int
+		wantGetTemplateCalls int
+		wantListVersionCalls int
+	}{
+		{
+			name:                 "invalid template id returns bad request",
+			target:               "/schedules/versions?template_id=bad-id",
+			getTemplateErr:       appointments.ErrValidation,
+			wantStatus:           http.StatusBadRequest,
+			wantError:            "invalid schedule filters",
+			wantGetTemplateCalls: 1,
+		},
+		{
+			name:   "doctor scope is enforced for versions",
+			target: "/schedules/versions?template_id=" + validTemplateID,
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+			},
+			repoTemplate:         template,
+			wantStatus:           http.StatusOK,
+			wantVersionCount:     len(versions),
+			wantGetTemplateCalls: 1,
+			wantListVersionCalls: 1,
+		},
+		{
+			name:   "doctor cannot access another professionals history",
+			target: "/schedules/versions?template_id=" + validTemplateID,
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+			},
+			repoTemplate:         appointments.ScheduleTemplate{ID: validTemplateID, ProfessionalID: otherProfessionalID, Versions: versions},
+			wantStatus:           http.StatusForbidden,
+			wantError:            "forbidden professional scope",
+			wantGetTemplateCalls: 1,
+		},
+		{
+			name:                 "not found returns not found",
+			target:               "/schedules/versions?template_id=" + validTemplateID,
+			getTemplateErr:       appointments.ErrNotFound,
+			wantStatus:           http.StatusNotFound,
+			wantError:            "schedule not found",
+			wantGetTemplateCalls: 1,
+		},
+		{
+			name:                 "success returns versions",
+			target:               "/schedules/versions?template_id=" + validTemplateID,
+			repoTemplate:         template,
+			wantStatus:           http.StatusOK,
+			wantVersionCount:     len(versions),
+			wantGetTemplateCalls: 1,
+			wantListVersionCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubAppointmentsRepository{
+				getTemplateFn: func(_ context.Context, templateID string) (appointments.ScheduleTemplate, error) {
+					if templateID != validTemplateID && tt.getTemplateErr == nil {
+						t.Fatalf("templateID = %q, want %q", templateID, validTemplateID)
+					}
+					if tt.getTemplateErr != nil {
+						return appointments.ScheduleTemplate{}, tt.getTemplateErr
+					}
+					return appointments.ScheduleTemplate{ID: tt.repoTemplate.ID, ProfessionalID: tt.repoTemplate.ProfessionalID}, nil
+				},
+				listTemplateVersionsFn: func(_ context.Context, templateID string) ([]appointments.ScheduleTemplateVersion, error) {
+					if templateID != validTemplateID {
+						t.Fatalf("templateID = %q, want %q", templateID, validTemplateID)
+					}
+					if tt.listVersionsErr != nil {
+						return nil, tt.listVersionsErr
+					}
+					return tt.repoTemplate.Versions, nil
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &tt.directory)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, tt.target, nil))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if repo.getTemplateCalls != tt.wantGetTemplateCalls {
+				t.Fatalf("GetTemplate calls = %d, want %d", repo.getTemplateCalls, tt.wantGetTemplateCalls)
+			}
+			if repo.listTemplateVersionsCalls != tt.wantListVersionCalls {
+				t.Fatalf("ListTemplateVersions calls = %d, want %d", repo.listTemplateVersionsCalls, tt.wantListVersionCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response struct {
+				Items []appointments.ScheduleTemplateVersion `json:"items"`
+			}
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if len(response.Items) != tt.wantVersionCount {
+				t.Fatalf("items len = %d, want %d", len(response.Items), tt.wantVersionCount)
+			}
+			if response.Items[0].VersionNumber != tt.repoTemplate.Versions[0].VersionNumber {
+				t.Fatalf("first version = %d, want %d", response.Items[0].VersionNumber, tt.repoTemplate.Versions[0].VersionNumber)
+			}
+		})
+	}
+}
+
 func TestListSlotsReturnsBadRequestOnInvalidFilters(t *testing.T) {
 	repo := &stubAppointmentsRepository{
 		listSlotsFn: func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error) {
@@ -582,14 +1052,22 @@ func TestDoctorCancelChecksOwnershipBeforeMutation(t *testing.T) {
 }
 
 type stubAppointmentsRepository struct {
-	createSlotsBulkFn      func(context.Context, appointments.BulkCreateSlotsParams) ([]appointments.AvailabilitySlot, error)
-	listSlotsFn            func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error)
-	createAppointmentFn    func(context.Context, appointments.CreateAppointmentParams) (appointments.Appointment, error)
-	listAppointmentsFn     func(context.Context, appointments.AppointmentFilters) ([]appointments.Appointment, error)
-	getAppointmentByIDFn   func(context.Context, string) (appointments.Appointment, error)
-	cancelAppointmentFn    func(context.Context, string) (appointments.Appointment, error)
-	createAppointmentCalls int
-	cancelAppointmentCalls int
+	createSlotsBulkFn         func(context.Context, appointments.BulkCreateSlotsParams) ([]appointments.AvailabilitySlot, error)
+	listSlotsFn               func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error)
+	createTemplateFn          func(context.Context, appointments.CreateTemplateParams) (appointments.ScheduleTemplate, error)
+	getActiveTemplateFn       func(context.Context, string, string) (appointments.ScheduleTemplateVersion, error)
+	getTemplateFn             func(context.Context, string) (appointments.ScheduleTemplate, error)
+	listTemplateVersionsFn    func(context.Context, string) ([]appointments.ScheduleTemplateVersion, error)
+	createAppointmentFn       func(context.Context, appointments.CreateAppointmentParams) (appointments.Appointment, error)
+	listAppointmentsFn        func(context.Context, appointments.AppointmentFilters) ([]appointments.Appointment, error)
+	getAppointmentByIDFn      func(context.Context, string) (appointments.Appointment, error)
+	cancelAppointmentFn       func(context.Context, string) (appointments.Appointment, error)
+	createTemplateCalls       int
+	getActiveTemplateCalls    int
+	getTemplateCalls          int
+	listTemplateVersionsCalls int
+	createAppointmentCalls    int
+	cancelAppointmentCalls    int
 }
 
 type stubDirectoryLookup struct {
@@ -645,6 +1123,38 @@ func (s *stubAppointmentsRepository) ListSlots(ctx context.Context, filters appo
 	return s.listSlotsFn(ctx, filters)
 }
 
+func (s *stubAppointmentsRepository) CreateTemplate(ctx context.Context, params appointments.CreateTemplateParams) (appointments.ScheduleTemplate, error) {
+	s.createTemplateCalls++
+	if s.createTemplateFn == nil {
+		return appointments.ScheduleTemplate{}, errors.New("unexpected CreateTemplate call")
+	}
+	return s.createTemplateFn(ctx, params)
+}
+
+func (s *stubAppointmentsRepository) GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (appointments.ScheduleTemplateVersion, error) {
+	s.getActiveTemplateCalls++
+	if s.getActiveTemplateFn == nil {
+		return appointments.ScheduleTemplateVersion{}, errors.New("unexpected GetActiveTemplate call")
+	}
+	return s.getActiveTemplateFn(ctx, professionalID, effectiveDate)
+}
+
+func (s *stubAppointmentsRepository) GetTemplate(ctx context.Context, templateID string) (appointments.ScheduleTemplate, error) {
+	s.getTemplateCalls++
+	if s.getTemplateFn == nil {
+		return appointments.ScheduleTemplate{}, errors.New("unexpected GetTemplate call")
+	}
+	return s.getTemplateFn(ctx, templateID)
+}
+
+func (s *stubAppointmentsRepository) ListTemplateVersions(ctx context.Context, templateID string) ([]appointments.ScheduleTemplateVersion, error) {
+	s.listTemplateVersionsCalls++
+	if s.listTemplateVersionsFn == nil {
+		return nil, errors.New("unexpected ListTemplateVersions call")
+	}
+	return s.listTemplateVersionsFn(ctx, templateID)
+}
+
 func (s *stubAppointmentsRepository) CreateAppointment(ctx context.Context, params appointments.CreateAppointmentParams) (appointments.Appointment, error) {
 	s.createAppointmentCalls++
 	if s.createAppointmentFn == nil {
@@ -697,4 +1207,8 @@ func newAuthenticatedRequest(method, target string, body io.Reader) *http.Reques
 
 func testAppointmentsConfig() Config {
 	return Config{ServiceName: "appointments-service", Version: "test", Environment: "test"}
+}
+
+func ptrToString(value string) *string {
+	return &value
 }

--- a/services/appointments-service/migrations/005_schedule_blocks.sql
+++ b/services/appointments-service/migrations/005_schedule_blocks.sql
@@ -1,0 +1,36 @@
+-- Schedule blocks subtract availability from recurring templates or specific dates.
+-- Scope defines which date columns are valid for each block type.
+CREATE TABLE schedule_blocks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    professional_id UUID NOT NULL,
+    scope TEXT NOT NULL,
+    block_date DATE,
+    start_date DATE,
+    end_date DATE,
+    day_of_week SMALLINT,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    template_id UUID REFERENCES schedule_templates(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT schedule_blocks_scope_valid CHECK (scope IN ('single', 'range', 'template')),
+    CONSTRAINT schedule_blocks_time_range_valid CHECK (start_time < end_time),
+    CONSTRAINT schedule_blocks_day_of_week_valid CHECK (day_of_week IS NULL OR day_of_week BETWEEN 1 AND 7),
+    CONSTRAINT schedule_blocks_scope_columns_valid CHECK (
+        (scope = 'single' AND block_date IS NOT NULL AND start_date IS NULL AND end_date IS NULL AND day_of_week IS NULL AND template_id IS NULL) OR
+        (scope = 'range' AND block_date IS NULL AND start_date IS NOT NULL AND end_date IS NOT NULL AND start_date <= end_date AND day_of_week IS NULL AND template_id IS NULL) OR
+        (scope = 'template' AND block_date IS NULL AND start_date IS NULL AND end_date IS NULL AND day_of_week IS NOT NULL AND template_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX schedule_blocks_professional_scope_idx
+    ON schedule_blocks (professional_id, scope);
+
+CREATE INDEX schedule_blocks_professional_block_date_idx
+    ON schedule_blocks (professional_id, block_date);
+
+CREATE INDEX schedule_blocks_professional_range_idx
+    ON schedule_blocks (professional_id, start_date, end_date);
+
+CREATE INDEX schedule_blocks_template_idx
+    ON schedule_blocks (template_id);


### PR DESCRIPTION
Closes #33

## Summary
- complete the phase 1 schedule template and block foundation inside appointments-service
- add effective-dated schedule resolution plus schedule service and HTTP endpoints
- extend repository, integration, and HTTP coverage for the new schedule workflows

## Changes
| File | Change |
|------|--------|
| services/appointments-service/internal/appointments/schedule_models.go | Added schedule template, version, and block models |
| services/appointments-service/internal/appointments/repository.go | Added template and block repository methods plus effective-dated lookup |
| services/appointments-service/internal/appointments/service.go | Added schedule service for active schedule and version history flows |
| services/appointments-service/internal/http/server.go | Added schedules POST/GET and schedules versions GET endpoints |
| services/appointments-service/migrations/005_schedule_blocks.sql | Added schedule block schema and constraints |
| services/appointments-service/internal/appointments test files | Added focused unit and integration coverage for models, repository, migrations, and service behavior |
| services/appointments-service/internal/http/server_test.go | Added HTTP handler coverage for schedule endpoints |

## Test Plan
- [x] Ran go test in services/appointments-service/internal/appointments
- [x] Ran focused repository and service tests for schedule templates, blocks, and effective-dated lookups
- [x] Ran go test in services/appointments-service/internal/http

## Contributor Checklist
- [x] Linked an approved issue
- [x] Conventional commit format used
- [x] No Co-Authored-By trailers added
