### PR TITLE
feat: add weekly schedule template flow with consultations-based agenda

### DIFF
--- a/services/appointments-service/internal/appointments/appointment_consultation_compatibility_integration_test.go
+++ b/services/appointments-service/internal/appointments/appointment_consultation_compatibility_integration_test.go
@@ -1,0 +1,200 @@
+package appointments
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRepositoryIntegrationLegacyAppointmentsRemainFunctionalAfterConsultationMigration(t *testing.T) {
+	repo, db := newPostgresConsultationIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440401"
+	patientID := "550e8400-e29b-41d4-a716-446655440402"
+
+	slots, err := repo.CreateSlotsBulk(ctx, BulkCreateSlotsParams{
+		ProfessionalID:      professionalID,
+		Date:                "2026-04-20",
+		StartTime:           "09:00",
+		EndTime:             "09:30",
+		SlotDurationMinutes: 30,
+	})
+	if err != nil {
+		t.Fatalf("create slots: %v", err)
+	}
+	if len(slots) != 1 {
+		t.Fatalf("slots len = %d, want 1", len(slots))
+	}
+
+	created, err := repo.CreateAppointment(ctx, CreateAppointmentParams{
+		SlotID:         slots[0].ID,
+		PatientID:      patientID,
+		ProfessionalID: professionalID,
+	})
+	if err != nil {
+		t.Fatalf("create appointment through legacy flow: %v", err)
+	}
+	if created.Status != "booked" {
+		t.Fatalf("created status = %q, want booked", created.Status)
+	}
+
+	persisted := fetchConsultationRecord(t, db, created.ID)
+	if persisted.Status != "scheduled" {
+		t.Fatalf("persisted consultation status = %q, want scheduled", persisted.Status)
+	}
+	if persisted.Source != "secretary" {
+		t.Fatalf("persisted consultation source = %q, want secretary", persisted.Source)
+	}
+
+	fetched, err := repo.GetAppointmentByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get appointment by id through legacy flow: %v", err)
+	}
+	if fetched.Status != "booked" {
+		t.Fatalf("fetched status = %q, want booked", fetched.Status)
+	}
+
+	listed, err := repo.ListAppointments(ctx, AppointmentFilters{ProfessionalID: professionalID})
+	if err != nil {
+		t.Fatalf("list appointments through legacy flow: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("listed len = %d, want 1", len(listed))
+	}
+	if listed[0].Status != "booked" {
+		t.Fatalf("listed status = %q, want booked", listed[0].Status)
+	}
+
+	cancelled, err := repo.CancelAppointment(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("cancel appointment through legacy flow: %v", err)
+	}
+	if cancelled.Status != "cancelled" {
+		t.Fatalf("cancelled status = %q, want cancelled", cancelled.Status)
+	}
+	if cancelled.CancelledAt == nil {
+		t.Fatal("cancelled appointment missing cancelled_at")
+	}
+
+	reloaded := fetchConsultationRecord(t, db, created.ID)
+	if reloaded.Status != "cancelled" {
+		t.Fatalf("reloaded consultation status = %q, want cancelled", reloaded.Status)
+	}
+	if !reloaded.CancelledAt.Valid {
+		t.Fatal("reloaded consultation cancelled_at = NULL, want timestamp")
+	}
+
+	slot := fetchSlotByID(t, db, slots[0].ID)
+	if slot.Status != "available" {
+		t.Fatalf("slot status after cancellation = %q, want available", slot.Status)
+	}
+}
+
+func TestRepositoryIntegrationLegacyAppointmentsListScheduledConsultationsAsBooked(t *testing.T) {
+	repo, db := newPostgresConsultationIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440411"
+	patientID := "550e8400-e29b-41d4-a716-446655440412"
+	slotID := "550e8400-e29b-41d4-a716-446655440413"
+	start := time.Date(2026, time.April, 21, 10, 0, 0, 0, time.UTC)
+	end := start.Add(30 * time.Minute)
+
+	seedAvailabilitySlot(t, db, slotID, professionalID, start, end, "booked")
+
+	consultation, err := repo.CreateConsultation(ctx, CreateConsultationParams{
+		SlotID:         &slotID,
+		ProfessionalID: professionalID,
+		PatientID:      patientID,
+		Source:         ConsultationSourceDoctor,
+	})
+	if err != nil {
+		t.Fatalf("create consultation: %v", err)
+	}
+
+	fetched, err := repo.GetAppointmentByID(ctx, consultation.ID)
+	if err != nil {
+		t.Fatalf("get scheduled consultation through legacy flow: %v", err)
+	}
+	if fetched.Status != "booked" {
+		t.Fatalf("legacy fetched status = %q, want booked", fetched.Status)
+	}
+
+	listed, err := repo.ListAppointments(ctx, AppointmentFilters{ProfessionalID: professionalID, Status: "booked"})
+	if err != nil {
+		t.Fatalf("list scheduled consultation through legacy flow: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("listed len = %d, want 1", len(listed))
+	}
+	if listed[0].ID != consultation.ID {
+		t.Fatalf("listed consultation id = %q, want %q", listed[0].ID, consultation.ID)
+	}
+	if listed[0].Status != "booked" {
+		t.Fatalf("listed status = %q, want booked", listed[0].Status)
+	}
+}
+
+func TestRepositoryIntegrationLegacyAppointmentsRejectBlockedSlotsAfterConsultationMigration(t *testing.T) {
+	repo, db := newPostgresConsultationIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440421"
+	patientID := "550e8400-e29b-41d4-a716-446655440422"
+
+	template, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+		ProfessionalID: professionalID,
+		EffectiveFrom:  "2026-04-01",
+		Recurrence:     json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}}`),
+	})
+	if err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	_, err = repo.CreateScheduleBlock(ctx, CreateScheduleBlockParams{
+		ProfessionalID: professionalID,
+		Scope:          "template",
+		DayOfWeek:      intPtr(1),
+		StartTime:      "09:00",
+		EndTime:        "09:30",
+		TemplateID:     &template.ID,
+	})
+	if err != nil {
+		t.Fatalf("create schedule block: %v", err)
+	}
+
+	slots, err := repo.CreateSlotsBulk(ctx, BulkCreateSlotsParams{
+		ProfessionalID:      professionalID,
+		Date:                "2026-04-20",
+		StartTime:           "09:00",
+		EndTime:             "09:30",
+		SlotDurationMinutes: 30,
+	})
+	if err != nil {
+		t.Fatalf("create slots: %v", err)
+	}
+	if len(slots) != 1 {
+		t.Fatalf("slots len = %d, want 1", len(slots))
+	}
+
+	_, err = repo.CreateAppointment(ctx, CreateAppointmentParams{
+		SlotID:         slots[0].ID,
+		PatientID:      patientID,
+		ProfessionalID: professionalID,
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("create appointment err = %v, want %v", err, ErrConflict)
+	}
+
+	if got := countRows(t, db, "consultations"); got != 0 {
+		t.Fatalf("consultations persisted = %d, want 0", got)
+	}
+
+	slot := fetchSlotByID(t, db, slots[0].ID)
+	if slot.Status != "available" {
+		t.Fatalf("slot status after blocked booking attempt = %q, want available", slot.Status)
+	}
+}

--- a/services/appointments-service/internal/appointments/consultation_entity_migration_integration_test.go
+++ b/services/appointments-service/internal/appointments/consultation_entity_migration_integration_test.go
@@ -1,0 +1,175 @@
+package appointments
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestRepositoryIntegrationConsultationEntityMigrationRenamesAppointmentsAndPreservesBookings(t *testing.T) {
+	_, db := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440150"
+	bookedSlotID := "550e8400-e29b-41d4-a716-446655440151"
+	cancelledSlotID := "550e8400-e29b-41d4-a716-446655440152"
+	bookedAppointmentID := "550e8400-e29b-41d4-a716-446655440153"
+	cancelledAppointmentID := "550e8400-e29b-41d4-a716-446655440154"
+	bookedPatientID := "550e8400-e29b-41d4-a716-446655440155"
+	cancelledPatientID := "550e8400-e29b-41d4-a716-446655440156"
+
+	seedAvailabilitySlot(t, db, bookedSlotID, professionalID, time.Date(2026, 5, 5, 9, 0, 0, 0, time.UTC), time.Date(2026, 5, 5, 9, 30, 0, 0, time.UTC), "booked")
+	seedAvailabilitySlot(t, db, cancelledSlotID, professionalID, time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC), time.Date(2026, 5, 5, 10, 30, 0, 0, time.UTC), "cancelled")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO appointments (id, slot_id, professional_id, patient_id, status)
+		VALUES ($1, $2, $3, $4, 'booked')
+	`, bookedAppointmentID, bookedSlotID, professionalID, bookedPatientID); err != nil {
+		t.Fatalf("seed booked appointment: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO appointments (id, slot_id, professional_id, patient_id, status, cancelled_at)
+		VALUES ($1, $2, $3, $4, 'cancelled', NOW())
+	`, cancelledAppointmentID, cancelledSlotID, professionalID, cancelledPatientID); err != nil {
+		t.Fatalf("seed cancelled appointment: %v", err)
+	}
+
+	applySingleAppointmentsMigration(t, db, "006_consultation_entity.sql")
+
+	assertRelationExists(t, db, "consultations")
+	assertRelationMissing(t, db, "appointments")
+
+	booked := fetchConsultationRecord(t, db, bookedAppointmentID)
+	if booked.Status != "scheduled" {
+		t.Fatalf("booked migration status = %q, want scheduled", booked.Status)
+	}
+	if booked.Source != "secretary" {
+		t.Fatalf("booked migration source = %q, want secretary", booked.Source)
+	}
+	if booked.Notes.Valid {
+		t.Fatalf("booked migration notes = %q, want NULL", booked.Notes.String)
+	}
+
+	cancelled := fetchConsultationRecord(t, db, cancelledAppointmentID)
+	if cancelled.Status != "cancelled" {
+		t.Fatalf("cancelled migration status = %q, want cancelled", cancelled.Status)
+	}
+	if !cancelled.CancelledAt.Valid {
+		t.Fatal("cancelled migration cancelled_at = NULL, want timestamp")
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO consultations (slot_id, professional_id, patient_id, status, source)
+		VALUES ($1, $2, $3, 'checked_in', 'doctor')
+	`, cancelledSlotID, professionalID, "550e8400-e29b-41d4-a716-446655440157"); err != nil {
+		t.Fatalf("insert checked-in consultation: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO consultations (slot_id, professional_id, patient_id, status, source)
+		VALUES ($1, $2, $3, 'rescheduled', 'doctor')
+	`, cancelledSlotID, professionalID, "550e8400-e29b-41d4-a716-446655440158"); err == nil {
+		t.Fatal("expected invalid consultation status insert to fail")
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO consultations (slot_id, professional_id, patient_id, status, source)
+		VALUES ($1, $2, $3, 'scheduled', 'referral')
+	`, cancelledSlotID, professionalID, "550e8400-e29b-41d4-a716-446655440159"); err == nil {
+		t.Fatal("expected invalid consultation source insert to fail")
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO consultations (slot_id, professional_id, patient_id, status, source, cancelled_at)
+		VALUES ($1, $2, $3, 'cancelled', 'doctor', NOW())
+	`, bookedSlotID, professionalID, "550e8400-e29b-41d4-a716-446655440160"); err != nil {
+		t.Fatalf("insert cancelled consultation on scheduled slot: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO consultations (slot_id, professional_id, patient_id, status, source)
+		VALUES ($1, $2, $3, 'scheduled', 'doctor')
+	`, bookedSlotID, professionalID, "550e8400-e29b-41d4-a716-446655440161"); err == nil {
+		t.Fatal("expected duplicate scheduled consultation insert to fail")
+	}
+
+	if got := countRows(t, db, "consultations"); got != 4 {
+		t.Fatalf("consultations persisted = %d, want 4", got)
+	}
+}
+
+type consultationMigrationRecord struct {
+	Status      string
+	Source      string
+	Notes       sql.NullString
+	CancelledAt sql.NullTime
+}
+
+func applySingleAppointmentsMigration(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := db.ExecContext(ctx, readAppointmentsMigrationFile(t, name)); err != nil {
+		t.Fatalf("apply migration %s: %v", name, err)
+	}
+}
+
+func assertRelationExists(t *testing.T, db *sql.DB, relation string) {
+	t.Helper()
+
+	var got sql.NullString
+	if err := db.QueryRow(`SELECT to_regclass('public.' || $1)`, relation).Scan(&got); err != nil {
+		t.Fatalf("lookup relation %s: %v", relation, err)
+	}
+	if !got.Valid || got.String == "" {
+		t.Fatalf("relation %s missing", relation)
+	}
+}
+
+func assertRelationMissing(t *testing.T, db *sql.DB, relation string) {
+	t.Helper()
+
+	var got sql.NullString
+	if err := db.QueryRow(`SELECT to_regclass('public.' || $1)`, relation).Scan(&got); err != nil {
+		t.Fatalf("lookup relation %s: %v", relation, err)
+	}
+	if got.Valid && got.String != "" {
+		t.Fatalf("relation %s exists as %s, want missing", relation, got.String)
+	}
+}
+
+func fetchConsultationRecord(t *testing.T, db *sql.DB, consultationID string) consultationMigrationRecord {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var record consultationMigrationRecord
+	if err := db.QueryRowContext(ctx, `
+		SELECT status, source, notes, cancelled_at
+		FROM consultations
+		WHERE id = $1
+	`, consultationID).Scan(&record.Status, &record.Source, &record.Notes, &record.CancelledAt); err != nil {
+		t.Fatalf("fetch consultation %s: %v", consultationID, err)
+	}
+
+	return record
+}
+
+func seedAvailabilitySlot(t *testing.T, db *sql.DB, slotID string, professionalID string, start time.Time, end time.Time, status string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO availability_slots (id, professional_id, start_time, end_time, status)
+		VALUES ($1, $2, $3, $4, $5)
+	`, slotID, professionalID, start, end, status); err != nil {
+		t.Fatalf("seed slot %s: %v", slotID, err)
+	}
+}

--- a/services/appointments-service/internal/appointments/consultation_entity_migration_integration_test.go
+++ b/services/appointments-service/internal/appointments/consultation_entity_migration_integration_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRepositoryIntegrationConsultationEntityMigrationRenamesAppointmentsAndPreservesBookings(t *testing.T) {
-	_, db := newPostgresIntegrationRepository(t)
+	_, db := newPostgresLegacyAppointmentsIntegrationRepository(t)
 
 	ctx := context.Background()
 	professionalID := "550e8400-e29b-41d4-a716-446655440150"

--- a/services/appointments-service/internal/appointments/consultation_models.go
+++ b/services/appointments-service/internal/appointments/consultation_models.go
@@ -1,0 +1,79 @@
+package appointments
+
+import "time"
+
+type ConsultationStatus string
+
+const (
+	ConsultationStatusScheduled ConsultationStatus = "scheduled"
+	ConsultationStatusCheckedIn ConsultationStatus = "checked_in"
+	ConsultationStatusCompleted ConsultationStatus = "completed"
+	ConsultationStatusCancelled ConsultationStatus = "cancelled"
+	ConsultationStatusNoShow    ConsultationStatus = "no_show"
+)
+
+func (status ConsultationStatus) IsValid() bool {
+	switch status {
+	case ConsultationStatusScheduled,
+		ConsultationStatusCheckedIn,
+		ConsultationStatusCompleted,
+		ConsultationStatusCancelled,
+		ConsultationStatusNoShow:
+		return true
+	default:
+		return false
+	}
+}
+
+type ConsultationSource string
+
+type ConsultationActorRole string
+
+const (
+	ConsultationActorRoleSecretary ConsultationActorRole = "secretary"
+	ConsultationActorRoleDoctor    ConsultationActorRole = "doctor"
+)
+
+func (role ConsultationActorRole) IsValid() bool {
+	switch role {
+	case ConsultationActorRoleSecretary,
+		ConsultationActorRoleDoctor:
+		return true
+	default:
+		return false
+	}
+}
+
+const (
+	ConsultationSourceOnline    ConsultationSource = "online"
+	ConsultationSourceSecretary ConsultationSource = "secretary"
+	ConsultationSourceDoctor    ConsultationSource = "doctor"
+)
+
+func (source ConsultationSource) IsValid() bool {
+	switch source {
+	case ConsultationSourceOnline,
+		ConsultationSourceSecretary,
+		ConsultationSourceDoctor:
+		return true
+	default:
+		return false
+	}
+}
+
+type Consultation struct {
+	ID             string             `json:"id"`
+	SlotID         *string            `json:"slot_id,omitempty"`
+	ProfessionalID string             `json:"professional_id"`
+	PatientID      string             `json:"patient_id"`
+	Status         ConsultationStatus `json:"status"`
+	Source         ConsultationSource `json:"source"`
+	ScheduledStart time.Time          `json:"scheduled_start"`
+	ScheduledEnd   time.Time          `json:"scheduled_end"`
+	Notes          *string            `json:"notes,omitempty"`
+	CheckInTime    *time.Time         `json:"check_in_time,omitempty"`
+	ReceptionNotes *string            `json:"reception_notes,omitempty"`
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
+	CancelledAt    *time.Time         `json:"cancelled_at,omitempty"`
+}

--- a/services/appointments-service/internal/appointments/consultation_models_test.go
+++ b/services/appointments-service/internal/appointments/consultation_models_test.go
@@ -1,0 +1,154 @@
+package appointments
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestConsultationModelMatchesSchemaContract(t *testing.T) {
+	t.Parallel()
+
+	consultationType := reflect.TypeOf(Consultation{})
+
+	assertField(t, consultationType, "ID", reflect.TypeOf(""), "id")
+	assertField(t, consultationType, "ProfessionalID", reflect.TypeOf(""), "professional_id")
+	assertField(t, consultationType, "PatientID", reflect.TypeOf(""), "patient_id")
+	assertField(t, consultationType, "Status", reflect.TypeOf(ConsultationStatus("")), "status")
+	assertField(t, consultationType, "Source", reflect.TypeOf(ConsultationSource("")), "source")
+	assertField(t, consultationType, "SlotID", reflect.TypeOf((*string)(nil)), "slot_id,omitempty")
+	assertField(t, consultationType, "ScheduledStart", reflect.TypeOf(time.Time{}), "scheduled_start")
+	assertField(t, consultationType, "ScheduledEnd", reflect.TypeOf(time.Time{}), "scheduled_end")
+	assertField(t, consultationType, "Notes", reflect.TypeOf((*string)(nil)), "notes,omitempty")
+	assertField(t, consultationType, "CheckInTime", reflect.TypeOf((*time.Time)(nil)), "check_in_time,omitempty")
+	assertField(t, consultationType, "ReceptionNotes", reflect.TypeOf((*string)(nil)), "reception_notes,omitempty")
+	assertField(t, consultationType, "CreatedAt", reflect.TypeOf(time.Time{}), "created_at")
+	assertField(t, consultationType, "UpdatedAt", reflect.TypeOf(time.Time{}), "updated_at")
+	assertField(t, consultationType, "CancelledAt", reflect.TypeOf((*time.Time)(nil)), "cancelled_at,omitempty")
+}
+
+func TestConsultationJSONOptionalMetadata(t *testing.T) {
+	t.Parallel()
+
+	checkInTime := time.Date(2026, time.April, 16, 9, 45, 0, 0, time.UTC)
+	scheduledStart := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 10, 30, 0, 0, time.UTC)
+	slotID := "slot-123"
+	receptionNotes := "Paciente llegó temprano"
+
+	tests := []struct {
+		name         string
+		consultation Consultation
+		wantPresent  []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "nil metadata omitted",
+			consultation: Consultation{ScheduledStart: scheduledStart, ScheduledEnd: scheduledEnd},
+			wantAbsent:   []string{"slot_id", "check_in_time", "reception_notes"},
+			wantPresent:  []string{"scheduled_start", "scheduled_end"},
+		},
+		{
+			name: "optional metadata included when set",
+			consultation: Consultation{
+				SlotID:         &slotID,
+				ScheduledStart: scheduledStart,
+				ScheduledEnd:   scheduledEnd,
+				CheckInTime:    &checkInTime,
+				ReceptionNotes: &receptionNotes,
+			},
+			wantPresent: []string{"slot_id", "scheduled_start", "scheduled_end", "check_in_time", "reception_notes"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := marshalJSONMap(t, tt.consultation)
+
+			for _, key := range tt.wantPresent {
+				if _, ok := payload[key]; !ok {
+					t.Fatalf("expected key %q to be present", key)
+				}
+			}
+
+			for _, key := range tt.wantAbsent {
+				if _, ok := payload[key]; ok {
+					t.Fatalf("expected key %q to be omitted", key)
+				}
+			}
+		})
+	}
+}
+
+func TestConsultationStatusIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status ConsultationStatus
+		want   bool
+	}{
+		{name: "scheduled is valid", status: ConsultationStatusScheduled, want: true},
+		{name: "checked_in is valid", status: ConsultationStatusCheckedIn, want: true},
+		{name: "completed is valid", status: ConsultationStatusCompleted, want: true},
+		{name: "cancelled is valid", status: ConsultationStatusCancelled, want: true},
+		{name: "no_show is valid", status: ConsultationStatusNoShow, want: true},
+		{name: "legacy booked is invalid", status: ConsultationStatus("booked"), want: false},
+		{name: "empty is invalid", status: ConsultationStatus(""), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.status.IsValid(); got != tt.want {
+				t.Fatalf("IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsultationSourceIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source ConsultationSource
+		want   bool
+	}{
+		{name: "online is valid", source: ConsultationSourceOnline, want: true},
+		{name: "secretary is valid", source: ConsultationSourceSecretary, want: true},
+		{name: "doctor is valid", source: ConsultationSourceDoctor, want: true},
+		{name: "patient is invalid", source: ConsultationSource("patient"), want: false},
+		{name: "empty is invalid", source: ConsultationSource(""), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.source.IsValid(); got != tt.want {
+				t.Fatalf("IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func marshalJSONMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	return payload
+}

--- a/services/appointments-service/internal/appointments/consultation_repository_postgres_integration_test.go
+++ b/services/appointments-service/internal/appointments/consultation_repository_postgres_integration_test.go
@@ -1,0 +1,118 @@
+package appointments
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRepositoryIntegrationConsultationLifecyclePersistsOptionalMetadata(t *testing.T) {
+	repo, _ := newPostgresConsultationIntegrationRepository(t)
+
+	ctx := context.Background()
+	slotID := "550e8400-e29b-41d4-a716-446655440301"
+	professionalID := "550e8400-e29b-41d4-a716-446655440302"
+	patientID := "550e8400-e29b-41d4-a716-446655440303"
+	notes := "Trae resultados de laboratorio"
+	receptionNotes := "Paciente presente en recepción"
+	checkInTime := time.Date(2026, time.April, 16, 9, 55, 0, 0, time.UTC)
+	scheduledStart := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 10, 30, 0, 0, time.UTC)
+
+	seedAvailabilitySlot(t, repo.db, slotID, professionalID, scheduledStart, scheduledEnd, "available")
+
+	created, err := repo.CreateConsultation(ctx, CreateConsultationParams{
+		SlotID:         &slotID,
+		ProfessionalID: professionalID,
+		PatientID:      patientID,
+		Source:         ConsultationSourceSecretary,
+		Notes:          &notes,
+	})
+	if err != nil {
+		t.Fatalf("create consultation: %v", err)
+	}
+	if created.SlotID == nil || *created.SlotID != slotID {
+		t.Fatalf("created slot_id = %v, want %q", created.SlotID, slotID)
+	}
+	if created.Notes == nil || *created.Notes != notes {
+		t.Fatalf("created notes = %v, want %q", created.Notes, notes)
+	}
+	if !created.ScheduledStart.Equal(scheduledStart) {
+		t.Fatalf("created scheduled_start = %s, want %s", created.ScheduledStart, scheduledStart)
+	}
+	if !created.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("created scheduled_end = %s, want %s", created.ScheduledEnd, scheduledEnd)
+	}
+
+	persisted, err := repo.GetConsultation(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get consultation: %v", err)
+	}
+	if persisted.Status != ConsultationStatusScheduled {
+		t.Fatalf("persisted status = %q, want %q", persisted.Status, ConsultationStatusScheduled)
+	}
+	if !persisted.ScheduledStart.Equal(scheduledStart) || !persisted.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("persisted schedule = [%s %s], want [%s %s]", persisted.ScheduledStart, persisted.ScheduledEnd, scheduledStart, scheduledEnd)
+	}
+
+	updated, err := repo.UpdateConsultationStatus(ctx, created.ID, UpdateConsultationStatusParams{
+		Status:         ConsultationStatusCheckedIn,
+		CheckInTime:    &checkInTime,
+		ReceptionNotes: &receptionNotes,
+	})
+	if err != nil {
+		t.Fatalf("update consultation status: %v", err)
+	}
+	if updated.CheckInTime == nil || !updated.CheckInTime.Equal(checkInTime) {
+		t.Fatalf("updated check_in_time = %v, want %s", updated.CheckInTime, checkInTime)
+	}
+	if updated.ReceptionNotes == nil || *updated.ReceptionNotes != receptionNotes {
+		t.Fatalf("updated reception_notes = %v, want %q", updated.ReceptionNotes, receptionNotes)
+	}
+
+	reloaded, err := repo.GetConsultation(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("reload consultation: %v", err)
+	}
+	if reloaded.CheckInTime == nil || !reloaded.CheckInTime.Equal(checkInTime) {
+		t.Fatalf("reloaded check_in_time = %v, want %s", reloaded.CheckInTime, checkInTime)
+	}
+	if reloaded.ReceptionNotes == nil || *reloaded.ReceptionNotes != receptionNotes {
+		t.Fatalf("reloaded reception_notes = %v, want %q", reloaded.ReceptionNotes, receptionNotes)
+	}
+}
+
+func TestRepositoryIntegrationStandaloneConsultationPersistsScheduleRange(t *testing.T) {
+	repo, _ := newPostgresConsultationIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440311"
+	patientID := "550e8400-e29b-41d4-a716-446655440312"
+	scheduledStart := time.Date(2026, time.April, 16, 11, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 11, 20, 0, 0, time.UTC)
+
+	created, err := repo.CreateConsultation(ctx, CreateConsultationParams{
+		ProfessionalID: professionalID,
+		PatientID:      patientID,
+		Source:         ConsultationSourceDoctor,
+		ScheduledStart: &scheduledStart,
+		ScheduledEnd:   &scheduledEnd,
+	})
+	if err != nil {
+		t.Fatalf("create standalone consultation: %v", err)
+	}
+	if created.SlotID != nil {
+		t.Fatalf("created slot_id = %v, want nil", created.SlotID)
+	}
+	if !created.ScheduledStart.Equal(scheduledStart) || !created.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("created schedule = [%s %s], want [%s %s]", created.ScheduledStart, created.ScheduledEnd, scheduledStart, scheduledEnd)
+	}
+
+	persisted, err := repo.GetConsultation(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get standalone consultation: %v", err)
+	}
+	if !persisted.ScheduledStart.Equal(scheduledStart) || !persisted.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("persisted schedule = [%s %s], want [%s %s]", persisted.ScheduledStart, persisted.ScheduledEnd, scheduledStart, scheduledEnd)
+	}
+}

--- a/services/appointments-service/internal/appointments/consultation_repository_test.go
+++ b/services/appointments-service/internal/appointments/consultation_repository_test.go
@@ -1,0 +1,337 @@
+package appointments
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCreateConsultationReturnsScheduledConsultation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 9, 0, 0, 0, time.UTC)
+	slotID := "550e8400-e29b-41d4-a716-446655440201"
+	notes := "Paciente con estudios previos"
+	scheduledStart := time.Date(2026, time.April, 16, 9, 30, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newConsultationRow(
+			"550e8400-e29b-41d4-a716-446655440200",
+			&slotID,
+			"550e8400-e29b-41d4-a716-446655440202",
+			"550e8400-e29b-41d4-a716-446655440203",
+			ConsultationStatusScheduled,
+			ConsultationSourceSecretary,
+			&notes,
+			scheduledStart,
+			scheduledEnd,
+			nil,
+			nil,
+			now,
+			now,
+			nil,
+		),
+	}}))
+
+	consultation, err := repo.CreateConsultation(context.Background(), CreateConsultationParams{
+		SlotID:         &slotID,
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440202",
+		PatientID:      "550e8400-e29b-41d4-a716-446655440203",
+		Source:         ConsultationSourceSecretary,
+		Notes:          &notes,
+	})
+	if err != nil {
+		t.Fatalf("CreateConsultation error = %v", err)
+	}
+	if consultation.SlotID == nil || *consultation.SlotID != slotID {
+		t.Fatalf("slot_id = %v, want %q", consultation.SlotID, slotID)
+	}
+	if consultation.Status != ConsultationStatusScheduled {
+		t.Fatalf("status = %q, want %q", consultation.Status, ConsultationStatusScheduled)
+	}
+	if consultation.Source != ConsultationSourceSecretary {
+		t.Fatalf("source = %q, want %q", consultation.Source, ConsultationSourceSecretary)
+	}
+	if consultation.Notes == nil || *consultation.Notes != notes {
+		t.Fatalf("notes = %v, want %q", consultation.Notes, notes)
+	}
+	if !consultation.ScheduledStart.Equal(scheduledStart) {
+		t.Fatalf("scheduled_start = %s, want %s", consultation.ScheduledStart, scheduledStart)
+	}
+	if !consultation.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("scheduled_end = %s, want %s", consultation.ScheduledEnd, scheduledEnd)
+	}
+	if consultation.CheckInTime != nil {
+		t.Fatalf("check_in_time = %v, want nil", consultation.CheckInTime)
+	}
+	if consultation.ReceptionNotes != nil {
+		t.Fatalf("reception_notes = %v, want nil", consultation.ReceptionNotes)
+	}
+}
+
+func TestCreateConsultationRequiresStandaloneScheduleRangeWhenSlotMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, nil))
+
+	_, err := repo.CreateConsultation(context.Background(), CreateConsultationParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440211",
+		PatientID:      "550e8400-e29b-41d4-a716-446655440212",
+		Source:         ConsultationSourceDoctor,
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+}
+
+func TestCreateConsultationAllowsNilSlotIDWithStandaloneScheduleRange(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledStart := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 10, 20, 0, 0, time.UTC)
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newConsultationRow(
+			"550e8400-e29b-41d4-a716-446655440210",
+			nil,
+			"550e8400-e29b-41d4-a716-446655440211",
+			"550e8400-e29b-41d4-a716-446655440212",
+			ConsultationStatusScheduled,
+			ConsultationSourceDoctor,
+			nil,
+			scheduledStart,
+			scheduledEnd,
+			nil,
+			nil,
+			now,
+			now,
+			nil,
+		),
+	}}))
+
+	consultation, err := repo.CreateConsultation(context.Background(), CreateConsultationParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440211",
+		PatientID:      "550e8400-e29b-41d4-a716-446655440212",
+		Source:         ConsultationSourceDoctor,
+		ScheduledStart: &scheduledStart,
+		ScheduledEnd:   &scheduledEnd,
+	})
+	if err != nil {
+		t.Fatalf("CreateConsultation error = %v", err)
+	}
+	if consultation.SlotID != nil {
+		t.Fatalf("slot_id = %v, want nil", consultation.SlotID)
+	}
+	if consultation.Notes != nil {
+		t.Fatalf("notes = %v, want nil", consultation.Notes)
+	}
+	if !consultation.ScheduledStart.Equal(scheduledStart) {
+		t.Fatalf("scheduled_start = %s, want %s", consultation.ScheduledStart, scheduledStart)
+	}
+	if !consultation.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("scheduled_end = %s, want %s", consultation.ScheduledEnd, scheduledEnd)
+	}
+}
+
+func TestGetConsultationReturnsConsultation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 11, 0, 0, 0, time.UTC)
+	slotID := "550e8400-e29b-41d4-a716-446655440221"
+	scheduledStart := time.Date(2026, time.April, 16, 11, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 11, 30, 0, 0, time.UTC)
+	checkInTime := time.Date(2026, time.April, 16, 10, 45, 0, 0, time.UTC)
+	receptionNotes := "Paciente ya está en sala"
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newConsultationRow(
+			"550e8400-e29b-41d4-a716-446655440220",
+			&slotID,
+			"550e8400-e29b-41d4-a716-446655440222",
+			"550e8400-e29b-41d4-a716-446655440223",
+			ConsultationStatusCheckedIn,
+			ConsultationSourceOnline,
+			nil,
+			scheduledStart,
+			scheduledEnd,
+			&checkInTime,
+			&receptionNotes,
+			now,
+			now,
+			nil,
+		),
+	}}))
+
+	consultation, err := repo.GetConsultation(context.Background(), "550e8400-e29b-41d4-a716-446655440220")
+	if err != nil {
+		t.Fatalf("GetConsultation error = %v", err)
+	}
+	if consultation.CheckInTime == nil || !consultation.CheckInTime.Equal(checkInTime) {
+		t.Fatalf("check_in_time = %v, want %s", consultation.CheckInTime, checkInTime)
+	}
+	if !consultation.ScheduledStart.Equal(scheduledStart) {
+		t.Fatalf("scheduled_start = %s, want %s", consultation.ScheduledStart, scheduledStart)
+	}
+	if !consultation.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("scheduled_end = %s, want %s", consultation.ScheduledEnd, scheduledEnd)
+	}
+	if consultation.ReceptionNotes == nil || *consultation.ReceptionNotes != receptionNotes {
+		t.Fatalf("reception_notes = %v, want %q", consultation.ReceptionNotes, receptionNotes)
+	}
+}
+
+func TestGetConsultationReturnsNotFoundWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{err: sql.ErrNoRows}}))
+
+	_, err := repo.GetConsultation(context.Background(), "550e8400-e29b-41d4-a716-446655440230")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func TestUpdateConsultationStatusReturnsUpdatedConsultation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 12, 0, 0, 0, time.UTC)
+	slotID := "550e8400-e29b-41d4-a716-446655440241"
+	scheduledStart := time.Date(2026, time.April, 16, 12, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 12, 30, 0, 0, time.UTC)
+	checkInTime := time.Date(2026, time.April, 16, 11, 55, 0, 0, time.UTC)
+	receptionNotes := "Ingresó con 5 minutos de demora"
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newConsultationRow(
+			"550e8400-e29b-41d4-a716-446655440240",
+			&slotID,
+			"550e8400-e29b-41d4-a716-446655440242",
+			"550e8400-e29b-41d4-a716-446655440243",
+			ConsultationStatusCheckedIn,
+			ConsultationSourceSecretary,
+			nil,
+			scheduledStart,
+			scheduledEnd,
+			&checkInTime,
+			&receptionNotes,
+			now,
+			now,
+			nil,
+		),
+	}}))
+
+	consultation, err := repo.UpdateConsultationStatus(context.Background(), "550e8400-e29b-41d4-a716-446655440240", UpdateConsultationStatusParams{
+		Status:         ConsultationStatusCheckedIn,
+		CheckInTime:    &checkInTime,
+		ReceptionNotes: &receptionNotes,
+	})
+	if err != nil {
+		t.Fatalf("UpdateConsultationStatus error = %v", err)
+	}
+	if consultation.Status != ConsultationStatusCheckedIn {
+		t.Fatalf("status = %q, want %q", consultation.Status, ConsultationStatusCheckedIn)
+	}
+	if !consultation.ScheduledStart.Equal(scheduledStart) {
+		t.Fatalf("scheduled_start = %s, want %s", consultation.ScheduledStart, scheduledStart)
+	}
+	if !consultation.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("scheduled_end = %s, want %s", consultation.ScheduledEnd, scheduledEnd)
+	}
+	if consultation.CheckInTime == nil || !consultation.CheckInTime.Equal(checkInTime) {
+		t.Fatalf("check_in_time = %v, want %s", consultation.CheckInTime, checkInTime)
+	}
+	if consultation.ReceptionNotes == nil || *consultation.ReceptionNotes != receptionNotes {
+		t.Fatalf("reception_notes = %v, want %q", consultation.ReceptionNotes, receptionNotes)
+	}
+}
+
+func TestUpdateConsultationStatusClearsOptionalMetadataWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 13, 0, 0, 0, time.UTC)
+	scheduledStart := time.Date(2026, time.April, 16, 13, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 13, 30, 0, 0, time.UTC)
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newConsultationRow(
+			"550e8400-e29b-41d4-a716-446655440250",
+			nil,
+			"550e8400-e29b-41d4-a716-446655440251",
+			"550e8400-e29b-41d4-a716-446655440252",
+			ConsultationStatusCompleted,
+			ConsultationSourceDoctor,
+			nil,
+			scheduledStart,
+			scheduledEnd,
+			nil,
+			nil,
+			now,
+			now,
+			nil,
+		),
+	}}))
+
+	consultation, err := repo.UpdateConsultationStatus(context.Background(), "550e8400-e29b-41d4-a716-446655440250", UpdateConsultationStatusParams{
+		Status: ConsultationStatusCompleted,
+	})
+	if err != nil {
+		t.Fatalf("UpdateConsultationStatus error = %v", err)
+	}
+	if consultation.CheckInTime != nil {
+		t.Fatalf("check_in_time = %v, want nil", consultation.CheckInTime)
+	}
+	if !consultation.ScheduledStart.Equal(scheduledStart) {
+		t.Fatalf("scheduled_start = %s, want %s", consultation.ScheduledStart, scheduledStart)
+	}
+	if !consultation.ScheduledEnd.Equal(scheduledEnd) {
+		t.Fatalf("scheduled_end = %s, want %s", consultation.ScheduledEnd, scheduledEnd)
+	}
+	if consultation.ReceptionNotes != nil {
+		t.Fatalf("reception_notes = %v, want nil", consultation.ReceptionNotes)
+	}
+}
+
+func TestUpdateConsultationStatusReturnsValidationOnBadStatus(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository(newScriptedDB(t, nil))
+
+	_, err := repo.UpdateConsultationStatus(context.Background(), "550e8400-e29b-41d4-a716-446655440260", UpdateConsultationStatusParams{
+		Status: ConsultationStatus("booked"),
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+}
+
+func newConsultationRow(id string, slotID *string, professionalID, patientID string, status ConsultationStatus, source ConsultationSource, notes *string, scheduledStart, scheduledEnd time.Time, checkInTime *time.Time, receptionNotes *string, createdAt, updatedAt time.Time, cancelledAt *time.Time) []driver.Value {
+	return []driver.Value{
+		id,
+		nullableStringValue(slotID),
+		professionalID,
+		patientID,
+		string(status),
+		string(source),
+		nullableStringValue(notes),
+		scheduledStart,
+		scheduledEnd,
+		nullableTimeValue(checkInTime),
+		nullableStringValue(receptionNotes),
+		createdAt,
+		updatedAt,
+		nullableTimeValue(cancelledAt),
+	}
+}
+
+func nullableTimeValue(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
+}

--- a/services/appointments-service/internal/appointments/consultation_schedule_range_migration_integration_test.go
+++ b/services/appointments-service/internal/appointments/consultation_schedule_range_migration_integration_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRepositoryIntegrationConsultationScheduleRangeMigrationBackfillsAndAllowsStandaloneConsultations(t *testing.T) {
-	_, db := newPostgresIntegrationRepository(t)
+	_, db := newPostgresLegacyAppointmentsIntegrationRepository(t)
 
 	ctx := context.Background()
 	professionalID := "550e8400-e29b-41d4-a716-446655440170"

--- a/services/appointments-service/internal/appointments/consultation_schedule_range_migration_integration_test.go
+++ b/services/appointments-service/internal/appointments/consultation_schedule_range_migration_integration_test.go
@@ -1,0 +1,63 @@
+package appointments
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestRepositoryIntegrationConsultationScheduleRangeMigrationBackfillsAndAllowsStandaloneConsultations(t *testing.T) {
+	_, db := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+	professionalID := "550e8400-e29b-41d4-a716-446655440170"
+	slotID := "550e8400-e29b-41d4-a716-446655440171"
+	consultationID := "550e8400-e29b-41d4-a716-446655440172"
+	slotStart := time.Date(2026, time.May, 5, 9, 0, 0, 0, time.UTC)
+	slotEnd := time.Date(2026, time.May, 5, 9, 30, 0, 0, time.UTC)
+
+	seedAvailabilitySlot(t, db, slotID, professionalID, slotStart, slotEnd, "booked")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO appointments (id, slot_id, professional_id, patient_id, status)
+		VALUES ($1, $2, $3, $4, 'booked')
+	`, consultationID, slotID, professionalID, "550e8400-e29b-41d4-a716-446655440173"); err != nil {
+		t.Fatalf("seed appointment before migration: %v", err)
+	}
+
+	applySingleAppointmentsMigration(t, db, "006_consultation_entity.sql")
+	applySingleAppointmentsMigration(t, db, "007_consultation_schedule_range.sql")
+
+	var scheduledStart, scheduledEnd time.Time
+	if err := db.QueryRowContext(ctx, `
+		SELECT scheduled_start, scheduled_end
+		FROM consultations
+		WHERE id = $1
+	`, consultationID).Scan(&scheduledStart, &scheduledEnd); err != nil {
+		t.Fatalf("load migrated consultation schedule range: %v", err)
+	}
+	if !scheduledStart.Equal(slotStart) || !scheduledEnd.Equal(slotEnd) {
+		t.Fatalf("migrated schedule = [%s %s], want [%s %s]", scheduledStart, scheduledEnd, slotStart, slotEnd)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO consultations (professional_id, patient_id, status, source, scheduled_start, scheduled_end)
+		VALUES ($1, $2, 'scheduled', 'doctor', $3, $4)
+	`, professionalID, "550e8400-e29b-41d4-a716-446655440174", time.Date(2026, time.May, 5, 11, 0, 0, 0, time.UTC), time.Date(2026, time.May, 5, 11, 20, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("insert standalone consultation after schedule range migration: %v", err)
+	}
+
+	assertConsultationScheduleRangeColumnsNotNull(t, db)
+}
+
+func assertConsultationScheduleRangeColumnsNotNull(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if columnAllowsNulls(t, db, "consultations", "scheduled_start") {
+		t.Fatal("consultations.scheduled_start allows NULL, want NOT NULL")
+	}
+	if columnAllowsNulls(t, db, "consultations", "scheduled_end") {
+		t.Fatal("consultations.scheduled_end allows NULL, want NOT NULL")
+	}
+}

--- a/services/appointments-service/internal/appointments/consultation_schema_contract_test.go
+++ b/services/appointments-service/internal/appointments/consultation_schema_contract_test.go
@@ -1,0 +1,54 @@
+package appointments
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCurrentBootstrapConsultationsSchemaSupportsRuntimeContract(t *testing.T) {
+	migration := readAppointmentsMigrationFile(t, "001_init.sql")
+
+	checks := []struct {
+		name string
+		want string
+	}{
+		{name: "nullable slot for standalone consultations", want: "slot_id UUID"},
+		{name: "scheduled start range", want: "scheduled_start TIMESTAMPTZ NOT NULL"},
+		{name: "scheduled end range", want: "scheduled_end TIMESTAMPTZ NOT NULL"},
+		{name: "check-in metadata", want: "check_in_time TIMESTAMPTZ"},
+		{name: "reception metadata", want: "reception_notes TEXT"},
+	}
+
+	for _, tt := range checks {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(migration, tt.want) {
+				t.Fatalf("001_init.sql missing %q", tt.want)
+			}
+		})
+	}
+
+	if strings.Contains(migration, "slot_id UUID NOT NULL") {
+		t.Fatal("001_init.sql keeps consultations.slot_id NOT NULL, want nullable for standalone consultations")
+	}
+}
+
+func TestForwardConsultationEntityMigrationAddsRuntimeMetadataAndStandaloneSupport(t *testing.T) {
+	migration := readAppointmentsMigrationFile(t, "006_consultation_entity.sql")
+
+	checks := []struct {
+		name string
+		want string
+	}{
+		{name: "check-in metadata", want: "ADD COLUMN check_in_time TIMESTAMPTZ"},
+		{name: "reception metadata", want: "ADD COLUMN reception_notes TEXT"},
+		{name: "standalone consultations", want: "ALTER COLUMN slot_id DROP NOT NULL"},
+	}
+
+	for _, tt := range checks {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(migration, tt.want) {
+				t.Fatalf("006_consultation_entity.sql missing %q", tt.want)
+			}
+		})
+	}
+}

--- a/services/appointments-service/internal/appointments/repository.go
+++ b/services/appointments-service/internal/appointments/repository.go
@@ -26,6 +26,10 @@ type Repository struct {
 	db *sql.DB
 }
 
+type appointmentRelationQuerier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
 type BulkCreateSlotsParams struct {
 	ProfessionalID      string `json:"professional_id"`
 	Date                string `json:"date"`
@@ -74,6 +78,27 @@ type Appointment struct {
 	CancelledAt    *time.Time `json:"cancelled_at,omitempty"`
 }
 
+type CreateConsultationParams struct {
+	SlotID         *string            `json:"slot_id,omitempty"`
+	ProfessionalID string             `json:"professional_id"`
+	PatientID      string             `json:"patient_id"`
+	Source         ConsultationSource `json:"source"`
+	ScheduledStart *time.Time         `json:"scheduled_start,omitempty"`
+	ScheduledEnd   *time.Time         `json:"scheduled_end,omitempty"`
+	Notes          *string            `json:"notes,omitempty"`
+}
+
+type UpdateConsultationStatusParams struct {
+	Status         ConsultationStatus `json:"status"`
+	CheckInTime    *time.Time         `json:"check_in_time,omitempty"`
+	ReceptionNotes *string            `json:"reception_notes,omitempty"`
+}
+
+type ConsultationFilters struct {
+	ProfessionalID string
+	WeekStart      string
+}
+
 type CreateTemplateParams struct {
 	ProfessionalID string          `json:"professional_id"`
 	EffectiveFrom  string          `json:"effective_from"`
@@ -119,6 +144,42 @@ func ValidateBulkCreateSlotsParams(params BulkCreateSlotsParams) error {
 
 func ValidateCreateAppointmentParams(params CreateAppointmentParams) error {
 	return validateAppointmentParams(params)
+}
+
+func ValidateScheduleBlockParams(params CreateScheduleBlockParams) (CreateScheduleBlockParams, error) {
+	validated, err := validateScheduleBlockParams(params.ProfessionalID, params.Scope, params.BlockDate, params.StartDate, params.EndDate, params.DayOfWeek, params.StartTime, params.EndTime, params.TemplateID)
+	if err != nil {
+		return CreateScheduleBlockParams{}, err
+	}
+
+	result := CreateScheduleBlockParams{
+		ProfessionalID: validated.professionalID,
+		Scope:          validated.scope,
+		StartTime:      validated.startTime,
+		EndTime:        validated.endTime,
+	}
+	if validated.blockDate != nil {
+		value := validated.blockDate.Format("2006-01-02")
+		result.BlockDate = &value
+	}
+	if validated.startDate != nil {
+		value := validated.startDate.Format("2006-01-02")
+		result.StartDate = &value
+	}
+	if validated.endDate != nil {
+		value := validated.endDate.Format("2006-01-02")
+		result.EndDate = &value
+	}
+	if validated.dayOfWeek != nil {
+		day := *validated.dayOfWeek
+		result.DayOfWeek = &day
+	}
+	if validated.templateID != nil {
+		value := *validated.templateID
+		result.TemplateID = &value
+	}
+
+	return result, nil
 }
 
 func NewRepository(db *sql.DB) *Repository {
@@ -264,12 +325,29 @@ func (r *Repository) CreateAppointment(ctx context.Context, params CreateAppoint
 	if slot.ProfessionalID != strings.TrimSpace(params.ProfessionalID) {
 		return Appointment{}, ErrValidation
 	}
+	if err := ensureSlotIsNotBlocked(ctx, tx, slot); err != nil {
+		return Appointment{}, err
+	}
 
-	appointmentRow := tx.QueryRowContext(ctx, `
+	useConsultations, err := usesConsultationAppointmentStore(ctx, tx)
+	if err != nil {
+		return Appointment{}, err
+	}
+
+	appointmentQuery := `
 		INSERT INTO appointments (slot_id, professional_id, patient_id)
 		VALUES ($1, $2, $3)
 		RETURNING id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
-	`, strings.TrimSpace(params.SlotID), strings.TrimSpace(params.ProfessionalID), strings.TrimSpace(params.PatientID))
+	`
+	if useConsultations {
+		appointmentQuery = `
+			INSERT INTO consultations (slot_id, professional_id, patient_id, source)
+			VALUES ($1, $2, $3, 'secretary')
+			RETURNING id, slot_id, professional_id, patient_id, CASE WHEN status = 'scheduled' THEN 'booked' ELSE status END, created_at, updated_at, cancelled_at
+		`
+	}
+
+	appointmentRow := tx.QueryRowContext(ctx, appointmentQuery, strings.TrimSpace(params.SlotID), strings.TrimSpace(params.ProfessionalID), strings.TrimSpace(params.PatientID))
 
 	appointment, err := scanAppointment(appointmentRow)
 	if err != nil {
@@ -295,10 +373,222 @@ func (r *Repository) CreateAppointment(ctx context.Context, params CreateAppoint
 	return appointment, nil
 }
 
+func ensureSlotIsNotBlocked(ctx context.Context, tx *sql.Tx, slot AvailabilitySlot) error {
+	activeTemplateID, err := activeTemplateIDForSlot(ctx, tx, slot.ProfessionalID, slot.StartTime)
+	if err != nil {
+		return err
+	}
+
+	blocks, err := listScheduleBlocksForProfessional(ctx, tx, slot.ProfessionalID)
+	if err != nil {
+		return err
+	}
+
+	blocked, err := isBlocked(blocks, ScheduleTemplate{
+		ID:             activeTemplateID,
+		ProfessionalID: slot.ProfessionalID,
+	}, slot.StartTime, slot.StartTime, slot.EndTime)
+	if err != nil {
+		return err
+	}
+	if blocked {
+		return ErrConflict
+	}
+
+	return nil
+}
+
+func activeTemplateIDForSlot(ctx context.Context, tx *sql.Tx, professionalID string, slotStart time.Time) (string, error) {
+	var templateID string
+	err := tx.QueryRowContext(ctx, `
+		SELECT v.template_id
+		FROM schedule_template_versions v
+		JOIN schedule_templates t ON t.id = v.template_id
+		WHERE t.professional_id = $1
+		  AND v.effective_from <= $2
+		ORDER BY v.effective_from DESC, v.version_number DESC
+		LIMIT 1
+	`, professionalID, slotStart.Format("2006-01-02")).Scan(&templateID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return templateID, nil
+}
+
+func listScheduleBlocksForProfessional(ctx context.Context, tx *sql.Tx, professionalID string) ([]ScheduleBlock, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, professional_id, scope, block_date, start_date, end_date, day_of_week, TO_CHAR(start_time, 'HH24:MI'), TO_CHAR(end_time, 'HH24:MI'), template_id, created_at, updated_at
+		FROM schedule_blocks
+		WHERE professional_id = $1
+		ORDER BY COALESCE(block_date, start_date) NULLS LAST, day_of_week NULLS LAST, start_time, created_at
+	`, professionalID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	blocks := make([]ScheduleBlock, 0)
+	for rows.Next() {
+		block, scanErr := scanScheduleBlock(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		blocks = append(blocks, block)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return blocks, nil
+}
+
+func (r *Repository) CreateConsultation(ctx context.Context, params CreateConsultationParams) (Consultation, error) {
+	validated, err := validateCreateConsultationParams(params)
+	if err != nil {
+		return Consultation{}, err
+	}
+
+	query := `
+		INSERT INTO consultations (slot_id, professional_id, patient_id, source, scheduled_start, scheduled_end, notes)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
+	`
+	args := []any{validated.slotID, validated.professionalID, validated.patientID, validated.source, validated.scheduledStart, validated.scheduledEnd, validated.notes}
+	if validated.slotID != nil {
+		query = `
+			INSERT INTO consultations (slot_id, professional_id, patient_id, source, scheduled_start, scheduled_end, notes)
+			SELECT $1, $2, $3, $4, start_time, end_time, $5
+			FROM availability_slots
+			WHERE id = $1 AND professional_id = $2
+			RETURNING id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
+		`
+		args = []any{validated.slotID, validated.professionalID, validated.patientID, validated.source, validated.notes}
+	}
+
+	consultation, err := scanConsultation(r.db.QueryRowContext(ctx, query, args...))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Consultation{}, ErrNotFound
+	}
+	if err != nil {
+		if isConflictViolation(err) {
+			return Consultation{}, ErrConflict
+		}
+		return Consultation{}, err
+	}
+
+	return consultation, nil
+}
+
+func (r *Repository) GetConsultation(ctx context.Context, consultationID string) (Consultation, error) {
+	validatedID, err := validateConsultationID(consultationID)
+	if err != nil {
+		return Consultation{}, err
+	}
+
+	consultation, err := scanConsultation(r.db.QueryRowContext(ctx, `
+		SELECT id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
+		FROM consultations
+		WHERE id = $1
+	`, validatedID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Consultation{}, ErrNotFound
+	}
+	if err != nil {
+		return Consultation{}, err
+	}
+
+	return consultation, nil
+}
+
+func (r *Repository) ListConsultations(ctx context.Context, filters ConsultationFilters) ([]Consultation, error) {
+	professionalID, weekStart, err := validateConsultationFilters(filters)
+	if err != nil {
+		return nil, err
+	}
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
+		FROM consultations
+		WHERE professional_id = $1
+		  AND scheduled_end > $2
+		  AND scheduled_start < $3
+		ORDER BY scheduled_start, created_at, id
+	`, professionalID, weekStart, weekEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	consultations := make([]Consultation, 0)
+	for rows.Next() {
+		consultation, scanErr := scanConsultation(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		consultations = append(consultations, consultation)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return consultations, nil
+}
+
+func (r *Repository) UpdateConsultationStatus(ctx context.Context, consultationID string, params UpdateConsultationStatusParams) (Consultation, error) {
+	validatedID, validated, err := validateUpdateConsultationStatusParams(consultationID, params)
+	if err != nil {
+		return Consultation{}, err
+	}
+
+	consultation, err := scanConsultation(r.db.QueryRowContext(ctx, `
+		UPDATE consultations
+		SET status = $2,
+		    check_in_time = $3,
+		    reception_notes = $4,
+		    cancelled_at = CASE
+		        WHEN $2 = 'cancelled' THEN COALESCE(cancelled_at, NOW())
+		        ELSE NULL
+		    END,
+		    updated_at = NOW()
+		WHERE id = $1
+		RETURNING id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
+	`, validatedID, validated.status, validated.checkInTime, validated.receptionNotes))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Consultation{}, ErrNotFound
+	}
+	if err != nil {
+		if isConflictViolation(err) {
+			return Consultation{}, ErrConflict
+		}
+		return Consultation{}, err
+	}
+
+	return consultation, nil
+}
+
 func (r *Repository) ListAppointments(ctx context.Context, filters AppointmentFilters) ([]Appointment, error) {
+	useConsultations, err := usesConsultationAppointmentStore(ctx, r.db)
+	if err != nil {
+		return nil, err
+	}
+
+	statusColumn := "status"
+	tableName := "appointments"
+	if useConsultations {
+		statusColumn = legacyAppointmentStatusSelectSQL("status")
+		tableName = "consultations"
+	}
+
 	baseQuery := `
-		SELECT id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
-		FROM appointments
+		SELECT id, slot_id, professional_id, patient_id, ` + statusColumn + `, created_at, updated_at, cancelled_at
+		FROM ` + tableName + `
 	`
 
 	where := make([]string, 0)
@@ -314,7 +604,7 @@ func (r *Repository) ListAppointments(ctx context.Context, filters AppointmentFi
 	}
 	if filters.Status != "" {
 		where = append(where, fmt.Sprintf("status = $%d", len(args)+1))
-		args = append(args, strings.TrimSpace(filters.Status))
+		args = append(args, legacyAppointmentStatusFilter(strings.TrimSpace(filters.Status), useConsultations))
 	}
 	if filters.Date != "" {
 		date, err := time.Parse("2006-01-02", strings.TrimSpace(filters.Date))
@@ -360,11 +650,25 @@ func (r *Repository) GetAppointmentByID(ctx context.Context, appointmentID strin
 		return Appointment{}, ErrValidation
 	}
 
-	appointment, err := scanAppointment(r.db.QueryRowContext(ctx, `
+	useConsultations, err := usesConsultationAppointmentStore(ctx, r.db)
+	if err != nil {
+		return Appointment{}, err
+	}
+
+	query := `
 		SELECT id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
 		FROM appointments
 		WHERE id = $1
-	`, strings.TrimSpace(appointmentID)))
+	`
+	if useConsultations {
+		query = `
+			SELECT id, slot_id, professional_id, patient_id, ` + legacyAppointmentStatusSelectSQL("status") + `, created_at, updated_at, cancelled_at
+			FROM consultations
+			WHERE id = $1
+		`
+	}
+
+	appointment, err := scanAppointment(r.db.QueryRowContext(ctx, query, strings.TrimSpace(appointmentID)))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Appointment{}, ErrNotFound
 	}
@@ -386,12 +690,39 @@ func (r *Repository) CancelAppointment(ctx context.Context, appointmentID string
 	}
 	defer tx.Rollback()
 
-	appointment, err := scanAppointment(tx.QueryRowContext(ctx, `
+	useConsultations, err := usesConsultationAppointmentStore(ctx, tx)
+	if err != nil {
+		return Appointment{}, err
+	}
+
+	selectQuery := `
 		SELECT id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
 		FROM appointments
 		WHERE id = $1
 		FOR UPDATE
-	`, strings.TrimSpace(appointmentID)))
+	`
+	updateQuery := `
+		UPDATE appointments
+		SET status = 'cancelled', cancelled_at = $2, updated_at = $2
+		WHERE id = $1
+		RETURNING id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
+	`
+	if useConsultations {
+		selectQuery = `
+			SELECT id, slot_id, professional_id, patient_id, ` + legacyAppointmentStatusSelectSQL("status") + `, created_at, updated_at, cancelled_at
+			FROM consultations
+			WHERE id = $1
+			FOR UPDATE
+		`
+		updateQuery = `
+			UPDATE consultations
+			SET status = 'cancelled', cancelled_at = $2, updated_at = $2
+			WHERE id = $1
+			RETURNING id, slot_id, professional_id, patient_id, ` + legacyAppointmentStatusSelectSQL("status") + `, created_at, updated_at, cancelled_at
+		`
+	}
+
+	appointment, err := scanAppointment(tx.QueryRowContext(ctx, selectQuery, strings.TrimSpace(appointmentID)))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Appointment{}, ErrNotFound
 	}
@@ -403,12 +734,7 @@ func (r *Repository) CancelAppointment(ctx context.Context, appointmentID string
 	}
 
 	now := time.Now().UTC()
-	updated, err := scanAppointment(tx.QueryRowContext(ctx, `
-		UPDATE appointments
-		SET status = 'cancelled', cancelled_at = $2, updated_at = $2
-		WHERE id = $1
-		RETURNING id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
-	`, strings.TrimSpace(appointmentID), now))
+	updated, err := scanAppointment(tx.QueryRowContext(ctx, updateQuery, strings.TrimSpace(appointmentID), now))
 	if err != nil {
 		return Appointment{}, err
 	}
@@ -427,6 +753,37 @@ func (r *Repository) CancelAppointment(ctx context.Context, appointmentID string
 	}
 
 	return updated, nil
+}
+
+func usesConsultationAppointmentStore(ctx context.Context, querier appointmentRelationQuerier) (bool, error) {
+	var relation string
+	err := querier.QueryRowContext(ctx, `
+		SELECT CASE
+			WHEN to_regclass('public.consultations') IS NOT NULL THEN 'consultations'
+			WHEN to_regclass('public.appointments') IS NOT NULL THEN 'appointments'
+			ELSE ''
+		END
+	`).Scan(&relation)
+	if err != nil {
+		return false, err
+	}
+	if relation == "" {
+		return false, sql.ErrNoRows
+	}
+
+	return relation == "consultations", nil
+}
+
+func legacyAppointmentStatusSelectSQL(column string) string {
+	return fmt.Sprintf("CASE WHEN %s = 'scheduled' THEN 'booked' ELSE %s END", column, column)
+}
+
+func legacyAppointmentStatusFilter(status string, useConsultations bool) string {
+	if useConsultations && status == "booked" {
+		return "scheduled"
+	}
+
+	return status
 }
 
 func (r *Repository) CreateTemplate(ctx context.Context, params CreateTemplateParams) (ScheduleTemplate, error) {
@@ -1022,6 +1379,10 @@ type appointmentScanner interface {
 	Scan(dest ...any) error
 }
 
+type consultationScanner interface {
+	Scan(dest ...any) error
+}
+
 type templateScanner interface {
 	Scan(dest ...any) error
 }
@@ -1050,6 +1411,161 @@ func scanAppointment(scanner appointmentScanner) (Appointment, error) {
 		appointment.CancelledAt = &cancelledAt.Time
 	}
 	return appointment, nil
+}
+
+func scanConsultation(scanner consultationScanner) (Consultation, error) {
+	var (
+		consultation                  Consultation
+		slotID, notes, receptionNotes sql.NullString
+		checkInTime, cancelledAt      sql.NullTime
+	)
+
+	err := scanner.Scan(
+		&consultation.ID,
+		&slotID,
+		&consultation.ProfessionalID,
+		&consultation.PatientID,
+		&consultation.Status,
+		&consultation.Source,
+		&notes,
+		&consultation.ScheduledStart,
+		&consultation.ScheduledEnd,
+		&checkInTime,
+		&receptionNotes,
+		&consultation.CreatedAt,
+		&consultation.UpdatedAt,
+		&cancelledAt,
+	)
+	if err != nil {
+		return Consultation{}, err
+	}
+
+	if slotID.Valid {
+		consultation.SlotID = &slotID.String
+	}
+	if notes.Valid {
+		consultation.Notes = &notes.String
+	}
+	if checkInTime.Valid {
+		consultation.CheckInTime = &checkInTime.Time
+	}
+	if receptionNotes.Valid {
+		consultation.ReceptionNotes = &receptionNotes.String
+	}
+	if cancelledAt.Valid {
+		consultation.CancelledAt = &cancelledAt.Time
+	}
+
+	return consultation, nil
+}
+
+type validatedCreateConsultationParams struct {
+	slotID         *string
+	professionalID string
+	patientID      string
+	source         ConsultationSource
+	scheduledStart time.Time
+	scheduledEnd   time.Time
+	notes          *string
+}
+
+type validatedUpdateConsultationStatusParams struct {
+	status         ConsultationStatus
+	checkInTime    *time.Time
+	receptionNotes *string
+}
+
+func validateCreateConsultationParams(params CreateConsultationParams) (validatedCreateConsultationParams, error) {
+	professionalID := strings.TrimSpace(params.ProfessionalID)
+	patientID := strings.TrimSpace(params.PatientID)
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return validatedCreateConsultationParams{}, ErrValidation
+	}
+	if _, err := uuid.Parse(patientID); err != nil {
+		return validatedCreateConsultationParams{}, ErrValidation
+	}
+	if !params.Source.IsValid() {
+		return validatedCreateConsultationParams{}, ErrValidation
+	}
+
+	validated := validatedCreateConsultationParams{
+		professionalID: professionalID,
+		patientID:      patientID,
+		source:         params.Source,
+	}
+
+	if params.SlotID != nil {
+		slotID := strings.TrimSpace(*params.SlotID)
+		if _, err := uuid.Parse(slotID); err != nil {
+			return validatedCreateConsultationParams{}, ErrValidation
+		}
+		if params.ScheduledStart != nil || params.ScheduledEnd != nil {
+			return validatedCreateConsultationParams{}, ErrValidation
+		}
+		validated.slotID = &slotID
+	} else {
+		if params.ScheduledStart == nil || params.ScheduledEnd == nil {
+			return validatedCreateConsultationParams{}, ErrValidation
+		}
+		scheduledStart := params.ScheduledStart.UTC()
+		scheduledEnd := params.ScheduledEnd.UTC()
+		if !scheduledStart.Before(scheduledEnd) {
+			return validatedCreateConsultationParams{}, ErrValidation
+		}
+		validated.scheduledStart = scheduledStart
+		validated.scheduledEnd = scheduledEnd
+	}
+	if params.Notes != nil {
+		notes := strings.TrimSpace(*params.Notes)
+		validated.notes = &notes
+	}
+
+	return validated, nil
+}
+
+func validateConsultationID(consultationID string) (string, error) {
+	validatedID := strings.TrimSpace(consultationID)
+	if _, err := uuid.Parse(validatedID); err != nil {
+		return "", ErrValidation
+	}
+
+	return validatedID, nil
+}
+
+func validateConsultationFilters(filters ConsultationFilters) (string, time.Time, error) {
+	professionalID := strings.TrimSpace(filters.ProfessionalID)
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return "", time.Time{}, ErrValidation
+	}
+
+	weekStart, err := time.Parse("2006-01-02", strings.TrimSpace(filters.WeekStart))
+	if err != nil {
+		return "", time.Time{}, ErrValidation
+	}
+
+	return professionalID, weekStart.UTC(), nil
+}
+
+func validateUpdateConsultationStatusParams(consultationID string, params UpdateConsultationStatusParams) (string, validatedUpdateConsultationStatusParams, error) {
+	validatedID, err := validateConsultationID(consultationID)
+	if err != nil {
+		return "", validatedUpdateConsultationStatusParams{}, err
+	}
+	if !params.Status.IsValid() {
+		return "", validatedUpdateConsultationStatusParams{}, ErrValidation
+	}
+
+	validated := validatedUpdateConsultationStatusParams{status: params.Status}
+	if params.CheckInTime != nil {
+		checkInTime := params.CheckInTime.UTC()
+		validated.checkInTime = &checkInTime
+	}
+	if params.ReceptionNotes != nil {
+		receptionNotes := strings.TrimSpace(*params.ReceptionNotes)
+		validated.receptionNotes = &receptionNotes
+	}
+
+	return validatedID, validated, nil
 }
 
 func scanTemplate(scanner templateScanner) (ScheduleTemplate, error) {

--- a/services/appointments-service/internal/appointments/repository.go
+++ b/services/appointments-service/internal/appointments/repository.go
@@ -341,8 +341,10 @@ func (r *Repository) CreateAppointment(ctx context.Context, params CreateAppoint
 	`
 	if useConsultations {
 		appointmentQuery = `
-			INSERT INTO consultations (slot_id, professional_id, patient_id, source)
-			VALUES ($1, $2, $3, 'secretary')
+			INSERT INTO consultations (slot_id, professional_id, patient_id, source, scheduled_start, scheduled_end)
+			SELECT $1, $2, $3, 'secretary', start_time, end_time
+			FROM availability_slots
+			WHERE id = $1 AND professional_id = $2
 			RETURNING id, slot_id, professional_id, patient_id, CASE WHEN status = 'scheduled' THEN 'booked' ELSE status END, created_at, updated_at, cancelled_at
 		`
 	}

--- a/services/appointments-service/internal/appointments/repository_postgres_integration_helpers_test.go
+++ b/services/appointments-service/internal/appointments/repository_postgres_integration_helpers_test.go
@@ -41,6 +41,39 @@ func newPostgresIntegrationRepository(t *testing.T) (*Repository, *sql.DB) {
 	return NewRepository(db), db
 }
 
+func newPostgresConsultationIntegrationRepository(t *testing.T) (*Repository, *sql.DB) {
+	t.Helper()
+
+	dsn := postgresIntegrationTestDSN()
+	if dsn == "" {
+		t.Skip(describeIntegrationDSNRequirement())
+	}
+
+	if reason := postgresIntegrationResetSkipReason(dsn); reason != "" {
+		t.Skip(reason)
+	}
+
+	db, err := OpenDB(dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	resetAppointmentsSchema(t, db)
+	applyAppointmentsMigrations(t, db)
+	applySingleAppointmentsMigration(t, db, "006_consultation_entity.sql")
+	applySingleAppointmentsMigration(t, db, "007_consultation_schedule_range.sql")
+
+	if reason := consultationRepositorySchemaSupportSkipReason(t, db); reason != "" {
+		t.Skip(reason)
+	}
+
+	return NewRepository(db), db
+}
+
 func postgresIntegrationTestDSN() string {
 	if dsn := strings.TrimSpace(os.Getenv("APPOINTMENTS_TEST_DATABASE_DSN")); dsn != "" {
 		return dsn
@@ -206,4 +239,68 @@ func countRows(t *testing.T, db *sql.DB, table string) int {
 
 func describeIntegrationDSNRequirement() string {
 	return fmt.Sprintf("run with %s set to a dedicated PostgreSQL database ending in _test and APPOINTMENTS_TEST_DATABASE_RESET_ALLOWED=true", "APPOINTMENTS_TEST_DATABASE_DSN")
+}
+
+func consultationRepositorySchemaSupportSkipReason(t *testing.T, db *sql.DB) string {
+	t.Helper()
+
+	if !columnExists(t, db, "consultations", "check_in_time") {
+		return "skipping consultation repository integration tests: consultations.check_in_time column is not present after migration 006"
+	}
+	if !columnExists(t, db, "consultations", "reception_notes") {
+		return "skipping consultation repository integration tests: consultations.reception_notes column is not present after migration 006"
+	}
+	if !columnAllowsNulls(t, db, "consultations", "slot_id") {
+		return "skipping consultation repository integration tests: consultations.slot_id is still NOT NULL after migration 006"
+	}
+	if !columnExists(t, db, "consultations", "scheduled_start") {
+		return "skipping consultation repository integration tests: consultations.scheduled_start column is not present after migration 007"
+	}
+	if !columnExists(t, db, "consultations", "scheduled_end") {
+		return "skipping consultation repository integration tests: consultations.scheduled_end column is not present after migration 007"
+	}
+
+	return ""
+}
+
+func columnExists(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = $1
+			  AND column_name = $2
+		)
+	`, table, column).Scan(&exists); err != nil {
+		t.Fatalf("lookup column %s.%s: %v", table, column, err)
+	}
+
+	return exists
+}
+
+func columnAllowsNulls(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var isNullable string
+	if err := db.QueryRowContext(ctx, `
+		SELECT is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = $1
+		  AND column_name = $2
+	`, table, column).Scan(&isNullable); err != nil {
+		t.Fatalf("lookup nullability %s.%s: %v", table, column, err)
+	}
+
+	return strings.EqualFold(strings.TrimSpace(isNullable), "YES")
 }

--- a/services/appointments-service/internal/appointments/repository_postgres_integration_helpers_test.go
+++ b/services/appointments-service/internal/appointments/repository_postgres_integration_helpers_test.go
@@ -36,7 +36,7 @@ func newPostgresIntegrationRepository(t *testing.T) (*Repository, *sql.DB) {
 	})
 
 	resetAppointmentsSchema(t, db)
-	applyAppointmentsMigrations(t, db)
+	applyCurrentAppointmentsSchema(t, db)
 
 	return NewRepository(db), db
 }
@@ -63,13 +63,40 @@ func newPostgresConsultationIntegrationRepository(t *testing.T) (*Repository, *s
 	})
 
 	resetAppointmentsSchema(t, db)
-	applyAppointmentsMigrations(t, db)
-	applySingleAppointmentsMigration(t, db, "006_consultation_entity.sql")
-	applySingleAppointmentsMigration(t, db, "007_consultation_schedule_range.sql")
+	applyCurrentAppointmentsSchema(t, db)
 
 	if reason := consultationRepositorySchemaSupportSkipReason(t, db); reason != "" {
+		t.Fatal(reason)
+	}
+
+	return NewRepository(db), db
+}
+
+func newPostgresLegacyAppointmentsIntegrationRepository(t *testing.T) (*Repository, *sql.DB) {
+	t.Helper()
+
+	dsn := postgresIntegrationTestDSN()
+	if dsn == "" {
+		t.Skip(describeIntegrationDSNRequirement())
+	}
+
+	if reason := postgresIntegrationResetSkipReason(dsn); reason != "" {
 		t.Skip(reason)
 	}
+
+	db, err := OpenDB(dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	resetAppointmentsSchema(t, db)
+	applyLegacyAppointmentsSchema(t, db)
+	applySingleAppointmentsMigration(t, db, "004_schedule_templates.sql")
+	applySingleAppointmentsMigration(t, db, "005_schedule_blocks.sql")
 
 	return NewRepository(db), db
 }
@@ -125,7 +152,13 @@ func resetAppointmentsSchema(t *testing.T, db *sql.DB) {
 func applyAppointmentsMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
 
-	for _, migration := range []string{"001_init.sql", "002_prevent_availability_slot_overlaps.sql", "003_allow_rebooking_cancelled_slots.sql", "004_schedule_templates.sql", "005_schedule_blocks.sql"} {
+	applyCurrentAppointmentsSchema(t, db)
+}
+
+func applyCurrentAppointmentsSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	for _, migration := range []string{"001_init.sql"} {
 		contents := readAppointmentsMigrationFile(t, migration)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -134,6 +167,71 @@ func applyAppointmentsMigrations(t *testing.T, db *sql.DB) {
 		if err != nil {
 			t.Fatalf("apply migration %s: %v", migration, err)
 		}
+	}
+}
+
+func applyLegacyAppointmentsSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	const legacySchema = `
+		CREATE EXTENSION IF NOT EXISTS pgcrypto;
+		CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+		CREATE TABLE availability_slots (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			professional_id UUID NOT NULL,
+			start_time TIMESTAMPTZ NOT NULL,
+			end_time TIMESTAMPTZ NOT NULL,
+			status TEXT NOT NULL DEFAULT 'available',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT availability_slots_time_range_valid CHECK (start_time < end_time),
+			CONSTRAINT availability_slots_status_valid CHECK (status IN ('available', 'booked', 'cancelled')),
+			CONSTRAINT availability_slots_professional_start_unique UNIQUE (professional_id, start_time),
+			CONSTRAINT availability_slots_no_overlap EXCLUDE USING gist (
+				professional_id WITH =,
+				tstzrange(start_time, end_time, '[)') WITH &&
+			)
+		);
+
+		CREATE INDEX availability_slots_professional_start_idx
+			ON availability_slots (professional_id, start_time);
+		CREATE INDEX availability_slots_status_idx
+			ON availability_slots (status);
+
+		CREATE TABLE appointments (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			slot_id UUID NOT NULL,
+			professional_id UUID NOT NULL,
+			patient_id UUID NOT NULL,
+			status TEXT NOT NULL DEFAULT 'booked',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			cancelled_at TIMESTAMPTZ,
+			CONSTRAINT appointments_slot_fk FOREIGN KEY (slot_id) REFERENCES availability_slots(id),
+			CONSTRAINT appointments_status_valid CHECK (status IN ('booked', 'cancelled')),
+			CONSTRAINT appointments_cancelled_at_consistency CHECK (
+				(status = 'cancelled' AND cancelled_at IS NOT NULL) OR
+				(status = 'booked' AND cancelled_at IS NULL)
+			)
+		);
+
+		CREATE UNIQUE INDEX appointments_slot_booked_unique_idx
+			ON appointments (slot_id)
+			WHERE status = 'booked';
+		CREATE INDEX appointments_patient_id_idx
+			ON appointments (patient_id);
+		CREATE INDEX appointments_professional_id_idx
+			ON appointments (professional_id);
+		CREATE INDEX appointments_status_idx
+			ON appointments (status);
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := db.ExecContext(ctx, legacySchema); err != nil {
+		t.Fatalf("apply legacy appointments schema: %v", err)
 	}
 }
 
@@ -180,11 +278,25 @@ func fetchAppointmentByID(t *testing.T, db *sql.DB, appointmentID string) Appoin
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	row := db.QueryRowContext(ctx, `
+	useConsultations, err := usesConsultationAppointmentStore(ctx, db)
+	if err != nil {
+		t.Fatalf("resolve appointment store: %v", err)
+	}
+
+	query := `
 		SELECT id, slot_id, professional_id, patient_id, status, created_at, updated_at, cancelled_at
 		FROM appointments
 		WHERE id = $1
-	`, appointmentID)
+	`
+	if useConsultations {
+		query = `
+			SELECT id, slot_id, professional_id, patient_id, ` + legacyAppointmentStatusSelectSQL("status") + `, created_at, updated_at, cancelled_at
+			FROM consultations
+			WHERE id = $1
+		`
+	}
+
+	row := db.QueryRowContext(ctx, query, appointmentID)
 
 	appointment, err := scanAppointment(row)
 	if err != nil {
@@ -214,8 +326,18 @@ func countAppointments(t *testing.T, db *sql.DB) int {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	useConsultations, err := usesConsultationAppointmentStore(ctx, db)
+	if err != nil {
+		t.Fatalf("resolve appointment store: %v", err)
+	}
+	tableName := "appointments"
+	if useConsultations {
+		tableName = "consultations"
+	}
+
 	var total int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM appointments`).Scan(&total); err != nil {
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)
+	if err := db.QueryRowContext(ctx, query).Scan(&total); err != nil {
 		t.Fatalf("count appointments: %v", err)
 	}
 
@@ -245,19 +367,19 @@ func consultationRepositorySchemaSupportSkipReason(t *testing.T, db *sql.DB) str
 	t.Helper()
 
 	if !columnExists(t, db, "consultations", "check_in_time") {
-		return "skipping consultation repository integration tests: consultations.check_in_time column is not present after migration 006"
+		return "consultation repository integration schema invalid: consultations.check_in_time column is not present"
 	}
 	if !columnExists(t, db, "consultations", "reception_notes") {
-		return "skipping consultation repository integration tests: consultations.reception_notes column is not present after migration 006"
+		return "consultation repository integration schema invalid: consultations.reception_notes column is not present"
 	}
 	if !columnAllowsNulls(t, db, "consultations", "slot_id") {
-		return "skipping consultation repository integration tests: consultations.slot_id is still NOT NULL after migration 006"
+		return "consultation repository integration schema invalid: consultations.slot_id is still NOT NULL"
 	}
 	if !columnExists(t, db, "consultations", "scheduled_start") {
-		return "skipping consultation repository integration tests: consultations.scheduled_start column is not present after migration 007"
+		return "consultation repository integration schema invalid: consultations.scheduled_start column is not present"
 	}
 	if !columnExists(t, db, "consultations", "scheduled_end") {
-		return "skipping consultation repository integration tests: consultations.scheduled_end column is not present after migration 007"
+		return "consultation repository integration schema invalid: consultations.scheduled_end column is not present"
 	}
 
 	return ""

--- a/services/appointments-service/internal/appointments/repository_postgres_integration_test.go
+++ b/services/appointments-service/internal/appointments/repository_postgres_integration_test.go
@@ -442,6 +442,138 @@ func TestRepositoryIntegrationCreateAppointmentRejectsDoubleBookingForSameSlot(t
 	}
 }
 
+func TestRepositoryIntegrationCreateAppointmentRejectsSlotsCoveredByActiveScheduleBlocks(t *testing.T) {
+	repo, db := newPostgresIntegrationRepository(t)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		professionalID string
+		patientID      string
+		date           string
+		startTime      string
+		endTime        string
+		createBlock    func(t *testing.T, repo *Repository, ctx context.Context, professionalID string)
+	}{
+		{
+			name:           "single block rejects booking",
+			professionalID: "550e8400-e29b-41d4-a716-446655440023",
+			patientID:      "550e8400-e29b-41d4-a716-446655440024",
+			date:           "2026-04-14",
+			startTime:      "09:00",
+			endTime:        "09:30",
+			createBlock: func(t *testing.T, repo *Repository, ctx context.Context, professionalID string) {
+				t.Helper()
+
+				_, err := repo.CreateScheduleBlock(ctx, CreateScheduleBlockParams{
+					ProfessionalID: professionalID,
+					Scope:          "single",
+					BlockDate:      stringPtr("2026-04-14"),
+					StartTime:      "09:00",
+					EndTime:        "09:30",
+				})
+				if err != nil {
+					t.Fatalf("create single block: %v", err)
+				}
+			},
+		},
+		{
+			name:           "range block rejects booking",
+			professionalID: "550e8400-e29b-41d4-a716-446655440025",
+			patientID:      "550e8400-e29b-41d4-a716-446655440026",
+			date:           "2026-04-15",
+			startTime:      "10:00",
+			endTime:        "10:30",
+			createBlock: func(t *testing.T, repo *Repository, ctx context.Context, professionalID string) {
+				t.Helper()
+
+				_, err := repo.CreateScheduleBlock(ctx, CreateScheduleBlockParams{
+					ProfessionalID: professionalID,
+					Scope:          "range",
+					StartDate:      stringPtr("2026-04-14"),
+					EndDate:        stringPtr("2026-04-16"),
+					StartTime:      "09:45",
+					EndTime:        "10:45",
+				})
+				if err != nil {
+					t.Fatalf("create range block: %v", err)
+				}
+			},
+		},
+		{
+			name:           "template block rejects booking when active template matches",
+			professionalID: "550e8400-e29b-41d4-a716-446655440027",
+			patientID:      "550e8400-e29b-41d4-a716-446655440028",
+			date:           "2026-04-20",
+			startTime:      "08:00",
+			endTime:        "08:30",
+			createBlock: func(t *testing.T, repo *Repository, ctx context.Context, professionalID string) {
+				t.Helper()
+
+				template, err := repo.CreateTemplate(ctx, CreateTemplateParams{
+					ProfessionalID: professionalID,
+					EffectiveFrom:  "2026-04-01",
+					Recurrence:     json.RawMessage(`{"monday":{"start_time":"08:00","end_time":"09:00","slot_duration_minutes":30}}`),
+				})
+				if err != nil {
+					t.Fatalf("create template: %v", err)
+				}
+
+				_, err = repo.CreateScheduleBlock(ctx, CreateScheduleBlockParams{
+					ProfessionalID: professionalID,
+					Scope:          "template",
+					DayOfWeek:      intPtr(1),
+					StartTime:      "08:00",
+					EndTime:        "08:30",
+					TemplateID:     &template.ID,
+				})
+				if err != nil {
+					t.Fatalf("create template block: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slots, err := repo.CreateSlotsBulk(ctx, BulkCreateSlotsParams{
+				ProfessionalID:      tt.professionalID,
+				Date:                tt.date,
+				StartTime:           tt.startTime,
+				EndTime:             tt.endTime,
+				SlotDurationMinutes: 30,
+			})
+			if err != nil {
+				t.Fatalf("create slots: %v", err)
+			}
+			if len(slots) != 1 {
+				t.Fatalf("slots len = %d, want 1", len(slots))
+			}
+
+			tt.createBlock(t, repo, ctx, tt.professionalID)
+
+			_, err = repo.CreateAppointment(ctx, CreateAppointmentParams{
+				SlotID:         slots[0].ID,
+				PatientID:      tt.patientID,
+				ProfessionalID: tt.professionalID,
+			})
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("create appointment err = %v, want %v", err, ErrConflict)
+			}
+
+			if got := countAppointments(t, db); got != 0 {
+				t.Fatalf("appointments persisted = %d, want 0", got)
+			}
+
+			persistedSlot := fetchSlotByID(t, db, slots[0].ID)
+			if persistedSlot.Status != "available" {
+				t.Fatalf("slot status after blocked booking attempt = %q, want available", persistedSlot.Status)
+			}
+		})
+	}
+}
+
 func TestRepositoryIntegrationCreateAppointmentConcurrentSameSlotReturnsOneSuccessAndOneConflict(t *testing.T) {
 	repo, db := newPostgresIntegrationRepository(t)
 

--- a/services/appointments-service/internal/appointments/repository_test.go
+++ b/services/appointments-service/internal/appointments/repository_test.go
@@ -99,6 +99,96 @@ func TestValidateAppointmentParams(t *testing.T) {
 	}
 }
 
+func TestCreateAppointmentRejectsSlotsCoveredByActiveScheduleBlocks(t *testing.T) {
+	t.Parallel()
+
+	day := time.Date(2026, time.April, 20, 9, 0, 0, 0, time.UTC)
+	templateID := "550e8400-e29b-41d4-a716-446655440090"
+
+	tests := []struct {
+		name                 string
+		slotStart            time.Time
+		slotEnd              time.Time
+		activeTemplateRow    []driver.Value
+		scheduleBlockResults [][]driver.Value
+	}{
+		{
+			name:      "single block",
+			slotStart: day,
+			slotEnd:   day.Add(30 * time.Minute),
+			scheduleBlockResults: [][]driver.Value{
+				newScheduleBlockRow(
+					"550e8400-e29b-41d4-a716-446655440091",
+					"550e8400-e29b-41d4-a716-446655440002",
+					"single",
+					datePtr(day), nil, nil, nil,
+					"09:00", "09:30",
+					nil,
+					day, day,
+				),
+			},
+		},
+		{
+			name:      "range block",
+			slotStart: day,
+			slotEnd:   day.Add(30 * time.Minute),
+			scheduleBlockResults: [][]driver.Value{
+				newScheduleBlockRow(
+					"550e8400-e29b-41d4-a716-446655440092",
+					"550e8400-e29b-41d4-a716-446655440002",
+					"range",
+					nil, datePtr(day.AddDate(0, 0, -1)), datePtr(day.AddDate(0, 0, 1)), nil,
+					"08:45", "09:15",
+					nil,
+					day, day,
+				),
+			},
+		},
+		{
+			name:              "template block for active template",
+			slotStart:         day,
+			slotEnd:           day.Add(30 * time.Minute),
+			activeTemplateRow: []driver.Value{templateID},
+			scheduleBlockResults: [][]driver.Value{
+				newScheduleBlockRow(
+					"550e8400-e29b-41d4-a716-446655440094",
+					"550e8400-e29b-41d4-a716-446655440002",
+					"template",
+					nil, nil, nil, intPtr(1),
+					"09:00", "09:30",
+					&templateID,
+					day, day,
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := []scriptedQueryResult{{
+				row: newSlotRow("550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440002", tt.slotStart, tt.slotEnd),
+			}}
+			if tt.activeTemplateRow != nil {
+				results = append(results, scriptedQueryResult{row: tt.activeTemplateRow})
+			} else {
+				results = append(results, scriptedQueryResult{err: sql.ErrNoRows})
+			}
+			results = append(results, scriptedQueryResult{rows: tt.scheduleBlockResults})
+
+			repo := NewRepository(newScriptedDB(t, results))
+
+			_, err := repo.CreateAppointment(context.Background(), CreateAppointmentParams{
+				SlotID:         "550e8400-e29b-41d4-a716-446655440000",
+				PatientID:      "550e8400-e29b-41d4-a716-446655440001",
+				ProfessionalID: "550e8400-e29b-41d4-a716-446655440002",
+			})
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("err = %v, want %v", err, ErrConflict)
+			}
+		})
+	}
+}
+
 func TestCreateSlotsBulkReturnsConflictOnRealOverlap(t *testing.T) {
 	t.Parallel()
 
@@ -170,8 +260,9 @@ func TestGetAppointmentByIDReturnsAppointment(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.April, 10, 9, 0, 0, 0, time.UTC)
-	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
-		row: newAppointmentRow(
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{
+		{row: []driver.Value{"appointments"}},
+		{row: newAppointmentRow(
 			"550e8400-e29b-41d4-a716-446655440099",
 			"550e8400-e29b-41d4-a716-446655440010",
 			"550e8400-e29b-41d4-a716-446655440011",
@@ -180,8 +271,8 @@ func TestGetAppointmentByIDReturnsAppointment(t *testing.T) {
 			now,
 			now,
 			nil,
-		),
-	}}))
+		)},
+	}))
 
 	appointment, err := repo.GetAppointmentByID(context.Background(), "550e8400-e29b-41d4-a716-446655440099")
 	if err != nil {
@@ -564,6 +655,8 @@ func TestDeleteScheduleBlockReturnsNotFoundWhenMissing(t *testing.T) {
 func stringPtr(value string) *string { return &value }
 
 func intPtr(value int) *int { return &value }
+
+func datePtr(value time.Time) *time.Time { return &value }
 
 func newScheduleBlockRow(id, professionalID, scope string, blockDate, startDate, endDate *time.Time, dayOfWeek *int, startTime, endTime string, templateID *string, createdAt, updatedAt time.Time) []driver.Value {
 	var blockDateValue any

--- a/services/appointments-service/internal/appointments/schedule_models.go
+++ b/services/appointments-service/internal/appointments/schedule_models.go
@@ -38,3 +38,12 @@ type ScheduleBlock struct {
 	CreatedAt      time.Time  `json:"created_at"`
 	UpdatedAt      time.Time  `json:"updated_at"`
 }
+
+type WeekAgenda struct {
+	ProfessionalID string             `json:"professional_id"`
+	WeekStart      string             `json:"week_start"`
+	Templates      []ScheduleTemplate `json:"templates"`
+	Blocks         []ScheduleBlock    `json:"blocks"`
+	Consultations  []Consultation     `json:"consultations"`
+	Slots          []AvailabilitySlot `json:"slots"`
+}

--- a/services/appointments-service/internal/appointments/service.go
+++ b/services/appointments-service/internal/appointments/service.go
@@ -1,6 +1,11 @@
 package appointments
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"time"
+)
 
 type scheduleRepository interface {
 	GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplateVersion, error)
@@ -12,8 +17,122 @@ type ScheduleService struct {
 	repo scheduleRepository
 }
 
+type consultationRepository interface {
+	GetConsultation(ctx context.Context, consultationID string) (Consultation, error)
+	UpdateConsultationStatus(ctx context.Context, consultationID string, params UpdateConsultationStatusParams) (Consultation, error)
+}
+
+type ConsultationStatusUpdateParams struct {
+	Status         ConsultationStatus    `json:"status"`
+	Source         *ConsultationSource   `json:"source,omitempty"`
+	ActorRole      ConsultationActorRole `json:"-"`
+	CheckInTime    *time.Time            `json:"check_in_time,omitempty"`
+	ReceptionNotes *string               `json:"reception_notes,omitempty"`
+}
+
+type ConsultationService struct {
+	repo consultationRepository
+}
+
 func NewScheduleService(repo scheduleRepository) *ScheduleService {
 	return &ScheduleService{repo: repo}
+}
+
+func NewConsultationService(repo consultationRepository) *ConsultationService {
+	return &ConsultationService{repo: repo}
+}
+
+type recurrenceWindow struct {
+	StartTime           string `json:"start_time"`
+	EndTime             string `json:"end_time"`
+	SlotDurationMinutes int    `json:"slot_duration_minutes"`
+}
+
+func GenerateSlotsForWeek(template ScheduleTemplate, blocks []ScheduleBlock, weekStart time.Time) ([]AvailabilitySlot, error) {
+	weekStart = startOfDay(weekStart)
+	slots := make([]AvailabilitySlot, 0)
+
+	for dayOffset := 0; dayOffset < 7; dayOffset++ {
+		day := weekStart.AddDate(0, 0, dayOffset)
+		version, ok := activeTemplateVersionForDate(template.Versions, day)
+		if !ok {
+			continue
+		}
+
+		recurrence, err := parseTemplateRecurrence(version.Recurrence)
+		if err != nil {
+			return nil, err
+		}
+
+		window, ok := recurrence[weekdayKey(day.Weekday())]
+		if !ok {
+			continue
+		}
+
+		startAt, endAt, duration, err := recurrenceBounds(day, window)
+		if err != nil {
+			return nil, err
+		}
+
+		for current := startAt; current.Before(endAt); current = current.Add(duration) {
+			next := current.Add(duration)
+			blocked, err := isBlocked(blocks, template, day, current, next)
+			if err != nil {
+				return nil, err
+			}
+			if blocked {
+				continue
+			}
+
+			slots = append(slots, AvailabilitySlot{
+				ProfessionalID: template.ProfessionalID,
+				StartTime:      current,
+				EndTime:        next,
+				Status:         "available",
+			})
+		}
+	}
+
+	return slots, nil
+}
+
+func ComposeWeekAgenda(professionalID string, weekStart time.Time, templates []ScheduleTemplate, blocks []ScheduleBlock, consultations []Consultation) (WeekAgenda, error) {
+	weekStart = startOfDay(weekStart)
+	agenda := WeekAgenda{
+		ProfessionalID: professionalID,
+		WeekStart:      weekStart.Format("2006-01-02"),
+		Templates:      make([]ScheduleTemplate, 0),
+		Blocks:         make([]ScheduleBlock, 0),
+		Consultations:  filterWeekConsultations(consultations, professionalID, weekStart),
+		Slots:          make([]AvailabilitySlot, 0),
+	}
+
+	relevantTemplateIDs := make(map[string]struct{})
+	for _, template := range templates {
+		if template.ProfessionalID != professionalID {
+			continue
+		}
+
+		relevantVersions := activeTemplateVersionsForWeek(template.Versions, weekStart)
+		if len(relevantVersions) == 0 {
+			continue
+		}
+
+		template.Versions = relevantVersions
+		relevantTemplateIDs[template.ID] = struct{}{}
+		agenda.Templates = append(agenda.Templates, template)
+
+		slots, err := GenerateSlotsForWeek(template, blocks, weekStart)
+		if err != nil {
+			return WeekAgenda{}, err
+		}
+		agenda.Slots = append(agenda.Slots, slots...)
+	}
+
+	agenda.Blocks = filterWeekBlocks(blocks, professionalID, relevantTemplateIDs, weekStart)
+	sortWeekAgenda(&agenda)
+
+	return agenda, nil
 }
 
 func (s *ScheduleService) GetSchedule(ctx context.Context, professionalID string, effectiveDate string) (ScheduleTemplate, error) {
@@ -46,4 +165,376 @@ func (s *ScheduleService) ListTemplateVersions(ctx context.Context, templateID s
 	template.Versions = versions
 
 	return template, nil
+}
+
+func (s *ConsultationService) UpdateStatus(ctx context.Context, consultationID string, params ConsultationStatusUpdateParams) (Consultation, error) {
+	consultation, err := s.repo.GetConsultation(ctx, consultationID)
+	if err != nil {
+		return Consultation{}, err
+	}
+
+	if err := validateConsultationStatusTransition(consultation.Status, params.Status); err != nil {
+		return Consultation{}, err
+	}
+	if err := validateConsultationStatusPermission(params.ActorRole, params.Status); err != nil {
+		return Consultation{}, err
+	}
+	if err := validateConsultationSourceImmutable(consultation.Source, params.Source); err != nil {
+		return Consultation{}, err
+	}
+
+	return s.repo.UpdateConsultationStatus(ctx, consultationID, UpdateConsultationStatusParams{
+		Status:         params.Status,
+		CheckInTime:    params.CheckInTime,
+		ReceptionNotes: params.ReceptionNotes,
+	})
+}
+
+func validateConsultationStatusTransition(current, next ConsultationStatus) error {
+	if !next.IsValid() {
+		return ErrValidation
+	}
+	if current == ConsultationStatusCompleted && next != ConsultationStatusCompleted {
+		return ErrValidation
+	}
+
+	return nil
+}
+
+func validateConsultationStatusPermission(actorRole ConsultationActorRole, next ConsultationStatus) error {
+	if next != ConsultationStatusCompleted {
+		return nil
+	}
+	if !actorRole.IsValid() {
+		return ErrValidation
+	}
+	if actorRole != ConsultationActorRoleDoctor {
+		return ErrValidation
+	}
+
+	return nil
+}
+
+func validateConsultationSourceImmutable(current ConsultationSource, next *ConsultationSource) error {
+	if next == nil {
+		return nil
+	}
+	if !next.IsValid() {
+		return ErrValidation
+	}
+	if current != *next {
+		return ErrValidation
+	}
+
+	return nil
+}
+
+func activeTemplateVersionsForWeek(versions []ScheduleTemplateVersion, weekStart time.Time) []ScheduleTemplateVersion {
+	selected := make(map[string]ScheduleTemplateVersion)
+	for dayOffset := 0; dayOffset < 7; dayOffset++ {
+		version, ok := activeTemplateVersionForDate(versions, weekStart.AddDate(0, 0, dayOffset))
+		if !ok {
+			continue
+		}
+		selected[version.ID] = version
+	}
+
+	relevant := make([]ScheduleTemplateVersion, 0, len(selected))
+	for _, version := range selected {
+		relevant = append(relevant, version)
+	}
+
+	sort.Slice(relevant, func(i, j int) bool {
+		left := startOfDay(relevant[i].EffectiveFrom)
+		right := startOfDay(relevant[j].EffectiveFrom)
+		if !left.Equal(right) {
+			return left.Before(right)
+		}
+		return relevant[i].VersionNumber < relevant[j].VersionNumber
+	})
+
+	return relevant
+}
+
+func activeTemplateVersionForDate(versions []ScheduleTemplateVersion, date time.Time) (ScheduleTemplateVersion, bool) {
+	date = startOfDay(date)
+	var (
+		selected ScheduleTemplateVersion
+		found    bool
+	)
+
+	for _, version := range versions {
+		effectiveFrom := startOfDay(version.EffectiveFrom)
+		if effectiveFrom.After(date) {
+			continue
+		}
+		if !found || effectiveFrom.After(startOfDay(selected.EffectiveFrom)) {
+			selected = version
+			found = true
+		}
+	}
+
+	return selected, found
+}
+
+func filterWeekBlocks(blocks []ScheduleBlock, professionalID string, templateIDs map[string]struct{}, weekStart time.Time) []ScheduleBlock {
+	filtered := make([]ScheduleBlock, 0)
+	for _, block := range blocks {
+		if block.ProfessionalID != professionalID {
+			continue
+		}
+		if !blockIntersectsWeek(block, templateIDs, weekStart) {
+			continue
+		}
+		filtered = append(filtered, block)
+	}
+
+	return filtered
+}
+
+func filterWeekConsultations(consultations []Consultation, professionalID string, weekStart time.Time) []Consultation {
+	weekStart = startOfDay(weekStart)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	filtered := make([]Consultation, 0)
+	for _, consultation := range consultations {
+		if consultation.ProfessionalID != professionalID {
+			continue
+		}
+		if consultation.ScheduledStart.IsZero() || consultation.ScheduledEnd.IsZero() {
+			continue
+		}
+		if !consultation.ScheduledEnd.After(weekStart) || !consultation.ScheduledStart.Before(weekEnd) {
+			continue
+		}
+		filtered = append(filtered, consultation)
+	}
+
+	return filtered
+}
+
+func blockIntersectsWeek(block ScheduleBlock, templateIDs map[string]struct{}, weekStart time.Time) bool {
+	weekStart = startOfDay(weekStart)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	switch block.Scope {
+	case "single":
+		if block.BlockDate == nil {
+			return false
+		}
+		blockDate := startOfDay(*block.BlockDate)
+		return (blockDate.Equal(weekStart) || blockDate.After(weekStart)) && blockDate.Before(weekEnd)
+	case "range":
+		if block.StartDate == nil || block.EndDate == nil {
+			return false
+		}
+		startDate := startOfDay(*block.StartDate)
+		endDate := startOfDay(*block.EndDate)
+		return !endDate.Before(weekStart) && startDate.Before(weekEnd)
+	case "template":
+		if block.TemplateID == nil || block.DayOfWeek == nil {
+			return false
+		}
+		if *block.DayOfWeek < 1 || *block.DayOfWeek > 7 {
+			return false
+		}
+		_, ok := templateIDs[*block.TemplateID]
+		return ok
+	default:
+		return false
+	}
+}
+
+func sortWeekAgenda(agenda *WeekAgenda) {
+	sort.Slice(agenda.Templates, func(i, j int) bool {
+		left := agenda.Templates[i]
+		right := agenda.Templates[j]
+		leftFrom := time.Time{}
+		rightFrom := time.Time{}
+		if len(left.Versions) > 0 {
+			leftFrom = startOfDay(left.Versions[0].EffectiveFrom)
+		}
+		if len(right.Versions) > 0 {
+			rightFrom = startOfDay(right.Versions[0].EffectiveFrom)
+		}
+		if !leftFrom.Equal(rightFrom) {
+			return leftFrom.Before(rightFrom)
+		}
+		return left.ID < right.ID
+	})
+
+	sort.Slice(agenda.Blocks, func(i, j int) bool {
+		left := blockSortDate(agenda.Blocks[i])
+		right := blockSortDate(agenda.Blocks[j])
+		if !left.Equal(right) {
+			return left.Before(right)
+		}
+		if agenda.Blocks[i].StartTime != agenda.Blocks[j].StartTime {
+			return agenda.Blocks[i].StartTime < agenda.Blocks[j].StartTime
+		}
+		return agenda.Blocks[i].ID < agenda.Blocks[j].ID
+	})
+
+	sort.Slice(agenda.Consultations, func(i, j int) bool {
+		left := agenda.Consultations[i]
+		right := agenda.Consultations[j]
+		if !left.ScheduledStart.Equal(right.ScheduledStart) {
+			return left.ScheduledStart.Before(right.ScheduledStart)
+		}
+		return left.ID < right.ID
+	})
+
+	sort.Slice(agenda.Slots, func(i, j int) bool {
+		if !agenda.Slots[i].StartTime.Equal(agenda.Slots[j].StartTime) {
+			return agenda.Slots[i].StartTime.Before(agenda.Slots[j].StartTime)
+		}
+		if !agenda.Slots[i].EndTime.Equal(agenda.Slots[j].EndTime) {
+			return agenda.Slots[i].EndTime.Before(agenda.Slots[j].EndTime)
+		}
+		return agenda.Slots[i].ID < agenda.Slots[j].ID
+	})
+}
+
+func blockSortDate(block ScheduleBlock) time.Time {
+	if block.BlockDate != nil {
+		return startOfDay(*block.BlockDate)
+	}
+	if block.StartDate != nil {
+		return startOfDay(*block.StartDate)
+	}
+	return time.Time{}
+}
+
+func parseTemplateRecurrence(payload json.RawMessage) (map[string]recurrenceWindow, error) {
+	var recurrence map[string]recurrenceWindow
+	if err := json.Unmarshal(payload, &recurrence); err != nil {
+		return nil, ErrValidation
+	}
+	if recurrence == nil {
+		return nil, ErrValidation
+	}
+
+	return recurrence, nil
+}
+
+func recurrenceBounds(day time.Time, window recurrenceWindow) (time.Time, time.Time, time.Duration, error) {
+	startAt, err := combineDateAndClock(day, window.StartTime)
+	if err != nil {
+		return time.Time{}, time.Time{}, 0, err
+	}
+	endAt, err := combineDateAndClock(day, window.EndTime)
+	if err != nil {
+		return time.Time{}, time.Time{}, 0, err
+	}
+	if !endAt.After(startAt) || window.SlotDurationMinutes <= 0 {
+		return time.Time{}, time.Time{}, 0, ErrValidation
+	}
+
+	duration := time.Duration(window.SlotDurationMinutes) * time.Minute
+	if endAt.Sub(startAt)%duration != 0 {
+		return time.Time{}, time.Time{}, 0, ErrValidation
+	}
+
+	return startAt, endAt, duration, nil
+}
+
+func isBlocked(blocks []ScheduleBlock, template ScheduleTemplate, day, slotStart, slotEnd time.Time) (bool, error) {
+	for _, block := range blocks {
+		applies, err := blockAppliesToSlot(block, template, day, slotStart, slotEnd)
+		if err != nil {
+			return false, err
+		}
+		if applies {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func blockAppliesToSlot(block ScheduleBlock, template ScheduleTemplate, day, slotStart, slotEnd time.Time) (bool, error) {
+	if block.ProfessionalID != "" && block.ProfessionalID != template.ProfessionalID {
+		return false, nil
+	}
+
+	if !blockMatchesDay(block, template.ID, day) {
+		return false, nil
+	}
+
+	blockStart, err := combineDateAndClock(day, block.StartTime)
+	if err != nil {
+		return false, err
+	}
+	blockEnd, err := combineDateAndClock(day, block.EndTime)
+	if err != nil {
+		return false, err
+	}
+	if !blockEnd.After(blockStart) {
+		return false, ErrValidation
+	}
+
+	return slotStart.Before(blockEnd) && blockStart.Before(slotEnd), nil
+}
+
+func blockMatchesDay(block ScheduleBlock, templateID string, day time.Time) bool {
+	targetDay := startOfDay(day)
+
+	switch block.Scope {
+	case "single":
+		return block.BlockDate != nil && startOfDay(*block.BlockDate).Equal(targetDay)
+	case "range":
+		if block.StartDate == nil || block.EndDate == nil {
+			return false
+		}
+		startDate := startOfDay(*block.StartDate)
+		endDate := startOfDay(*block.EndDate)
+		return (targetDay.Equal(startDate) || targetDay.After(startDate)) && (targetDay.Equal(endDate) || targetDay.Before(endDate))
+	case "template":
+		if block.DayOfWeek == nil || block.TemplateID == nil || *block.TemplateID != templateID {
+			return false
+		}
+		return isoWeekday(targetDay) == *block.DayOfWeek
+	default:
+		return false
+	}
+}
+
+func combineDateAndClock(day time.Time, clock string) (time.Time, error) {
+	parsed, err := time.Parse("15:04", clock)
+	if err != nil {
+		return time.Time{}, ErrValidation
+	}
+
+	day = startOfDay(day)
+	return time.Date(day.Year(), day.Month(), day.Day(), parsed.Hour(), parsed.Minute(), 0, 0, day.Location()), nil
+}
+
+func startOfDay(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, value.Location())
+}
+
+func weekdayKey(weekday time.Weekday) string {
+	switch weekday {
+	case time.Monday:
+		return "monday"
+	case time.Tuesday:
+		return "tuesday"
+	case time.Wednesday:
+		return "wednesday"
+	case time.Thursday:
+		return "thursday"
+	case time.Friday:
+		return "friday"
+	case time.Saturday:
+		return "saturday"
+	default:
+		return "sunday"
+	}
+}
+
+func isoWeekday(day time.Time) int {
+	if day.Weekday() == time.Sunday {
+		return 7
+	}
+	return int(day.Weekday())
 }

--- a/services/appointments-service/internal/appointments/service_test.go
+++ b/services/appointments-service/internal/appointments/service_test.go
@@ -2,10 +2,401 @@ package appointments
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 )
+
+func TestGenerateSlotsForWeekUsesEffectiveTemplateVersionForEachDay(t *testing.T) {
+	t.Parallel()
+
+	template := ScheduleTemplate{
+		ID:             "550e8400-e29b-41d4-a716-446655440010",
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440000",
+		Versions: []ScheduleTemplateVersion{
+			{
+				ID:            "550e8400-e29b-41d4-a716-446655440021",
+				TemplateID:    "550e8400-e29b-41d4-a716-446655440010",
+				VersionNumber: 2,
+				EffectiveFrom: time.Date(2026, time.April, 8, 0, 0, 0, 0, time.UTC),
+				Recurrence:    json.RawMessage(`{"wednesday":{"start_time":"10:00","end_time":"11:00","slot_duration_minutes":30}}`),
+			},
+			{
+				ID:            "550e8400-e29b-41d4-a716-446655440020",
+				TemplateID:    "550e8400-e29b-41d4-a716-446655440010",
+				VersionNumber: 1,
+				EffectiveFrom: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+				Recurrence:    json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}}`),
+			},
+		},
+	}
+
+	slots, err := GenerateSlotsForWeek(template, nil, time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("GenerateSlotsForWeek error = %v", err)
+	}
+	if len(slots) != 4 {
+		t.Fatalf("slots len = %d, want 4", len(slots))
+	}
+
+	wantStarts := []time.Time{
+		time.Date(2026, time.April, 6, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, time.April, 6, 9, 30, 0, 0, time.UTC),
+		time.Date(2026, time.April, 8, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, time.April, 8, 10, 30, 0, 0, time.UTC),
+	}
+	for i, wantStart := range wantStarts {
+		if !slots[i].StartTime.Equal(wantStart) {
+			t.Fatalf("slots[%d].start_time = %s, want %s", i, slots[i].StartTime, wantStart)
+		}
+		if slots[i].ProfessionalID != template.ProfessionalID {
+			t.Fatalf("slots[%d].professional_id = %q, want %q", i, slots[i].ProfessionalID, template.ProfessionalID)
+		}
+		if slots[i].Status != "available" {
+			t.Fatalf("slots[%d].status = %q, want available", i, slots[i].Status)
+		}
+	}
+}
+
+func TestGenerateSlotsForWeekFiltersSingleRangeAndTemplateBlocks(t *testing.T) {
+	t.Parallel()
+
+	templateID := "550e8400-e29b-41d4-a716-446655440010"
+	template := ScheduleTemplate{
+		ID:             templateID,
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440000",
+		Versions: []ScheduleTemplateVersion{{
+			ID:            "550e8400-e29b-41d4-a716-446655440020",
+			TemplateID:    templateID,
+			VersionNumber: 1,
+			EffectiveFrom: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			Recurrence: json.RawMessage(`{
+				"monday":{"start_time":"09:00","end_time":"12:00","slot_duration_minutes":30},
+				"wednesday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}
+			}`),
+		}},
+	}
+
+	monday := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+	wednesday := time.Date(2026, time.April, 8, 0, 0, 0, 0, time.UTC)
+	startDate := wednesday
+	endDate := time.Date(2026, time.April, 10, 0, 0, 0, 0, time.UTC)
+	matchingDay := 1
+	otherDay := 1
+	otherTemplateID := "550e8400-e29b-41d4-a716-446655440099"
+
+	slots, err := GenerateSlotsForWeek(template, []ScheduleBlock{
+		{
+			ProfessionalID: template.ProfessionalID,
+			Scope:          "single",
+			BlockDate:      &monday,
+			StartTime:      "10:00",
+			EndTime:        "11:00",
+		},
+		{
+			ProfessionalID: template.ProfessionalID,
+			Scope:          "range",
+			StartDate:      &startDate,
+			EndDate:        &endDate,
+			StartTime:      "09:00",
+			EndTime:        "09:30",
+		},
+		{
+			ProfessionalID: template.ProfessionalID,
+			Scope:          "template",
+			DayOfWeek:      &matchingDay,
+			StartTime:      "11:00",
+			EndTime:        "11:30",
+			TemplateID:     &templateID,
+		},
+		{
+			ProfessionalID: template.ProfessionalID,
+			Scope:          "template",
+			DayOfWeek:      &otherDay,
+			StartTime:      "09:00",
+			EndTime:        "09:30",
+			TemplateID:     &otherTemplateID,
+		},
+		{
+			ProfessionalID: "550e8400-e29b-41d4-a716-446655440111",
+			Scope:          "single",
+			BlockDate:      &monday,
+			StartTime:      "09:00",
+			EndTime:        "09:30",
+		},
+	}, monday)
+	if err != nil {
+		t.Fatalf("GenerateSlotsForWeek error = %v", err)
+	}
+	if len(slots) != 4 {
+		t.Fatalf("slots len = %d, want 4", len(slots))
+	}
+
+	wantStarts := []time.Time{
+		time.Date(2026, time.April, 6, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, time.April, 6, 9, 30, 0, 0, time.UTC),
+		time.Date(2026, time.April, 6, 11, 30, 0, 0, time.UTC),
+		time.Date(2026, time.April, 8, 9, 30, 0, 0, time.UTC),
+	}
+	for i, wantStart := range wantStarts {
+		if !slots[i].StartTime.Equal(wantStart) {
+			t.Fatalf("slots[%d].start_time = %s, want %s", i, slots[i].StartTime, wantStart)
+		}
+	}
+}
+
+func TestComposeWeekAgendaAggregatesTemplatesBlocksConsultationsAndSlots(t *testing.T) {
+	t.Parallel()
+
+	professionalID := "550e8400-e29b-41d4-a716-446655440000"
+	otherProfessionalID := "550e8400-e29b-41d4-a716-446655440999"
+	weekStart := time.Date(2026, time.April, 6, 14, 30, 0, 0, time.UTC)
+	templateID := "550e8400-e29b-41d4-a716-446655440010"
+	monday := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+	wednesday := time.Date(2026, time.April, 8, 0, 0, 0, 0, time.UTC)
+	otherTemplateID := "550e8400-e29b-41d4-a716-446655440011"
+
+	agenda, err := ComposeWeekAgenda(professionalID, weekStart, []ScheduleTemplate{
+		{
+			ID:             templateID,
+			ProfessionalID: professionalID,
+			Versions: []ScheduleTemplateVersion{
+				{
+					ID:            "550e8400-e29b-41d4-a716-446655440020",
+					TemplateID:    templateID,
+					VersionNumber: 1,
+					EffectiveFrom: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+					Recurrence:    json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}}`),
+				},
+				{
+					ID:            "550e8400-e29b-41d4-a716-446655440021",
+					TemplateID:    templateID,
+					VersionNumber: 2,
+					EffectiveFrom: time.Date(2026, time.April, 8, 0, 0, 0, 0, time.UTC),
+					Recurrence:    json.RawMessage(`{"wednesday":{"start_time":"10:00","end_time":"11:00","slot_duration_minutes":30}}`),
+				},
+				{
+					ID:            "550e8400-e29b-41d4-a716-446655440022",
+					TemplateID:    templateID,
+					VersionNumber: 3,
+					EffectiveFrom: time.Date(2026, time.April, 20, 0, 0, 0, 0, time.UTC),
+					Recurrence:    json.RawMessage(`{"monday":{"start_time":"12:00","end_time":"13:00","slot_duration_minutes":30}}`),
+				},
+			},
+		},
+		{
+			ID:             otherTemplateID,
+			ProfessionalID: otherProfessionalID,
+			Versions: []ScheduleTemplateVersion{{
+				ID:            "550e8400-e29b-41d4-a716-446655440023",
+				TemplateID:    otherTemplateID,
+				VersionNumber: 1,
+				EffectiveFrom: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+				Recurrence:    json.RawMessage(`{"monday":{"start_time":"15:00","end_time":"16:00","slot_duration_minutes":30}}`),
+			}},
+		},
+	}, []ScheduleBlock{
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440030",
+			ProfessionalID: professionalID,
+			Scope:          "single",
+			BlockDate:      &monday,
+			StartTime:      "09:30",
+			EndTime:        "10:00",
+		},
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440031",
+			ProfessionalID: professionalID,
+			Scope:          "template",
+			DayOfWeek:      intPtr(3),
+			StartTime:      "10:30",
+			EndTime:        "11:00",
+			TemplateID:     &templateID,
+		},
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440032",
+			ProfessionalID: otherProfessionalID,
+			Scope:          "single",
+			BlockDate:      &wednesday,
+			StartTime:      "10:00",
+			EndTime:        "10:30",
+		},
+	}, []Consultation{
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440040",
+			ProfessionalID: professionalID,
+			PatientID:      "550e8400-e29b-41d4-a716-446655440041",
+			Status:         ConsultationStatusScheduled,
+			Source:         ConsultationSourceSecretary,
+			ScheduledStart: time.Date(2026, time.April, 8, 9, 15, 0, 0, time.UTC),
+			ScheduledEnd:   time.Date(2026, time.April, 8, 9, 30, 0, 0, time.UTC),
+			CreatedAt:      time.Date(2026, time.April, 6, 8, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440042",
+			ProfessionalID: otherProfessionalID,
+			PatientID:      "550e8400-e29b-41d4-a716-446655440043",
+			Status:         ConsultationStatusScheduled,
+			Source:         ConsultationSourceDoctor,
+			ScheduledStart: time.Date(2026, time.April, 8, 10, 0, 0, 0, time.UTC),
+			ScheduledEnd:   time.Date(2026, time.April, 8, 10, 30, 0, 0, time.UTC),
+			CreatedAt:      time.Date(2026, time.April, 6, 7, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ComposeWeekAgenda error = %v", err)
+	}
+	if agenda.ProfessionalID != professionalID {
+		t.Fatalf("professional_id = %q, want %q", agenda.ProfessionalID, professionalID)
+	}
+	if agenda.WeekStart != "2026-04-06" {
+		t.Fatalf("week_start = %q, want %q", agenda.WeekStart, "2026-04-06")
+	}
+	if len(agenda.Templates) != 1 {
+		t.Fatalf("templates len = %d, want 1", len(agenda.Templates))
+	}
+	if len(agenda.Templates[0].Versions) != 2 {
+		t.Fatalf("template versions len = %d, want 2", len(agenda.Templates[0].Versions))
+	}
+	if agenda.Templates[0].Versions[0].VersionNumber != 1 || agenda.Templates[0].Versions[1].VersionNumber != 2 {
+		t.Fatalf("template version numbers = [%d %d], want [1 2]", agenda.Templates[0].Versions[0].VersionNumber, agenda.Templates[0].Versions[1].VersionNumber)
+	}
+	if len(agenda.Blocks) != 2 {
+		t.Fatalf("blocks len = %d, want 2", len(agenda.Blocks))
+	}
+	if len(agenda.Consultations) != 1 {
+		t.Fatalf("consultations len = %d, want 1", len(agenda.Consultations))
+	}
+	if len(agenda.Slots) != 2 {
+		t.Fatalf("slots len = %d, want 2", len(agenda.Slots))
+	}
+
+	wantSlotStarts := []time.Time{
+		time.Date(2026, time.April, 6, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, time.April, 8, 10, 0, 0, 0, time.UTC),
+	}
+	for i, wantStart := range wantSlotStarts {
+		if !agenda.Slots[i].StartTime.Equal(wantStart) {
+			t.Fatalf("slots[%d].start_time = %s, want %s", i, agenda.Slots[i].StartTime, wantStart)
+		}
+	}
+}
+
+func TestComposeWeekAgendaKeepsOnlyConsultationsIntersectingWeek(t *testing.T) {
+	t.Parallel()
+
+	professionalID := "550e8400-e29b-41d4-a716-446655440099"
+	weekStart := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+
+	agenda, err := ComposeWeekAgenda(professionalID, weekStart, nil, nil, []Consultation{
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440100",
+			ProfessionalID: professionalID,
+			PatientID:      "550e8400-e29b-41d4-a716-446655440101",
+			Status:         ConsultationStatusScheduled,
+			Source:         ConsultationSourceDoctor,
+			ScheduledStart: time.Date(2026, time.April, 8, 15, 0, 0, 0, time.UTC),
+			ScheduledEnd:   time.Date(2026, time.April, 8, 15, 20, 0, 0, time.UTC),
+		},
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440102",
+			ProfessionalID: professionalID,
+			PatientID:      "550e8400-e29b-41d4-a716-446655440103",
+			Status:         ConsultationStatusScheduled,
+			Source:         ConsultationSourceSecretary,
+			ScheduledStart: time.Date(2026, time.April, 13, 9, 0, 0, 0, time.UTC),
+			ScheduledEnd:   time.Date(2026, time.April, 13, 9, 20, 0, 0, time.UTC),
+		},
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440104",
+			ProfessionalID: professionalID,
+			PatientID:      "550e8400-e29b-41d4-a716-446655440105",
+			Status:         ConsultationStatusScheduled,
+			Source:         ConsultationSourceSecretary,
+			ScheduledStart: time.Date(2026, time.April, 5, 23, 50, 0, 0, time.UTC),
+			ScheduledEnd:   time.Date(2026, time.April, 6, 0, 10, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ComposeWeekAgenda error = %v", err)
+	}
+	if len(agenda.Consultations) != 2 {
+		t.Fatalf("consultations len = %d, want 2", len(agenda.Consultations))
+	}
+	if agenda.Consultations[0].ID != "550e8400-e29b-41d4-a716-446655440104" || agenda.Consultations[1].ID != "550e8400-e29b-41d4-a716-446655440100" {
+		t.Fatalf("consultation ids = [%s %s], want [550e8400-e29b-41d4-a716-446655440104 550e8400-e29b-41d4-a716-446655440100]", agenda.Consultations[0].ID, agenda.Consultations[1].ID)
+	}
+}
+
+func TestComposeWeekAgendaKeepsOnlyWeekRelevantTemplatesAndBlocks(t *testing.T) {
+	t.Parallel()
+
+	professionalID := "550e8400-e29b-41d4-a716-446655440000"
+	weekStart := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+	templateID := "550e8400-e29b-41d4-a716-446655440010"
+	beforeWeek := time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC)
+	afterWeek := time.Date(2026, time.April, 13, 0, 0, 0, 0, time.UTC)
+
+	agenda, err := ComposeWeekAgenda(professionalID, weekStart, []ScheduleTemplate{{
+		ID:             templateID,
+		ProfessionalID: professionalID,
+		Versions: []ScheduleTemplateVersion{{
+			ID:            "550e8400-e29b-41d4-a716-446655440020",
+			TemplateID:    templateID,
+			VersionNumber: 1,
+			EffectiveFrom: time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
+			Recurrence:    json.RawMessage(`{"monday":{"start_time":"08:00","end_time":"09:00","slot_duration_minutes":30}}`),
+		}, {
+			ID:            "550e8400-e29b-41d4-a716-446655440021",
+			TemplateID:    templateID,
+			VersionNumber: 2,
+			EffectiveFrom: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
+			Recurrence:    json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}}`),
+		}, {
+			ID:            "550e8400-e29b-41d4-a716-446655440022",
+			TemplateID:    templateID,
+			VersionNumber: 3,
+			EffectiveFrom: time.Date(2026, time.April, 20, 0, 0, 0, 0, time.UTC),
+			Recurrence:    json.RawMessage(`{"monday":{"start_time":"11:00","end_time":"12:00","slot_duration_minutes":30}}`),
+		}},
+	}}, []ScheduleBlock{
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440030",
+			ProfessionalID: professionalID,
+			Scope:          "single",
+			BlockDate:      &beforeWeek,
+			StartTime:      "09:00",
+			EndTime:        "09:30",
+		},
+		{
+			ID:             "550e8400-e29b-41d4-a716-446655440031",
+			ProfessionalID: professionalID,
+			Scope:          "single",
+			BlockDate:      &afterWeek,
+			StartTime:      "09:00",
+			EndTime:        "09:30",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ComposeWeekAgenda error = %v", err)
+	}
+	if len(agenda.Templates) != 1 {
+		t.Fatalf("templates len = %d, want 1", len(agenda.Templates))
+	}
+	if len(agenda.Templates[0].Versions) != 1 {
+		t.Fatalf("template versions len = %d, want 1", len(agenda.Templates[0].Versions))
+	}
+	if agenda.Templates[0].Versions[0].VersionNumber != 2 {
+		t.Fatalf("template version number = %d, want 2", agenda.Templates[0].Versions[0].VersionNumber)
+	}
+	if len(agenda.Blocks) != 0 {
+		t.Fatalf("blocks len = %d, want 0", len(agenda.Blocks))
+	}
+	if len(agenda.Slots) != 2 {
+		t.Fatalf("slots len = %d, want 2", len(agenda.Slots))
+	}
+}
 
 func TestScheduleServiceGetScheduleReturnsActiveTemplateForDate(t *testing.T) {
 	t.Parallel()
@@ -277,4 +668,246 @@ func (s *stubScheduleRepository) ListTemplateVersions(ctx context.Context, templ
 		return nil, nil
 	}
 	return s.listTemplateVersionsFn(ctx, templateID)
+}
+
+func TestConsultationServiceUpdateStatusAllowsValidTransition(t *testing.T) {
+	t.Parallel()
+
+	checkInTime := time.Date(2026, time.April, 16, 8, 55, 0, 0, time.UTC)
+	receptionNotes := "Paciente ya presente"
+	tests := []struct {
+		name          string
+		currentStatus ConsultationStatus
+		update        ConsultationStatusUpdateParams
+		wantStatus    ConsultationStatus
+	}{
+		{
+			name:          "scheduled to checked in",
+			currentStatus: ConsultationStatusScheduled,
+			update: ConsultationStatusUpdateParams{
+				Status:         ConsultationStatusCheckedIn,
+				CheckInTime:    &checkInTime,
+				ReceptionNotes: &receptionNotes,
+			},
+			wantStatus: ConsultationStatusCheckedIn,
+		},
+		{
+			name:          "checked in to completed",
+			currentStatus: ConsultationStatusCheckedIn,
+			update: ConsultationStatusUpdateParams{
+				Status:    ConsultationStatusCompleted,
+				ActorRole: ConsultationActorRoleDoctor,
+			},
+			wantStatus: ConsultationStatusCompleted,
+		},
+		{
+			name:          "same source is accepted",
+			currentStatus: ConsultationStatusScheduled,
+			update: ConsultationStatusUpdateParams{
+				Status: ConsultationStatusCancelled,
+				Source: sourcePtr(ConsultationSourceSecretary),
+			},
+			wantStatus: ConsultationStatusCancelled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			consultationID := "550e8400-e29b-41d4-a716-446655440300"
+			repo := &stubConsultationRepository{
+				getConsultationFn: func(_ context.Context, gotConsultationID string) (Consultation, error) {
+					if gotConsultationID != consultationID {
+						t.Fatalf("consultationID = %q, want %q", gotConsultationID, consultationID)
+					}
+					return Consultation{
+						ID:     consultationID,
+						Status: tt.currentStatus,
+						Source: ConsultationSourceSecretary,
+					}, nil
+				},
+				updateConsultationStatusFn: func(_ context.Context, gotConsultationID string, params UpdateConsultationStatusParams) (Consultation, error) {
+					if gotConsultationID != consultationID {
+						t.Fatalf("consultationID = %q, want %q", gotConsultationID, consultationID)
+					}
+					if params.Status != tt.update.Status {
+						t.Fatalf("status = %q, want %q", params.Status, tt.update.Status)
+					}
+					if !timesEqual(params.CheckInTime, tt.update.CheckInTime) {
+						t.Fatalf("check_in_time = %v, want %v", params.CheckInTime, tt.update.CheckInTime)
+					}
+					if !stringsEqual(params.ReceptionNotes, tt.update.ReceptionNotes) {
+						t.Fatalf("reception_notes = %v, want %v", params.ReceptionNotes, tt.update.ReceptionNotes)
+					}
+					return Consultation{
+						ID:             consultationID,
+						Status:         tt.wantStatus,
+						Source:         ConsultationSourceSecretary,
+						CheckInTime:    params.CheckInTime,
+						ReceptionNotes: params.ReceptionNotes,
+					}, nil
+				},
+			}
+
+			service := NewConsultationService(repo)
+
+			consultation, err := service.UpdateStatus(context.Background(), consultationID, tt.update)
+			if err != nil {
+				t.Fatalf("UpdateStatus error = %v", err)
+			}
+			if repo.getConsultationCalls != 1 {
+				t.Fatalf("GetConsultation calls = %d, want 1", repo.getConsultationCalls)
+			}
+			if repo.updateConsultationStatusCalls != 1 {
+				t.Fatalf("UpdateConsultationStatus calls = %d, want 1", repo.updateConsultationStatusCalls)
+			}
+			if consultation.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", consultation.Status, tt.wantStatus)
+			}
+			if consultation.Source != ConsultationSourceSecretary {
+				t.Fatalf("source = %q, want %q", consultation.Source, ConsultationSourceSecretary)
+			}
+		})
+	}
+}
+
+func TestConsultationServiceUpdateStatusRejectsInvalidTransitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		currentStatus ConsultationStatus
+		nextStatus    ConsultationStatus
+	}{
+		{name: "cannot move completed back to scheduled", currentStatus: ConsultationStatusCompleted, nextStatus: ConsultationStatusScheduled},
+		{name: "cannot move completed to cancelled", currentStatus: ConsultationStatusCompleted, nextStatus: ConsultationStatusCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &stubConsultationRepository{
+				getConsultationFn: func(context.Context, string) (Consultation, error) {
+					return Consultation{
+						ID:     "550e8400-e29b-41d4-a716-446655440301",
+						Status: tt.currentStatus,
+						Source: ConsultationSourceDoctor,
+					}, nil
+				},
+			}
+
+			service := NewConsultationService(repo)
+
+			_, err := service.UpdateStatus(context.Background(), "550e8400-e29b-41d4-a716-446655440301", ConsultationStatusUpdateParams{
+				Status: tt.nextStatus,
+			})
+			if !errors.Is(err, ErrValidation) {
+				t.Fatalf("err = %v, want %v", err, ErrValidation)
+			}
+			if repo.updateConsultationStatusCalls != 0 {
+				t.Fatalf("UpdateConsultationStatus calls = %d, want 0", repo.updateConsultationStatusCalls)
+			}
+		})
+	}
+}
+
+func TestConsultationServiceUpdateStatusRejectsSecretaryCompletingConsultation(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubConsultationRepository{
+		getConsultationFn: func(context.Context, string) (Consultation, error) {
+			return Consultation{
+				ID:     "550e8400-e29b-41d4-a716-446655440311",
+				Status: ConsultationStatusCheckedIn,
+				Source: ConsultationSourceSecretary,
+			}, nil
+		},
+	}
+
+	service := NewConsultationService(repo)
+
+	_, err := service.UpdateStatus(context.Background(), "550e8400-e29b-41d4-a716-446655440311", ConsultationStatusUpdateParams{
+		Status:    ConsultationStatusCompleted,
+		ActorRole: ConsultationActorRoleSecretary,
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+	if repo.updateConsultationStatusCalls != 0 {
+		t.Fatalf("UpdateConsultationStatus calls = %d, want 0", repo.updateConsultationStatusCalls)
+	}
+}
+
+func TestConsultationServiceUpdateStatusRejectsSourceChangeAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubConsultationRepository{
+		getConsultationFn: func(context.Context, string) (Consultation, error) {
+			return Consultation{
+				ID:     "550e8400-e29b-41d4-a716-446655440302",
+				Status: ConsultationStatusScheduled,
+				Source: ConsultationSourceSecretary,
+			}, nil
+		},
+	}
+
+	service := NewConsultationService(repo)
+	updatedSource := ConsultationSourceOnline
+
+	_, err := service.UpdateStatus(context.Background(), "550e8400-e29b-41d4-a716-446655440302", ConsultationStatusUpdateParams{
+		Status:    ConsultationStatusCompleted,
+		Source:    &updatedSource,
+		ActorRole: ConsultationActorRoleDoctor,
+	})
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("err = %v, want %v", err, ErrValidation)
+	}
+	if repo.updateConsultationStatusCalls != 0 {
+		t.Fatalf("UpdateConsultationStatus calls = %d, want 0", repo.updateConsultationStatusCalls)
+	}
+}
+
+type stubConsultationRepository struct {
+	getConsultationFn             func(ctx context.Context, consultationID string) (Consultation, error)
+	updateConsultationStatusFn    func(ctx context.Context, consultationID string, params UpdateConsultationStatusParams) (Consultation, error)
+	getConsultationCalls          int
+	updateConsultationStatusCalls int
+}
+
+func (s *stubConsultationRepository) GetConsultation(ctx context.Context, consultationID string) (Consultation, error) {
+	s.getConsultationCalls++
+	if s.getConsultationFn == nil {
+		return Consultation{}, nil
+	}
+	return s.getConsultationFn(ctx, consultationID)
+}
+
+func (s *stubConsultationRepository) UpdateConsultationStatus(ctx context.Context, consultationID string, params UpdateConsultationStatusParams) (Consultation, error) {
+	s.updateConsultationStatusCalls++
+	if s.updateConsultationStatusFn == nil {
+		return Consultation{}, nil
+	}
+	return s.updateConsultationStatusFn(ctx, consultationID, params)
+}
+
+func sourcePtr(source ConsultationSource) *ConsultationSource {
+	return &source
+}
+
+func timesEqual(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return left.Equal(*right)
+}
+
+func stringsEqual(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return *left == *right
 }

--- a/services/appointments-service/internal/http/server.go
+++ b/services/appointments-service/internal/http/server.go
@@ -34,6 +34,15 @@ type appointmentsRepository interface {
 	GetActiveTemplate(ctx context.Context, professionalID string, effectiveDate string) (appointments.ScheduleTemplateVersion, error)
 	GetTemplate(ctx context.Context, templateID string) (appointments.ScheduleTemplate, error)
 	ListTemplateVersions(ctx context.Context, templateID string) ([]appointments.ScheduleTemplateVersion, error)
+	CreateScheduleBlock(ctx context.Context, params appointments.CreateScheduleBlockParams) (appointments.ScheduleBlock, error)
+	GetScheduleBlock(ctx context.Context, blockID string) (appointments.ScheduleBlock, error)
+	ListScheduleBlocks(ctx context.Context, filters appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error)
+	UpdateScheduleBlock(ctx context.Context, blockID string, params appointments.UpdateScheduleBlockParams) (appointments.ScheduleBlock, error)
+	DeleteScheduleBlock(ctx context.Context, blockID string) error
+	CreateConsultation(ctx context.Context, params appointments.CreateConsultationParams) (appointments.Consultation, error)
+	GetConsultation(ctx context.Context, consultationID string) (appointments.Consultation, error)
+	ListConsultations(ctx context.Context, filters appointments.ConsultationFilters) ([]appointments.Consultation, error)
+	UpdateConsultationStatus(ctx context.Context, consultationID string, params appointments.UpdateConsultationStatusParams) (appointments.Consultation, error)
 	CreateAppointment(ctx context.Context, params appointments.CreateAppointmentParams) (appointments.Appointment, error)
 	ListAppointments(ctx context.Context, filters appointments.AppointmentFilters) ([]appointments.Appointment, error)
 	GetAppointmentByID(ctx context.Context, appointmentID string) (appointments.Appointment, error)
@@ -46,6 +55,48 @@ type createScheduleRequest struct {
 	Recurrence     json.RawMessage `json:"recurrence"`
 	CreatedBy      *string         `json:"created_by,omitempty"`
 	Reason         *string         `json:"reason,omitempty"`
+}
+
+type createConsultationRequest struct {
+	SlotID         *string                         `json:"slot_id,omitempty"`
+	ProfessionalID string                          `json:"professional_id"`
+	PatientID      string                          `json:"patient_id"`
+	Source         appointments.ConsultationSource `json:"source"`
+	ScheduledStart *time.Time                      `json:"scheduled_start,omitempty"`
+	ScheduledEnd   *time.Time                      `json:"scheduled_end,omitempty"`
+	Notes          *string                         `json:"notes,omitempty"`
+}
+
+type createBlockRequest struct {
+	ProfessionalID string  `json:"professional_id"`
+	Scope          string  `json:"scope"`
+	BlockDate      *string `json:"block_date,omitempty"`
+	StartDate      *string `json:"start_date,omitempty"`
+	EndDate        *string `json:"end_date,omitempty"`
+	DayOfWeek      *int    `json:"day_of_week,omitempty"`
+	StartTime      string  `json:"start_time"`
+	EndTime        string  `json:"end_time"`
+	TemplateID     *string `json:"template_id,omitempty"`
+}
+
+type updateBlockRequest struct {
+	ProfessionalID string  `json:"professional_id,omitempty"`
+	Scope          string  `json:"scope"`
+	BlockDate      *string `json:"block_date,omitempty"`
+	StartDate      *string `json:"start_date,omitempty"`
+	EndDate        *string `json:"end_date,omitempty"`
+	DayOfWeek      *int    `json:"day_of_week,omitempty"`
+	StartTime      string  `json:"start_time"`
+	EndTime        string  `json:"end_time"`
+	TemplateID     *string `json:"template_id,omitempty"`
+}
+
+type updateConsultationStatusRequest struct {
+	ID             string                           `json:"id"`
+	Status         appointments.ConsultationStatus  `json:"status"`
+	Source         *appointments.ConsultationSource `json:"source,omitempty"`
+	CheckInTime    *time.Time                       `json:"check_in_time,omitempty"`
+	ReceptionNotes *string                          `json:"reception_notes,omitempty"`
 }
 
 type directoryLookup interface {
@@ -84,6 +135,10 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/slots/bulk", s.bulkSlots)
 	s.mux.HandleFunc("/schedules", s.schedules)
 	s.mux.HandleFunc("/schedules/versions", s.scheduleVersions)
+	s.mux.HandleFunc("/blocks", s.blocks)
+	s.mux.HandleFunc("/blocks/", s.blockByID)
+	s.mux.HandleFunc("/consultations", s.consultations)
+	s.mux.HandleFunc("/agenda/week", s.agendaWeek)
 	s.mux.HandleFunc("/appointments", s.appointments)
 	s.mux.HandleFunc("/appointments/", s.appointmentByIDAction)
 }
@@ -187,6 +242,52 @@ func (s *Server) schedules(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
 	}
+}
+
+func (s *Server) consultations(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getConsultation(w, r)
+	case http.MethodPost:
+		s.createConsultation(w, r)
+	case http.MethodPatch:
+		s.patchConsultationStatus(w, r)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost, http.MethodPatch)
+	}
+}
+
+func (s *Server) blocks(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listBlocks(w, r)
+	case http.MethodPost:
+		s.createBlock(w, r)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
+	}
+}
+
+func (s *Server) blockByID(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getBlock(w, r)
+	case http.MethodPatch:
+		s.updateBlock(w, r)
+	case http.MethodDelete:
+		s.deleteBlock(w, r)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPatch, http.MethodDelete)
+	}
+}
+
+func (s *Server) agendaWeek(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	s.getAgendaWeek(w, r)
 }
 
 func (s *Server) scheduleVersions(w http.ResponseWriter, r *http.Request) {
@@ -406,6 +507,506 @@ func (s *Server) getScheduleVersions(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"items": versions})
 }
 
+func (s *Server) createBlock(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	var request createBlockRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	request.ProfessionalID, ok = enforceProfessionalScope(actor, request.ProfessionalID)
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	params := appointments.CreateScheduleBlockParams{
+		ProfessionalID: request.ProfessionalID,
+		Scope:          request.Scope,
+		BlockDate:      request.BlockDate,
+		StartDate:      request.StartDate,
+		EndDate:        request.EndDate,
+		DayOfWeek:      request.DayOfWeek,
+		StartTime:      request.StartTime,
+		EndTime:        request.EndTime,
+		TemplateID:     request.TemplateID,
+	}
+	if err := validateCreateBlockRequest(params); errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block request")
+		return
+	}
+
+	professionalExists, err := s.dir.ProfessionalExists(r.Context(), params.ProfessionalID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+	if !professionalExists {
+		writeError(w, http.StatusBadRequest, "professional not found")
+		return
+	}
+
+	block, err := s.repo.CreateScheduleBlock(r.Context(), params)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block request")
+		return
+	}
+	if errors.Is(err, appointments.ErrConflict) {
+		writeError(w, http.StatusConflict, "block conflicts with existing schedule")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create block")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, block)
+}
+
+func (s *Server) listBlocks(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	professionalID, ok := enforceProfessionalScope(actor, r.URL.Query().Get("professional_id"))
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	filters := appointments.ScheduleBlockFilters{
+		ProfessionalID: professionalID,
+		TemplateID:     strings.TrimSpace(r.URL.Query().Get("template_id")),
+		Scope:          strings.TrimSpace(r.URL.Query().Get("scope")),
+	}
+
+	blocks, err := s.repo.ListScheduleBlocks(r.Context(), filters)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list blocks")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"items": blocks})
+}
+
+func (s *Server) getBlock(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	block, err := s.repo.GetScheduleBlock(r.Context(), blockIDFromPath(r.URL.Path))
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block id")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "block not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load block")
+		return
+	}
+
+	if _, ok := enforceProfessionalScope(actor, block.ProfessionalID); !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, block)
+}
+
+func (s *Server) updateBlock(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	blockID := blockIDFromPath(r.URL.Path)
+	existing, err := s.repo.GetScheduleBlock(r.Context(), blockID)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block id")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "block not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load block")
+		return
+	}
+
+	if _, ok := enforceProfessionalScope(actor, existing.ProfessionalID); !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	var request updateBlockRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	professionalID := request.ProfessionalID
+	if strings.TrimSpace(professionalID) == "" {
+		professionalID = existing.ProfessionalID
+	}
+	professionalID, ok = enforceProfessionalScope(actor, professionalID)
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	params := appointments.UpdateScheduleBlockParams{
+		ProfessionalID: professionalID,
+		Scope:          request.Scope,
+		BlockDate:      request.BlockDate,
+		StartDate:      request.StartDate,
+		EndDate:        request.EndDate,
+		DayOfWeek:      request.DayOfWeek,
+		StartTime:      request.StartTime,
+		EndTime:        request.EndTime,
+		TemplateID:     request.TemplateID,
+	}
+	if err := validateUpdateBlockRequest(params); errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block request")
+		return
+	}
+
+	professionalExists, err := s.dir.ProfessionalExists(r.Context(), params.ProfessionalID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+	if !professionalExists {
+		writeError(w, http.StatusBadRequest, "professional not found")
+		return
+	}
+
+	updated, err := s.repo.UpdateScheduleBlock(r.Context(), blockID, params)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block request")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "block not found")
+		return
+	}
+	if errors.Is(err, appointments.ErrConflict) {
+		writeError(w, http.StatusConflict, "block conflicts with existing schedule")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update block")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) deleteBlock(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	blockID := blockIDFromPath(r.URL.Path)
+	block, err := s.repo.GetScheduleBlock(r.Context(), blockID)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block id")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "block not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load block")
+		return
+	}
+
+	if _, ok := enforceProfessionalScope(actor, block.ProfessionalID); !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	err = s.repo.DeleteScheduleBlock(r.Context(), blockID)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid block id")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "block not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete block")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) createConsultation(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	var request createConsultationRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	request.ProfessionalID, ok = enforceProfessionalScope(actor, request.ProfessionalID)
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	params := appointments.CreateConsultationParams{
+		SlotID:         request.SlotID,
+		ProfessionalID: request.ProfessionalID,
+		PatientID:      request.PatientID,
+		Source:         request.Source,
+		ScheduledStart: request.ScheduledStart,
+		ScheduledEnd:   request.ScheduledEnd,
+		Notes:          request.Notes,
+	}
+
+	if _, err := validateCreateConsultationRequest(params); errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid consultation request")
+		return
+	}
+
+	professionalExists, err := s.dir.ProfessionalExists(r.Context(), params.ProfessionalID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+	if !professionalExists {
+		writeError(w, http.StatusBadRequest, "professional not found")
+		return
+	}
+
+	patientExists, err := s.dir.PatientExists(r.Context(), params.PatientID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+	if !patientExists {
+		writeError(w, http.StatusBadRequest, "patient not found")
+		return
+	}
+
+	consultation, err := s.repo.CreateConsultation(r.Context(), params)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid consultation request")
+		return
+	}
+	if errors.Is(err, appointments.ErrConflict) {
+		writeError(w, http.StatusConflict, "consultation conflicts with existing schedule")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create consultation")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, consultation)
+}
+
+func (s *Server) getConsultation(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	consultation, err := s.repo.GetConsultation(r.Context(), strings.TrimSpace(r.URL.Query().Get("id")))
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid consultation filters")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "consultation not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load consultation")
+		return
+	}
+
+	if _, ok := enforceProfessionalScope(actor, consultation.ProfessionalID); !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, consultation)
+}
+
+func (s *Server) patchConsultationStatus(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	var request updateConsultationStatusRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	consultation, err := s.repo.GetConsultation(r.Context(), request.ID)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid consultation status update")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "consultation not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load consultation")
+		return
+	}
+
+	if _, ok := enforceProfessionalScope(actor, consultation.ProfessionalID); !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+	if actor.Role == "secretary" && request.Status == appointments.ConsultationStatusCompleted {
+		writeError(w, http.StatusForbidden, "insufficient role")
+		return
+	}
+
+	updated, err := appointments.NewConsultationService(s.repo).UpdateStatus(r.Context(), request.ID, appointments.ConsultationStatusUpdateParams{
+		Status:         request.Status,
+		Source:         request.Source,
+		ActorRole:      consultationActorRoleFromHTTPActor(actor.Role),
+		CheckInTime:    request.CheckInTime,
+		ReceptionNotes: request.ReceptionNotes,
+	})
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid consultation status update")
+		return
+	}
+	if errors.Is(err, appointments.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "consultation not found")
+		return
+	}
+	if errors.Is(err, appointments.ErrConflict) {
+		writeError(w, http.StatusConflict, "consultation status update conflicts with existing state")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update consultation")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) getAgendaWeek(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAgendaActor(w, r)
+	if !ok {
+		return
+	}
+
+	professionalID, ok := enforceProfessionalScope(actor, r.URL.Query().Get("professional_id"))
+	if !ok {
+		writeError(w, http.StatusForbidden, "forbidden professional scope")
+		return
+	}
+
+	weekStart, err := validateAgendaWeekFilters(professionalID, r.URL.Query().Get("week_start"))
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid agenda week filters")
+		return
+	}
+
+	blocks, err := s.repo.ListScheduleBlocks(r.Context(), appointments.ScheduleBlockFilters{ProfessionalID: professionalID})
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid agenda week filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load agenda week")
+		return
+	}
+
+	consultations, err := s.repo.ListConsultations(r.Context(), appointments.ConsultationFilters{
+		ProfessionalID: professionalID,
+		WeekStart:      weekStart.Format("2006-01-02"),
+	})
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid agenda week filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load agenda week")
+		return
+	}
+
+	templates, err := s.loadWeekAgendaTemplates(r.Context(), professionalID, weekStart)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid agenda week filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load agenda week")
+		return
+	}
+
+	agenda, err := appointments.ComposeWeekAgenda(professionalID, weekStart, templates, blocks, consultations)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid agenda week filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load agenda week")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, agenda)
+}
+
+func (s *Server) loadWeekAgendaTemplates(ctx context.Context, professionalID string, weekStart time.Time) ([]appointments.ScheduleTemplate, error) {
+	effectiveDate := weekStart.AddDate(0, 0, 6).Format("2006-01-02")
+	activeVersion, err := s.repo.GetActiveTemplate(ctx, professionalID, effectiveDate)
+	if errors.Is(err, appointments.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	template, err := s.repo.GetTemplate(ctx, activeVersion.TemplateID)
+	if err != nil {
+		return nil, err
+	}
+
+	versions, err := s.repo.ListTemplateVersions(ctx, template.ID)
+	if err != nil {
+		return nil, err
+	}
+	template.Versions = versions
+
+	return []appointments.ScheduleTemplate{template}, nil
+}
+
 func (s *Server) createAppointment(w http.ResponseWriter, r *http.Request) {
 	actor, ok := s.requireAgendaActor(w, r)
 	if !ok {
@@ -530,6 +1131,98 @@ func validateCreateScheduleRequest(params appointments.CreateTemplateParams) err
 	return nil
 }
 
+func validateCreateConsultationRequest(params appointments.CreateConsultationParams) (appointments.CreateConsultationParams, error) {
+	professionalID := strings.TrimSpace(params.ProfessionalID)
+	patientID := strings.TrimSpace(params.PatientID)
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return appointments.CreateConsultationParams{}, appointments.ErrValidation
+	}
+	if _, err := uuid.Parse(patientID); err != nil {
+		return appointments.CreateConsultationParams{}, appointments.ErrValidation
+	}
+	if !params.Source.IsValid() {
+		return appointments.CreateConsultationParams{}, appointments.ErrValidation
+	}
+	if params.SlotID != nil && strings.TrimSpace(*params.SlotID) == "" {
+		return appointments.CreateConsultationParams{}, appointments.ErrValidation
+	}
+	if params.SlotID != nil && (params.ScheduledStart != nil || params.ScheduledEnd != nil) {
+		return appointments.CreateConsultationParams{}, appointments.ErrValidation
+	}
+	if params.SlotID == nil {
+		if params.ScheduledStart == nil || params.ScheduledEnd == nil {
+			return appointments.CreateConsultationParams{}, appointments.ErrValidation
+		}
+		scheduledStart := params.ScheduledStart.UTC()
+		scheduledEnd := params.ScheduledEnd.UTC()
+		if !scheduledStart.Before(scheduledEnd) {
+			return appointments.CreateConsultationParams{}, appointments.ErrValidation
+		}
+		params.ScheduledStart = &scheduledStart
+		params.ScheduledEnd = &scheduledEnd
+	}
+	params.ProfessionalID = professionalID
+	params.PatientID = patientID
+	if params.Notes != nil {
+		notes := strings.TrimSpace(*params.Notes)
+		params.Notes = &notes
+	}
+
+	return params, nil
+}
+
+func validateCreateBlockRequest(params appointments.CreateScheduleBlockParams) error {
+	_, err := normalizeBlockParams(params.ProfessionalID, params.Scope, params.BlockDate, params.StartDate, params.EndDate, params.DayOfWeek, params.StartTime, params.EndTime, params.TemplateID)
+	return err
+}
+
+func validateUpdateBlockRequest(params appointments.UpdateScheduleBlockParams) error {
+	_, err := normalizeBlockParams(params.ProfessionalID, params.Scope, params.BlockDate, params.StartDate, params.EndDate, params.DayOfWeek, params.StartTime, params.EndTime, params.TemplateID)
+	return err
+}
+
+func normalizeBlockParams(professionalIDValue, scopeValue string, blockDateValue, startDateValue, endDateValue *string, dayOfWeekValue *int, startTimeValue, endTimeValue string, templateIDValue *string) (appointments.CreateScheduleBlockParams, error) {
+	params := appointments.CreateScheduleBlockParams{
+		ProfessionalID: strings.TrimSpace(professionalIDValue),
+		Scope:          strings.TrimSpace(scopeValue),
+		BlockDate:      trimOptionalString(blockDateValue),
+		StartDate:      trimOptionalString(startDateValue),
+		EndDate:        trimOptionalString(endDateValue),
+		DayOfWeek:      dayOfWeekValue,
+		StartTime:      strings.TrimSpace(startTimeValue),
+		EndTime:        strings.TrimSpace(endTimeValue),
+		TemplateID:     trimOptionalString(templateIDValue),
+	}
+
+	blockParams, err := appointments.ValidateScheduleBlockParams(params)
+	if err != nil {
+		return appointments.CreateScheduleBlockParams{}, err
+	}
+
+	return blockParams, nil
+}
+
+func trimOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	return &trimmed
+}
+
+func validateAgendaWeekFilters(professionalIDValue, weekStartValue string) (time.Time, error) {
+	if _, err := uuid.Parse(strings.TrimSpace(professionalIDValue)); err != nil {
+		return time.Time{}, appointments.ErrValidation
+	}
+
+	weekStart, err := time.Parse("2006-01-02", strings.TrimSpace(weekStartValue))
+	if err != nil {
+		return time.Time{}, appointments.ErrValidation
+	}
+
+	return weekStart.UTC(), nil
+}
+
 func writeUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("WWW-Authenticate", `Bearer realm="appointments-service"`)
 	writeError(w, http.StatusUnauthorized, "unauthorized")
@@ -618,6 +1311,21 @@ func enforceProfessionalScope(actor ActorContext, requestedProfessionalID string
 	}
 
 	return requestedProfessionalID, requestedProfessionalID == actor.ProfessionalID
+}
+
+func consultationActorRoleFromHTTPActor(role string) appointments.ConsultationActorRole {
+	switch role {
+	case "doctor":
+		return appointments.ConsultationActorRoleDoctor
+	case "secretary":
+		return appointments.ConsultationActorRoleSecretary
+	default:
+		return appointments.ConsultationActorRoleSecretary
+	}
+}
+
+func blockIDFromPath(path string) string {
+	return strings.Trim(strings.TrimPrefix(path, "/blocks/"), "/")
 }
 
 func (s *Server) authorizeCancelAppointment(w http.ResponseWriter, r *http.Request, actor ActorContext, appointmentID string) bool {

--- a/services/appointments-service/internal/http/server_test.go
+++ b/services/appointments-service/internal/http/server_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -772,6 +773,1005 @@ func TestGetScheduleVersionsScenarios(t *testing.T) {
 	}
 }
 
+func TestCreateBlockPostScenarios(t *testing.T) {
+	const validProfessionalID = "550e8400-e29b-41d4-a716-446655440502"
+	validTemplateID := "550e8400-e29b-41d4-a716-446655440503"
+	doctorProfessionalID := validProfessionalID
+	createdAt := time.Date(2026, time.April, 16, 9, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(5 * time.Minute)
+	blockDate := time.Date(2026, time.May, 12, 0, 0, 0, 0, time.UTC)
+	createdBlock := appointments.ScheduleBlock{
+		ID:             "550e8400-e29b-41d4-a716-446655440501",
+		ProfessionalID: validProfessionalID,
+		Scope:          "single",
+		BlockDate:      &blockDate,
+		StartTime:      "09:00",
+		EndTime:        "12:00",
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+	}
+	templateBlock := appointments.ScheduleBlock{
+		ID:             "550e8400-e29b-41d4-a716-446655440504",
+		ProfessionalID: validProfessionalID,
+		Scope:          "template",
+		DayOfWeek:      intPtr(1),
+		StartTime:      "13:00",
+		EndTime:        "15:00",
+		TemplateID:     &validTemplateID,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+	}
+
+	tests := []struct {
+		name                  string
+		body                  string
+		directory             stubDirectoryLookup
+		repoErr               error
+		repoBlock             appointments.ScheduleBlock
+		wantStatus            int
+		wantError             string
+		wantProfessionalCalls int
+		wantCreateRepoCalls   int
+	}{
+		{
+			name:                "invalid json body returns bad request",
+			body:                `{"professional_id":`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid json body",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name:                "invalid request returns bad request",
+			body:                `{"professional_id":"not-a-uuid","scope":"single","block_date":"2026-05-12","start_time":"09:00","end_time":"12:00"}`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid block request",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name: "doctor scope is enforced before create",
+			body: `{"scope":"single","block_date":"2026-05-12","start_time":"09:00","end_time":"12:00"}`,
+			directory: stubDirectoryLookup{
+				currentUser:        directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+				professionalExists: true,
+			},
+			repoBlock:             createdBlock,
+			wantStatus:            http.StatusCreated,
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "missing professional returns bad request",
+			body: `{"professional_id":"` + validProfessionalID + `","scope":"single","block_date":"2026-05-12","start_time":"09:00","end_time":"12:00"}`,
+			directory: stubDirectoryLookup{
+				professionalExists: false,
+			},
+			wantStatus:            http.StatusBadRequest,
+			wantError:             "professional not found",
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   0,
+		},
+		{
+			name: "template scope success returns created block",
+			body: `{"professional_id":"` + validProfessionalID + `","scope":"template","day_of_week":1,"start_time":"13:00","end_time":"15:00","template_id":"` + validTemplateID + `"}`,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+			},
+			repoBlock:             templateBlock,
+			wantStatus:            http.StatusCreated,
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.directory
+			repo := &stubAppointmentsRepository{
+				createScheduleBlockFn: func(_ context.Context, params appointments.CreateScheduleBlockParams) (appointments.ScheduleBlock, error) {
+					if params.ProfessionalID != validProfessionalID {
+						t.Fatalf("professional_id = %q, want %q", params.ProfessionalID, validProfessionalID)
+					}
+					return tt.repoBlock, tt.repoErr
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &dir)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodPost, "/blocks", bytes.NewBufferString(tt.body)))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if dir.professionalCalls != tt.wantProfessionalCalls {
+				t.Fatalf("ProfessionalExists calls = %d, want %d", dir.professionalCalls, tt.wantProfessionalCalls)
+			}
+			if repo.createScheduleBlockCalls != tt.wantCreateRepoCalls {
+				t.Fatalf("CreateScheduleBlock calls = %d, want %d", repo.createScheduleBlockCalls, tt.wantCreateRepoCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.ScheduleBlock
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != tt.repoBlock.ID || response.Scope != tt.repoBlock.Scope || response.ProfessionalID != tt.repoBlock.ProfessionalID {
+				t.Fatalf("response = %+v, want %+v", response, tt.repoBlock)
+			}
+		})
+	}
+}
+
+func TestListBlocksScenarios(t *testing.T) {
+	const validProfessionalID = "550e8400-e29b-41d4-a716-446655440602"
+	doctorProfessionalID := validProfessionalID
+	blockDate := time.Date(2026, time.May, 12, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name               string
+		target             string
+		directory          stubDirectoryLookup
+		repoErr            error
+		wantStatus         int
+		wantError          string
+		wantListRepoCalls  int
+		wantReturnedItems  int
+		wantProfessionalID string
+	}{
+		{
+			name:               "invalid filters return bad request",
+			target:             "/blocks?professional_id=bad-id",
+			repoErr:            appointments.ErrValidation,
+			wantStatus:         http.StatusBadRequest,
+			wantError:          "invalid block filters",
+			wantListRepoCalls:  1,
+			wantProfessionalID: "bad-id",
+		},
+		{
+			name:   "doctor scope is enforced for list",
+			target: "/blocks?scope=single",
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+			},
+			wantStatus:         http.StatusOK,
+			wantListRepoCalls:  1,
+			wantReturnedItems:  1,
+			wantProfessionalID: validProfessionalID,
+		},
+		{
+			name:               "success returns listed blocks",
+			target:             "/blocks?professional_id=" + validProfessionalID + "&scope=single",
+			wantStatus:         http.StatusOK,
+			wantListRepoCalls:  1,
+			wantReturnedItems:  1,
+			wantProfessionalID: validProfessionalID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubAppointmentsRepository{
+				listScheduleBlocksFn: func(_ context.Context, filters appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error) {
+					if filters.ProfessionalID != tt.wantProfessionalID {
+						t.Fatalf("professional_id = %q, want %q", filters.ProfessionalID, tt.wantProfessionalID)
+					}
+					if tt.repoErr != nil {
+						return nil, tt.repoErr
+					}
+					return []appointments.ScheduleBlock{{
+						ID:             "550e8400-e29b-41d4-a716-446655440601",
+						ProfessionalID: validProfessionalID,
+						Scope:          "single",
+						BlockDate:      &blockDate,
+						StartTime:      "09:00",
+						EndTime:        "12:00",
+					}}, nil
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &tt.directory)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, tt.target, nil))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if repo.listScheduleBlocksCalls != tt.wantListRepoCalls {
+				t.Fatalf("ListScheduleBlocks calls = %d, want %d", repo.listScheduleBlocksCalls, tt.wantListRepoCalls)
+			}
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response struct {
+				Items []appointments.ScheduleBlock `json:"items"`
+			}
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if len(response.Items) != tt.wantReturnedItems {
+				t.Fatalf("items len = %d, want %d", len(response.Items), tt.wantReturnedItems)
+			}
+		})
+	}
+}
+
+func TestBlockByIDScenarios(t *testing.T) {
+	const validBlockID = "550e8400-e29b-41d4-a716-446655440701"
+	const validProfessionalID = "550e8400-e29b-41d4-a716-446655440702"
+	const otherProfessionalID = "550e8400-e29b-41d4-a716-446655440799"
+	doctorProfessionalID := validProfessionalID
+	blockDate := time.Date(2026, time.May, 12, 0, 0, 0, 0, time.UTC)
+	storedBlock := appointments.ScheduleBlock{ID: validBlockID, ProfessionalID: validProfessionalID, Scope: "single", BlockDate: &blockDate, StartTime: "09:00", EndTime: "12:00"}
+	otherBlock := appointments.ScheduleBlock{ID: validBlockID, ProfessionalID: otherProfessionalID, Scope: "single", BlockDate: &blockDate, StartTime: "09:00", EndTime: "12:00"}
+
+	t.Run("get enforces doctor ownership", func(t *testing.T) {
+		repo := &stubAppointmentsRepository{
+			getScheduleBlockFn: func(context.Context, string) (appointments.ScheduleBlock, error) {
+				return otherBlock, nil
+			},
+		}
+		dir := &stubDirectoryLookup{currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true}}
+		server := NewServer(testAppointmentsConfig(), repo, dir)
+		recorder := httptest.NewRecorder()
+
+		server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, "/blocks/"+validBlockID, nil))
+
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+		}
+		assertErrorResponse(t, recorder.Body, "forbidden professional scope")
+	})
+
+	t.Run("patch updates block for allowed scope", func(t *testing.T) {
+		repo := &stubAppointmentsRepository{
+			getScheduleBlockFn: func(context.Context, string) (appointments.ScheduleBlock, error) {
+				return storedBlock, nil
+			},
+			updateScheduleBlockFn: func(_ context.Context, blockID string, params appointments.UpdateScheduleBlockParams) (appointments.ScheduleBlock, error) {
+				if blockID != validBlockID {
+					t.Fatalf("blockID = %q, want %q", blockID, validBlockID)
+				}
+				if params.ProfessionalID != validProfessionalID {
+					t.Fatalf("professional_id = %q, want %q", params.ProfessionalID, validProfessionalID)
+				}
+				return storedBlock, nil
+			},
+		}
+		dir := &stubDirectoryLookup{currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true}, professionalExists: true}
+		server := NewServer(testAppointmentsConfig(), repo, dir)
+		recorder := httptest.NewRecorder()
+
+		server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodPatch, "/blocks/"+validBlockID, bytes.NewBufferString(`{"scope":"single","block_date":"2026-05-12","start_time":"10:00","end_time":"12:00"}`)))
+
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+		}
+		if repo.getScheduleBlockCalls != 1 {
+			t.Fatalf("GetScheduleBlock calls = %d, want 1", repo.getScheduleBlockCalls)
+		}
+		if repo.updateScheduleBlockCalls != 1 {
+			t.Fatalf("UpdateScheduleBlock calls = %d, want 1", repo.updateScheduleBlockCalls)
+		}
+	})
+
+	t.Run("delete checks ownership before mutation", func(t *testing.T) {
+		repo := &stubAppointmentsRepository{
+			getScheduleBlockFn: func(context.Context, string) (appointments.ScheduleBlock, error) {
+				return otherBlock, nil
+			},
+			deleteScheduleBlockFn: func(context.Context, string) error {
+				return errors.New("delete should not be called")
+			},
+		}
+		dir := &stubDirectoryLookup{currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true}}
+		server := NewServer(testAppointmentsConfig(), repo, dir)
+		recorder := httptest.NewRecorder()
+
+		server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodDelete, "/blocks/"+validBlockID, nil))
+
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+		}
+		if repo.deleteScheduleBlockCalls != 0 {
+			t.Fatalf("DeleteScheduleBlock calls = %d, want 0", repo.deleteScheduleBlockCalls)
+		}
+		assertErrorResponse(t, recorder.Body, "forbidden professional scope")
+	})
+}
+
+func TestCreateConsultationPostScenarios(t *testing.T) {
+	const (
+		validConsultationID = "550e8400-e29b-41d4-a716-446655440401"
+		validSlotID         = "550e8400-e29b-41d4-a716-446655440402"
+		validPatientID      = "550e8400-e29b-41d4-a716-446655440403"
+		validProfessionalID = "550e8400-e29b-41d4-a716-446655440404"
+	)
+
+	validBody := `{"slot_id":"` + validSlotID + `","patient_id":"` + validPatientID + `","professional_id":"` + validProfessionalID + `","source":"secretary","notes":"Paciente con estudios"}`
+	standaloneStart := time.Date(2026, time.April, 16, 11, 0, 0, 0, time.UTC)
+	standaloneEnd := time.Date(2026, time.April, 16, 11, 20, 0, 0, time.UTC)
+	standaloneBody := `{"patient_id":"` + validPatientID + `","professional_id":"` + validProfessionalID + `","source":"doctor","scheduled_start":"2026-04-16T11:00:00Z","scheduled_end":"2026-04-16T11:20:00Z"}`
+	createdAt := time.Date(2026, time.April, 16, 9, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(5 * time.Minute)
+	scheduledStart := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 10, 30, 0, 0, time.UTC)
+	notes := "Paciente con estudios"
+	createdConsultation := appointments.Consultation{
+		ID:             validConsultationID,
+		SlotID:         ptrToString(validSlotID),
+		ProfessionalID: validProfessionalID,
+		PatientID:      validPatientID,
+		Status:         appointments.ConsultationStatusScheduled,
+		Source:         appointments.ConsultationSourceSecretary,
+		ScheduledStart: scheduledStart,
+		ScheduledEnd:   scheduledEnd,
+		Notes:          &notes,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+	}
+	standaloneConsultation := appointments.Consultation{
+		ID:             validConsultationID,
+		ProfessionalID: validProfessionalID,
+		PatientID:      validPatientID,
+		Status:         appointments.ConsultationStatusScheduled,
+		Source:         appointments.ConsultationSourceDoctor,
+		ScheduledStart: standaloneStart,
+		ScheduledEnd:   standaloneEnd,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+	}
+	doctorProfessionalID := validProfessionalID
+
+	tests := []struct {
+		name                  string
+		body                  string
+		directory             stubDirectoryLookup
+		repoErr               error
+		repoConsultation      appointments.Consultation
+		wantStatus            int
+		wantError             string
+		wantConsultation      *appointments.Consultation
+		wantProfessionalCalls int
+		wantPatientCalls      int
+		wantCreateRepoCalls   int
+	}{
+		{
+			name:                "invalid json body returns bad request",
+			body:                `{"professional_id":`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid json body",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name:                "invalid request returns bad request",
+			body:                `{"professional_id":"not-a-uuid","patient_id":"` + validPatientID + `","source":"secretary"}`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid consultation request",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name:                "standalone consultation requires explicit schedule range",
+			body:                `{"professional_id":"` + validProfessionalID + `","patient_id":"` + validPatientID + `","source":"doctor"}`,
+			wantStatus:          http.StatusBadRequest,
+			wantError:           "invalid consultation request",
+			wantCreateRepoCalls: 0,
+		},
+		{
+			name: "doctor scope is enforced before create",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				currentUser:        directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+				professionalExists: true,
+				patientExists:      true,
+			},
+			repoConsultation:      createdConsultation,
+			wantStatus:            http.StatusCreated,
+			wantConsultation:      &createdConsultation,
+			wantProfessionalCalls: 1,
+			wantPatientCalls:      1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "missing professional returns bad request",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: false,
+			},
+			wantStatus:            http.StatusBadRequest,
+			wantError:             "professional not found",
+			wantProfessionalCalls: 1,
+			wantCreateRepoCalls:   0,
+		},
+		{
+			name: "missing patient returns bad request",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+				patientExists:      false,
+			},
+			wantStatus:            http.StatusBadRequest,
+			wantError:             "patient not found",
+			wantProfessionalCalls: 1,
+			wantPatientCalls:      1,
+			wantCreateRepoCalls:   0,
+		},
+		{
+			name: "repo conflict returns conflict",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+				patientExists:      true,
+			},
+			repoErr:               appointments.ErrConflict,
+			wantStatus:            http.StatusConflict,
+			wantError:             "consultation conflicts with existing schedule",
+			wantProfessionalCalls: 1,
+			wantPatientCalls:      1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "standalone success returns created consultation",
+			body: standaloneBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+				patientExists:      true,
+			},
+			repoConsultation:      standaloneConsultation,
+			wantStatus:            http.StatusCreated,
+			wantConsultation:      &standaloneConsultation,
+			wantProfessionalCalls: 1,
+			wantPatientCalls:      1,
+			wantCreateRepoCalls:   1,
+		},
+		{
+			name: "success returns created consultation",
+			body: validBody,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+				patientExists:      true,
+			},
+			repoConsultation:      createdConsultation,
+			wantStatus:            http.StatusCreated,
+			wantConsultation:      &createdConsultation,
+			wantProfessionalCalls: 1,
+			wantPatientCalls:      1,
+			wantCreateRepoCalls:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.directory
+			repo := &stubAppointmentsRepository{
+				createConsultationFn: func(_ context.Context, params appointments.CreateConsultationParams) (appointments.Consultation, error) {
+					if params.ProfessionalID != validProfessionalID {
+						t.Fatalf("professional_id = %q, want %q", params.ProfessionalID, validProfessionalID)
+					}
+					if params.PatientID != validPatientID {
+						t.Fatalf("patient_id = %q, want %q", params.PatientID, validPatientID)
+					}
+					if strings.Contains(tt.body, `"source":"doctor"`) {
+						if params.Source != appointments.ConsultationSourceDoctor {
+							t.Fatalf("source = %q, want %q", params.Source, appointments.ConsultationSourceDoctor)
+						}
+						if params.SlotID != nil {
+							t.Fatalf("slot_id = %v, want nil", params.SlotID)
+						}
+						if !timesMatch(params.ScheduledStart, &standaloneStart) {
+							t.Fatalf("scheduled_start = %v, want %v", params.ScheduledStart, standaloneStart)
+						}
+						if !timesMatch(params.ScheduledEnd, &standaloneEnd) {
+							t.Fatalf("scheduled_end = %v, want %v", params.ScheduledEnd, standaloneEnd)
+						}
+					} else {
+						if params.Source != appointments.ConsultationSourceSecretary {
+							t.Fatalf("source = %q, want %q", params.Source, appointments.ConsultationSourceSecretary)
+						}
+						if params.SlotID == nil || *params.SlotID != validSlotID {
+							t.Fatalf("slot_id = %v, want %q", params.SlotID, validSlotID)
+						}
+						if params.ScheduledStart != nil || params.ScheduledEnd != nil {
+							t.Fatalf("scheduled range = [%v %v], want nil", params.ScheduledStart, params.ScheduledEnd)
+						}
+						if params.Notes == nil || *params.Notes != notes {
+							t.Fatalf("notes = %v, want %q", params.Notes, notes)
+						}
+					}
+					return tt.repoConsultation, tt.repoErr
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &dir)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodPost, "/consultations", bytes.NewBufferString(tt.body)))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if dir.professionalCalls != tt.wantProfessionalCalls {
+				t.Fatalf("ProfessionalExists calls = %d, want %d", dir.professionalCalls, tt.wantProfessionalCalls)
+			}
+			if dir.patientCalls != tt.wantPatientCalls {
+				t.Fatalf("PatientExists calls = %d, want %d", dir.patientCalls, tt.wantPatientCalls)
+			}
+			if repo.createConsultationCalls != tt.wantCreateRepoCalls {
+				t.Fatalf("CreateConsultation calls = %d, want %d", repo.createConsultationCalls, tt.wantCreateRepoCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.Consultation
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != tt.wantConsultation.ID || response.ProfessionalID != tt.wantConsultation.ProfessionalID || response.PatientID != tt.wantConsultation.PatientID || response.Status != tt.wantConsultation.Status {
+				t.Fatalf("response = %+v, want %+v", response, *tt.wantConsultation)
+			}
+		})
+	}
+}
+
+func TestGetConsultationScenarios(t *testing.T) {
+	const (
+		validConsultationID = "550e8400-e29b-41d4-a716-446655440411"
+		validProfessionalID = "550e8400-e29b-41d4-a716-446655440412"
+		validPatientID      = "550e8400-e29b-41d4-a716-446655440413"
+	)
+
+	otherProfessionalID := "550e8400-e29b-41d4-a716-446655440414"
+	doctorProfessionalID := validProfessionalID
+	consultation := appointments.Consultation{
+		ID:             validConsultationID,
+		ProfessionalID: validProfessionalID,
+		PatientID:      validPatientID,
+		Status:         appointments.ConsultationStatusCheckedIn,
+		Source:         appointments.ConsultationSourceOnline,
+	}
+
+	tests := []struct {
+		name             string
+		target           string
+		directory        stubDirectoryLookup
+		repoErr          error
+		repoConsultation appointments.Consultation
+		wantStatus       int
+		wantError        string
+		wantGetRepoCalls int
+	}{
+		{
+			name:             "invalid consultation id returns bad request",
+			target:           "/consultations?id=bad-id",
+			repoErr:          appointments.ErrValidation,
+			wantStatus:       http.StatusBadRequest,
+			wantError:        "invalid consultation filters",
+			wantGetRepoCalls: 1,
+		},
+		{
+			name:   "doctor cannot read another professional consultation",
+			target: "/consultations?id=" + validConsultationID,
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+			},
+			repoConsultation: appointments.Consultation{ID: validConsultationID, ProfessionalID: otherProfessionalID, PatientID: validPatientID},
+			wantStatus:       http.StatusForbidden,
+			wantError:        "forbidden professional scope",
+			wantGetRepoCalls: 1,
+		},
+		{
+			name:             "not found returns not found",
+			target:           "/consultations?id=" + validConsultationID,
+			repoErr:          appointments.ErrNotFound,
+			wantStatus:       http.StatusNotFound,
+			wantError:        "consultation not found",
+			wantGetRepoCalls: 1,
+		},
+		{
+			name:             "success returns consultation",
+			target:           "/consultations?id=" + validConsultationID,
+			repoConsultation: consultation,
+			wantStatus:       http.StatusOK,
+			wantGetRepoCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubAppointmentsRepository{
+				getConsultationFn: func(_ context.Context, consultationID string) (appointments.Consultation, error) {
+					if consultationID != validConsultationID && tt.repoErr == nil {
+						t.Fatalf("consultationID = %q, want %q", consultationID, validConsultationID)
+					}
+					if tt.repoErr != nil {
+						return appointments.Consultation{}, tt.repoErr
+					}
+					return tt.repoConsultation, nil
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &tt.directory)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, tt.target, nil))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if repo.getConsultationCalls != tt.wantGetRepoCalls {
+				t.Fatalf("GetConsultation calls = %d, want %d", repo.getConsultationCalls, tt.wantGetRepoCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.Consultation
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != tt.repoConsultation.ID || response.ProfessionalID != tt.repoConsultation.ProfessionalID || response.Status != tt.repoConsultation.Status {
+				t.Fatalf("response = %+v, want %+v", response, tt.repoConsultation)
+			}
+		})
+	}
+}
+
+func TestPatchConsultationStatusScenarios(t *testing.T) {
+	const (
+		validConsultationID = "550e8400-e29b-41d4-a716-446655440421"
+		validProfessionalID = "550e8400-e29b-41d4-a716-446655440422"
+		validPatientID      = "550e8400-e29b-41d4-a716-446655440423"
+	)
+
+	doctorProfessionalID := validProfessionalID
+	otherProfessionalID := "550e8400-e29b-41d4-a716-446655440424"
+	checkInTime := time.Date(2026, time.April, 16, 10, 25, 0, 0, time.UTC)
+	receptionNotes := "Paciente ya en recepción"
+	updatedConsultation := appointments.Consultation{
+		ID:             validConsultationID,
+		ProfessionalID: validProfessionalID,
+		PatientID:      validPatientID,
+		Status:         appointments.ConsultationStatusCheckedIn,
+		Source:         appointments.ConsultationSourceSecretary,
+		CheckInTime:    &checkInTime,
+		ReceptionNotes: &receptionNotes,
+	}
+
+	tests := []struct {
+		name            string
+		body            string
+		directory       stubDirectoryLookup
+		lookupErr       error
+		lookupResult    appointments.Consultation
+		updateErr       error
+		updatedResult   appointments.Consultation
+		wantStatus      int
+		wantError       string
+		wantLookupCalls int
+		wantUpdateCalls int
+	}{
+		{
+			name:            "invalid json body returns bad request",
+			body:            `{"status":`,
+			wantStatus:      http.StatusBadRequest,
+			wantError:       "invalid json body",
+			wantLookupCalls: 0,
+			wantUpdateCalls: 0,
+		},
+		{
+			name:            "invalid consultation id returns bad request",
+			body:            `{"id":"bad-id","status":"checked_in"}`,
+			lookupErr:       appointments.ErrValidation,
+			wantStatus:      http.StatusBadRequest,
+			wantError:       "invalid consultation status update",
+			wantLookupCalls: 1,
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "doctor cannot update another professional consultation",
+			body: `{"id":"` + validConsultationID + `","status":"checked_in"}`,
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-1", Role: "doctor", ProfessionalID: &doctorProfessionalID, Active: true},
+			},
+			lookupResult:    appointments.Consultation{ID: validConsultationID, ProfessionalID: otherProfessionalID, PatientID: validPatientID, Status: appointments.ConsultationStatusScheduled, Source: appointments.ConsultationSourceSecretary},
+			wantStatus:      http.StatusForbidden,
+			wantError:       "forbidden professional scope",
+			wantLookupCalls: 1,
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "secretary cannot mark consultation completed",
+			body: `{"id":"` + validConsultationID + `","status":"completed"}`,
+			directory: stubDirectoryLookup{
+				currentUser: directory.User{ID: "user-2", Role: "secretary", Active: true},
+			},
+			lookupResult:    appointments.Consultation{ID: validConsultationID, ProfessionalID: validProfessionalID, PatientID: validPatientID, Status: appointments.ConsultationStatusCheckedIn, Source: appointments.ConsultationSourceSecretary},
+			wantStatus:      http.StatusForbidden,
+			wantError:       "insufficient role",
+			wantLookupCalls: 1,
+			wantUpdateCalls: 0,
+		},
+		{
+			name:            "success returns updated consultation",
+			body:            `{"id":"` + validConsultationID + `","status":"checked_in","check_in_time":"2026-04-16T10:25:00Z","reception_notes":"Paciente ya en recepción"}`,
+			lookupResult:    appointments.Consultation{ID: validConsultationID, ProfessionalID: validProfessionalID, PatientID: validPatientID, Status: appointments.ConsultationStatusScheduled, Source: appointments.ConsultationSourceSecretary},
+			updatedResult:   updatedConsultation,
+			wantStatus:      http.StatusOK,
+			wantLookupCalls: 2,
+			wantUpdateCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubAppointmentsRepository{
+				getConsultationFn: func(_ context.Context, consultationID string) (appointments.Consultation, error) {
+					if consultationID != validConsultationID && tt.lookupErr == nil {
+						t.Fatalf("consultationID = %q, want %q", consultationID, validConsultationID)
+					}
+					if tt.lookupErr != nil {
+						return appointments.Consultation{}, tt.lookupErr
+					}
+					return tt.lookupResult, nil
+				},
+				updateConsultationStatusFn: func(_ context.Context, consultationID string, params appointments.UpdateConsultationStatusParams) (appointments.Consultation, error) {
+					if consultationID != validConsultationID {
+						t.Fatalf("consultationID = %q, want %q", consultationID, validConsultationID)
+					}
+					if params.Status != appointments.ConsultationStatusCheckedIn {
+						t.Fatalf("status = %q, want %q", params.Status, appointments.ConsultationStatusCheckedIn)
+					}
+					if !timesMatch(params.CheckInTime, &checkInTime) {
+						t.Fatalf("check_in_time = %v, want %v", params.CheckInTime, checkInTime)
+					}
+					if params.ReceptionNotes == nil || *params.ReceptionNotes != receptionNotes {
+						t.Fatalf("reception_notes = %v, want %q", params.ReceptionNotes, receptionNotes)
+					}
+					return tt.updatedResult, tt.updateErr
+				},
+			}
+
+			server := NewServer(testAppointmentsConfig(), repo, &tt.directory)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodPatch, "/consultations", bytes.NewBufferString(tt.body)))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if repo.getConsultationCalls != tt.wantLookupCalls {
+				t.Fatalf("GetConsultation calls = %d, want %d", repo.getConsultationCalls, tt.wantLookupCalls)
+			}
+			if repo.updateConsultationStatusCalls != tt.wantUpdateCalls {
+				t.Fatalf("UpdateConsultationStatus calls = %d, want %d", repo.updateConsultationStatusCalls, tt.wantUpdateCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.Consultation
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != tt.updatedResult.ID || response.Status != tt.updatedResult.Status {
+				t.Fatalf("response = %+v, want %+v", response, tt.updatedResult)
+			}
+		})
+	}
+}
+
+func TestGetAgendaWeekReturnsMergedAgenda(t *testing.T) {
+	t.Parallel()
+
+	const professionalID = "550e8400-e29b-41d4-a716-446655440010"
+	templateID := "550e8400-e29b-41d4-a716-446655440011"
+	weekStart := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+	versionRecurrence := json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}}`)
+	version := appointments.ScheduleTemplateVersion{
+		ID:            "550e8400-e29b-41d4-a716-446655440012",
+		TemplateID:    templateID,
+		VersionNumber: 1,
+		EffectiveFrom: weekStart,
+		Recurrence:    versionRecurrence,
+		CreatedAt:     weekStart.Add(-24 * time.Hour),
+	}
+	blockDate := weekStart
+	consultationStart := weekStart.Add(9 * time.Hour).Add(15 * time.Minute)
+	consultationEnd := consultationStart.Add(15 * time.Minute)
+
+	repo := &stubAppointmentsRepository{
+		getActiveTemplateFn: func(_ context.Context, gotProfessionalID, effectiveDate string) (appointments.ScheduleTemplateVersion, error) {
+			if gotProfessionalID != professionalID {
+				t.Fatalf("professionalID = %q, want %q", gotProfessionalID, professionalID)
+			}
+			if effectiveDate != "2026-04-12" {
+				t.Fatalf("effectiveDate = %q, want %q", effectiveDate, "2026-04-12")
+			}
+			return version, nil
+		},
+		getTemplateFn: func(_ context.Context, gotTemplateID string) (appointments.ScheduleTemplate, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("templateID = %q, want %q", gotTemplateID, templateID)
+			}
+			return appointments.ScheduleTemplate{
+				ID:             templateID,
+				ProfessionalID: professionalID,
+				CreatedAt:      weekStart.Add(-48 * time.Hour),
+				UpdatedAt:      weekStart.Add(-24 * time.Hour),
+			}, nil
+		},
+		listTemplateVersionsFn: func(_ context.Context, gotTemplateID string) ([]appointments.ScheduleTemplateVersion, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("templateID = %q, want %q", gotTemplateID, templateID)
+			}
+			return []appointments.ScheduleTemplateVersion{version}, nil
+		},
+		listScheduleBlocksFn: func(_ context.Context, filters appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error) {
+			if filters.ProfessionalID != professionalID {
+				t.Fatalf("filters.ProfessionalID = %q, want %q", filters.ProfessionalID, professionalID)
+			}
+			return []appointments.ScheduleBlock{{
+				ID:             "550e8400-e29b-41d4-a716-446655440013",
+				ProfessionalID: professionalID,
+				Scope:          "single",
+				BlockDate:      &blockDate,
+				StartTime:      "09:30",
+				EndTime:        "10:00",
+				CreatedAt:      weekStart.Add(-12 * time.Hour),
+				UpdatedAt:      weekStart.Add(-12 * time.Hour),
+			}}, nil
+		},
+		listConsultationsFn: func(_ context.Context, filters appointments.ConsultationFilters) ([]appointments.Consultation, error) {
+			if filters.ProfessionalID != professionalID {
+				t.Fatalf("filters.ProfessionalID = %q, want %q", filters.ProfessionalID, professionalID)
+			}
+			if filters.WeekStart != "2026-04-06" {
+				t.Fatalf("filters.WeekStart = %q, want %q", filters.WeekStart, "2026-04-06")
+			}
+			return []appointments.Consultation{{
+				ID:             "550e8400-e29b-41d4-a716-446655440014",
+				ProfessionalID: professionalID,
+				PatientID:      "550e8400-e29b-41d4-a716-446655440015",
+				Status:         appointments.ConsultationStatusScheduled,
+				Source:         appointments.ConsultationSourceSecretary,
+				ScheduledStart: consultationStart,
+				ScheduledEnd:   consultationEnd,
+				CreatedAt:      weekStart.Add(-6 * time.Hour),
+				UpdatedAt:      weekStart.Add(-6 * time.Hour),
+			}}, nil
+		},
+	}
+
+	server := NewServer(testAppointmentsConfig(), repo, &stubDirectoryLookup{})
+	recorder := httptest.NewRecorder()
+
+	server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, "/agenda/week?professional_id="+professionalID+"&week_start=2026-04-06", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if repo.getActiveTemplateCalls != 1 {
+		t.Fatalf("GetActiveTemplate calls = %d, want 1", repo.getActiveTemplateCalls)
+	}
+	if repo.getTemplateCalls != 1 {
+		t.Fatalf("GetTemplate calls = %d, want 1", repo.getTemplateCalls)
+	}
+	if repo.listTemplateVersionsCalls != 1 {
+		t.Fatalf("ListTemplateVersions calls = %d, want 1", repo.listTemplateVersionsCalls)
+	}
+	if repo.listScheduleBlocksCalls != 1 {
+		t.Fatalf("ListScheduleBlocks calls = %d, want 1", repo.listScheduleBlocksCalls)
+	}
+	if repo.listConsultationsCalls != 1 {
+		t.Fatalf("ListConsultations calls = %d, want 1", repo.listConsultationsCalls)
+	}
+
+	var response appointments.WeekAgenda
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ProfessionalID != professionalID {
+		t.Fatalf("professional_id = %q, want %q", response.ProfessionalID, professionalID)
+	}
+	if response.WeekStart != "2026-04-06" {
+		t.Fatalf("week_start = %q, want %q", response.WeekStart, "2026-04-06")
+	}
+	if len(response.Templates) != 1 || len(response.Templates[0].Versions) != 1 {
+		t.Fatalf("templates = %+v, want one template with one version", response.Templates)
+	}
+	if len(response.Blocks) != 1 {
+		t.Fatalf("blocks len = %d, want 1", len(response.Blocks))
+	}
+	if len(response.Consultations) != 1 {
+		t.Fatalf("consultations len = %d, want 1", len(response.Consultations))
+	}
+	if len(response.Slots) != 1 {
+		t.Fatalf("slots len = %d, want 1", len(response.Slots))
+	}
+}
+
+func TestGetAgendaWeekRejectsInvalidFilters(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(testAppointmentsConfig(), &stubAppointmentsRepository{}, &stubDirectoryLookup{})
+	recorder := httptest.NewRecorder()
+
+	server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, "/agenda/week?professional_id=bad-id&week_start=not-a-date", nil))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	assertErrorResponse(t, recorder.Body, "invalid agenda week filters")
+}
+
+func TestGetAgendaWeekReturnsEmptyScheduleWhenNoTemplateExists(t *testing.T) {
+	t.Parallel()
+
+	const professionalID = "550e8400-e29b-41d4-a716-446655440020"
+	weekStart := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+	repo := &stubAppointmentsRepository{
+		getActiveTemplateFn: func(context.Context, string, string) (appointments.ScheduleTemplateVersion, error) {
+			return appointments.ScheduleTemplateVersion{}, appointments.ErrNotFound
+		},
+		listScheduleBlocksFn: func(context.Context, appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error) {
+			return nil, nil
+		},
+		listConsultationsFn: func(context.Context, appointments.ConsultationFilters) ([]appointments.Consultation, error) {
+			return []appointments.Consultation{{
+				ID:             "550e8400-e29b-41d4-a716-446655440021",
+				ProfessionalID: professionalID,
+				PatientID:      "550e8400-e29b-41d4-a716-446655440022",
+				Status:         appointments.ConsultationStatusScheduled,
+				Source:         appointments.ConsultationSourceDoctor,
+				ScheduledStart: weekStart.Add(11 * time.Hour),
+				ScheduledEnd:   weekStart.Add(11*time.Hour + 20*time.Minute),
+			}}, nil
+		},
+	}
+
+	server := NewServer(testAppointmentsConfig(), repo, &stubDirectoryLookup{})
+	recorder := httptest.NewRecorder()
+
+	server.ServeHTTP(recorder, newAuthenticatedRequest(http.MethodGet, "/agenda/week?professional_id="+professionalID+"&week_start=2026-04-06", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if repo.getTemplateCalls != 0 {
+		t.Fatalf("GetTemplate calls = %d, want 0", repo.getTemplateCalls)
+	}
+	if repo.listTemplateVersionsCalls != 0 {
+		t.Fatalf("ListTemplateVersions calls = %d, want 0", repo.listTemplateVersionsCalls)
+	}
+
+	var response appointments.WeekAgenda
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Templates) != 0 {
+		t.Fatalf("templates len = %d, want 0", len(response.Templates))
+	}
+	if len(response.Slots) != 0 {
+		t.Fatalf("slots len = %d, want 0", len(response.Slots))
+	}
+	if len(response.Consultations) != 1 {
+		t.Fatalf("consultations len = %d, want 1", len(response.Consultations))
+	}
+}
+
 func TestListSlotsReturnsBadRequestOnInvalidFilters(t *testing.T) {
 	repo := &stubAppointmentsRepository{
 		listSlotsFn: func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error) {
@@ -1052,22 +2052,40 @@ func TestDoctorCancelChecksOwnershipBeforeMutation(t *testing.T) {
 }
 
 type stubAppointmentsRepository struct {
-	createSlotsBulkFn         func(context.Context, appointments.BulkCreateSlotsParams) ([]appointments.AvailabilitySlot, error)
-	listSlotsFn               func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error)
-	createTemplateFn          func(context.Context, appointments.CreateTemplateParams) (appointments.ScheduleTemplate, error)
-	getActiveTemplateFn       func(context.Context, string, string) (appointments.ScheduleTemplateVersion, error)
-	getTemplateFn             func(context.Context, string) (appointments.ScheduleTemplate, error)
-	listTemplateVersionsFn    func(context.Context, string) ([]appointments.ScheduleTemplateVersion, error)
-	createAppointmentFn       func(context.Context, appointments.CreateAppointmentParams) (appointments.Appointment, error)
-	listAppointmentsFn        func(context.Context, appointments.AppointmentFilters) ([]appointments.Appointment, error)
-	getAppointmentByIDFn      func(context.Context, string) (appointments.Appointment, error)
-	cancelAppointmentFn       func(context.Context, string) (appointments.Appointment, error)
-	createTemplateCalls       int
-	getActiveTemplateCalls    int
-	getTemplateCalls          int
-	listTemplateVersionsCalls int
-	createAppointmentCalls    int
-	cancelAppointmentCalls    int
+	createSlotsBulkFn             func(context.Context, appointments.BulkCreateSlotsParams) ([]appointments.AvailabilitySlot, error)
+	listSlotsFn                   func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error)
+	createTemplateFn              func(context.Context, appointments.CreateTemplateParams) (appointments.ScheduleTemplate, error)
+	getActiveTemplateFn           func(context.Context, string, string) (appointments.ScheduleTemplateVersion, error)
+	getTemplateFn                 func(context.Context, string) (appointments.ScheduleTemplate, error)
+	listTemplateVersionsFn        func(context.Context, string) ([]appointments.ScheduleTemplateVersion, error)
+	createScheduleBlockFn         func(context.Context, appointments.CreateScheduleBlockParams) (appointments.ScheduleBlock, error)
+	getScheduleBlockFn            func(context.Context, string) (appointments.ScheduleBlock, error)
+	listScheduleBlocksFn          func(context.Context, appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error)
+	updateScheduleBlockFn         func(context.Context, string, appointments.UpdateScheduleBlockParams) (appointments.ScheduleBlock, error)
+	deleteScheduleBlockFn         func(context.Context, string) error
+	createConsultationFn          func(context.Context, appointments.CreateConsultationParams) (appointments.Consultation, error)
+	getConsultationFn             func(context.Context, string) (appointments.Consultation, error)
+	listConsultationsFn           func(context.Context, appointments.ConsultationFilters) ([]appointments.Consultation, error)
+	updateConsultationStatusFn    func(context.Context, string, appointments.UpdateConsultationStatusParams) (appointments.Consultation, error)
+	createAppointmentFn           func(context.Context, appointments.CreateAppointmentParams) (appointments.Appointment, error)
+	listAppointmentsFn            func(context.Context, appointments.AppointmentFilters) ([]appointments.Appointment, error)
+	getAppointmentByIDFn          func(context.Context, string) (appointments.Appointment, error)
+	cancelAppointmentFn           func(context.Context, string) (appointments.Appointment, error)
+	createTemplateCalls           int
+	getActiveTemplateCalls        int
+	getTemplateCalls              int
+	listTemplateVersionsCalls     int
+	createScheduleBlockCalls      int
+	getScheduleBlockCalls         int
+	listScheduleBlocksCalls       int
+	updateScheduleBlockCalls      int
+	deleteScheduleBlockCalls      int
+	createConsultationCalls       int
+	getConsultationCalls          int
+	listConsultationsCalls        int
+	updateConsultationStatusCalls int
+	createAppointmentCalls        int
+	cancelAppointmentCalls        int
 }
 
 type stubDirectoryLookup struct {
@@ -1155,6 +2173,78 @@ func (s *stubAppointmentsRepository) ListTemplateVersions(ctx context.Context, t
 	return s.listTemplateVersionsFn(ctx, templateID)
 }
 
+func (s *stubAppointmentsRepository) CreateScheduleBlock(ctx context.Context, params appointments.CreateScheduleBlockParams) (appointments.ScheduleBlock, error) {
+	s.createScheduleBlockCalls++
+	if s.createScheduleBlockFn == nil {
+		return appointments.ScheduleBlock{}, errors.New("unexpected CreateScheduleBlock call")
+	}
+	return s.createScheduleBlockFn(ctx, params)
+}
+
+func (s *stubAppointmentsRepository) GetScheduleBlock(ctx context.Context, blockID string) (appointments.ScheduleBlock, error) {
+	s.getScheduleBlockCalls++
+	if s.getScheduleBlockFn == nil {
+		return appointments.ScheduleBlock{}, errors.New("unexpected GetScheduleBlock call")
+	}
+	return s.getScheduleBlockFn(ctx, blockID)
+}
+
+func (s *stubAppointmentsRepository) ListScheduleBlocks(ctx context.Context, filters appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error) {
+	s.listScheduleBlocksCalls++
+	if s.listScheduleBlocksFn == nil {
+		return nil, errors.New("unexpected ListScheduleBlocks call")
+	}
+	return s.listScheduleBlocksFn(ctx, filters)
+}
+
+func (s *stubAppointmentsRepository) UpdateScheduleBlock(ctx context.Context, blockID string, params appointments.UpdateScheduleBlockParams) (appointments.ScheduleBlock, error) {
+	s.updateScheduleBlockCalls++
+	if s.updateScheduleBlockFn == nil {
+		return appointments.ScheduleBlock{}, errors.New("unexpected UpdateScheduleBlock call")
+	}
+	return s.updateScheduleBlockFn(ctx, blockID, params)
+}
+
+func (s *stubAppointmentsRepository) DeleteScheduleBlock(ctx context.Context, blockID string) error {
+	s.deleteScheduleBlockCalls++
+	if s.deleteScheduleBlockFn == nil {
+		return errors.New("unexpected DeleteScheduleBlock call")
+	}
+	return s.deleteScheduleBlockFn(ctx, blockID)
+}
+
+func (s *stubAppointmentsRepository) CreateConsultation(ctx context.Context, params appointments.CreateConsultationParams) (appointments.Consultation, error) {
+	s.createConsultationCalls++
+	if s.createConsultationFn == nil {
+		return appointments.Consultation{}, errors.New("unexpected CreateConsultation call")
+	}
+	return s.createConsultationFn(ctx, params)
+}
+
+func (s *stubAppointmentsRepository) GetConsultation(ctx context.Context, consultationID string) (appointments.Consultation, error) {
+	s.getConsultationCalls++
+	if s.getConsultationFn == nil {
+		return appointments.Consultation{}, errors.New("unexpected GetConsultation call")
+	}
+	return s.getConsultationFn(ctx, consultationID)
+}
+
+func (s *stubAppointmentsRepository) ListConsultations(ctx context.Context, filters appointments.ConsultationFilters) ([]appointments.Consultation, error) {
+	s.listConsultationsCalls++
+	if s.listConsultationsFn == nil {
+		return nil, errors.New("unexpected ListConsultations call")
+	}
+	return s.listConsultationsFn(ctx, filters)
+}
+
+func (s *stubAppointmentsRepository) UpdateConsultationStatus(ctx context.Context, consultationID string, params appointments.UpdateConsultationStatusParams) (appointments.Consultation, error) {
+	s.updateConsultationStatusCalls++
+	if s.updateConsultationStatusFn == nil {
+		return appointments.Consultation{}, errors.New("unexpected UpdateConsultationStatus call")
+	}
+	return s.updateConsultationStatusFn(ctx, consultationID, params)
+}
+
 func (s *stubAppointmentsRepository) CreateAppointment(ctx context.Context, params appointments.CreateAppointmentParams) (appointments.Appointment, error) {
 	s.createAppointmentCalls++
 	if s.createAppointmentFn == nil {
@@ -1211,4 +2301,16 @@ func testAppointmentsConfig() Config {
 
 func ptrToString(value string) *string {
 	return &value
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func timesMatch(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return left.Equal(*right)
 }

--- a/services/appointments-service/migrations/001_init.sql
+++ b/services/appointments-service/migrations/001_init.sql
@@ -25,12 +25,14 @@ CREATE INDEX availability_slots_status_idx
 
 CREATE TABLE consultations (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    slot_id UUID NOT NULL,
+    slot_id UUID,
     professional_id UUID NOT NULL,
     patient_id UUID NOT NULL,
     status TEXT NOT NULL DEFAULT 'scheduled',
     source TEXT NOT NULL DEFAULT 'secretary',
     notes TEXT,
+    check_in_time TIMESTAMPTZ,
+    reception_notes TEXT,
     scheduled_start TIMESTAMPTZ NOT NULL,
     scheduled_end TIMESTAMPTZ NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/services/appointments-service/migrations/006_consultation_entity.sql
+++ b/services/appointments-service/migrations/006_consultation_entity.sql
@@ -11,7 +11,12 @@ ALTER TABLE consultations
 
 ALTER TABLE consultations
     ADD COLUMN source TEXT NOT NULL DEFAULT 'secretary',
-    ADD COLUMN notes TEXT;
+    ADD COLUMN notes TEXT,
+    ADD COLUMN check_in_time TIMESTAMPTZ,
+    ADD COLUMN reception_notes TEXT;
+
+ALTER TABLE consultations
+    ALTER COLUMN slot_id DROP NOT NULL;
 
 ALTER TABLE consultations
     DROP CONSTRAINT IF EXISTS appointments_status_valid,

--- a/services/appointments-service/migrations/006_consultation_entity.sql
+++ b/services/appointments-service/migrations/006_consultation_entity.sql
@@ -1,0 +1,48 @@
+-- Consultation entity evolution: migrate the legacy appointments table into
+-- consultations, align the status taxonomy, and add consultation metadata.
+
+ALTER TABLE appointments RENAME TO consultations;
+
+ALTER TABLE consultations
+    RENAME CONSTRAINT appointments_pkey TO consultations_pkey;
+
+ALTER TABLE consultations
+    RENAME CONSTRAINT appointments_slot_fk TO consultations_slot_fk;
+
+ALTER TABLE consultations
+    ADD COLUMN source TEXT NOT NULL DEFAULT 'secretary',
+    ADD COLUMN notes TEXT;
+
+ALTER TABLE consultations
+    DROP CONSTRAINT IF EXISTS appointments_status_valid,
+    DROP CONSTRAINT IF EXISTS appointments_cancelled_at_consistency;
+
+UPDATE consultations
+SET status = 'scheduled'
+WHERE status = 'booked';
+
+ALTER TABLE consultations
+    ALTER COLUMN status SET DEFAULT 'scheduled';
+
+ALTER TABLE consultations
+    ADD CONSTRAINT consultations_status_valid CHECK (status IN ('scheduled', 'checked_in', 'completed', 'cancelled', 'no_show')),
+    ADD CONSTRAINT consultations_cancelled_at_consistency CHECK (
+        (status = 'cancelled' AND cancelled_at IS NOT NULL) OR
+        (status IN ('scheduled', 'checked_in', 'completed', 'no_show') AND cancelled_at IS NULL)
+    ),
+    ADD CONSTRAINT consultations_source_valid CHECK (source IN ('online', 'secretary', 'doctor'));
+
+DROP INDEX IF EXISTS appointments_slot_booked_unique_idx;
+
+CREATE UNIQUE INDEX consultations_slot_scheduled_unique_idx
+    ON consultations (slot_id)
+    WHERE status = 'scheduled';
+
+ALTER INDEX IF EXISTS appointments_patient_id_idx
+    RENAME TO consultations_patient_id_idx;
+
+ALTER INDEX IF EXISTS appointments_professional_id_idx
+    RENAME TO consultations_professional_id_idx;
+
+ALTER INDEX IF EXISTS appointments_status_idx
+    RENAME TO consultations_status_idx;

--- a/services/appointments-service/migrations/007_consultation_schedule_range.sql
+++ b/services/appointments-service/migrations/007_consultation_schedule_range.sql
@@ -1,0 +1,18 @@
+ALTER TABLE consultations
+    ADD COLUMN scheduled_start TIMESTAMPTZ,
+    ADD COLUMN scheduled_end TIMESTAMPTZ;
+
+UPDATE consultations AS consultations_to_backfill
+SET scheduled_start = availability_slots.start_time,
+    scheduled_end = availability_slots.end_time
+FROM availability_slots
+WHERE consultations_to_backfill.slot_id = availability_slots.id
+  AND (consultations_to_backfill.scheduled_start IS NULL OR consultations_to_backfill.scheduled_end IS NULL);
+
+ALTER TABLE consultations
+    ALTER COLUMN scheduled_start SET NOT NULL,
+    ALTER COLUMN scheduled_end SET NOT NULL,
+    ADD CONSTRAINT consultations_scheduled_range_valid CHECK (scheduled_start < scheduled_end);
+
+CREATE INDEX consultations_professional_scheduled_start_idx
+    ON consultations (professional_id, scheduled_start);

--- a/services/appointments-service/openapi/openapi.yaml
+++ b/services/appointments-service/openapi/openapi.yaml
@@ -128,6 +128,875 @@ paths:
                   value:
                     error: failed to create slots
 
+  /schedules:
+    get:
+      summary: Get active schedule for a professional and effective date
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ProfessionalIDFilter'
+        - $ref: '#/components/parameters/EffectiveDateFilter'
+      responses:
+        '200':
+          description: Active schedule loaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleTemplate'
+        '400':
+          description: Invalid schedule filters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_schedule_filters:
+                  value:
+                    error: invalid schedule filters
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '404':
+          description: Schedule not found for the requested effective date
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                schedule_not_found:
+                  value:
+                    error: schedule not found
+        '500':
+          description: Unexpected failure while loading the schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_load_schedule:
+                  value:
+                    error: failed to load schedule
+    post:
+      summary: Create a schedule template version
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScheduleRequest'
+      responses:
+        '201':
+          description: Schedule created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleTemplate'
+        '400':
+          description: Invalid JSON body, invalid request payload, or missing professional reference
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_json_body:
+                  value:
+                    error: invalid json body
+                invalid_schedule_request:
+                  value:
+                    error: invalid schedule request
+                professional_not_found:
+                  value:
+                    error: professional not found
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot create this schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                insufficient_role:
+                  value:
+                    error: insufficient role
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '409':
+          description: A schedule version already exists for the effective date
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                duplicate_effective_date:
+                  value:
+                    error: schedule version already exists for effective date
+        '503':
+          description: Directory service unavailable while validating professional references
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                directory_service_unavailable:
+                  value:
+                    error: directory service unavailable
+        '500':
+          description: Unexpected failure while creating the schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_create_schedule:
+                  value:
+                    error: failed to create schedule
+
+  /schedules/versions:
+    get:
+      summary: List all versions for a schedule template
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TemplateIDFilter'
+      responses:
+        '200':
+          description: Schedule versions listed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleTemplateVersionListResponse'
+        '400':
+          description: Invalid schedule filters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_schedule_filters:
+                  value:
+                    error: invalid schedule filters
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                schedule_not_found:
+                  value:
+                    error: schedule not found
+        '500':
+          description: Unexpected failure while loading schedule versions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_load_schedule_versions:
+                  value:
+                    error: failed to load schedule versions
+
+  /blocks:
+    get:
+      summary: List schedule blocks
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ProfessionalIDFilter'
+        - $ref: '#/components/parameters/TemplateIDFilterOptional'
+        - $ref: '#/components/parameters/BlockScopeFilter'
+      responses:
+        '200':
+          description: Blocks listed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleBlockListResponse'
+        '400':
+          description: Invalid block filters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_block_filters:
+                  value:
+                    error: invalid block filters
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '500':
+          description: Unexpected failure while listing blocks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_list_blocks:
+                  value:
+                    error: failed to list blocks
+    post:
+      summary: Create a schedule block
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScheduleBlockRequest'
+      responses:
+        '201':
+          description: Block created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleBlock'
+        '400':
+          description: Invalid JSON body, invalid request payload, or missing professional reference
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_json_body:
+                  value:
+                    error: invalid json body
+                invalid_block_request:
+                  value:
+                    error: invalid block request
+                professional_not_found:
+                  value:
+                    error: professional not found
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '409':
+          description: Block conflicts with the existing schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                block_conflict:
+                  value:
+                    error: block conflicts with existing schedule
+        '503':
+          description: Directory service unavailable while validating professional references
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                directory_service_unavailable:
+                  value:
+                    error: directory service unavailable
+        '500':
+          description: Unexpected failure while creating the block
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_create_block:
+                  value:
+                    error: failed to create block
+
+  /blocks/{id}:
+    get:
+      summary: Get schedule block by ID
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/BlockIDPath'
+      responses:
+        '200':
+          description: Block loaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleBlock'
+        '400':
+          description: Invalid block ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_block_id:
+                  value:
+                    error: invalid block id
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '404':
+          description: Block not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                block_not_found:
+                  value:
+                    error: block not found
+        '500':
+          description: Unexpected failure while loading the block
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_load_block:
+                  value:
+                    error: failed to load block
+    patch:
+      summary: Update a schedule block
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/BlockIDPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateScheduleBlockRequest'
+      responses:
+        '200':
+          description: Block updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleBlock'
+        '400':
+          description: Invalid JSON body, block ID, or request payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_json_body:
+                  value:
+                    error: invalid json body
+                invalid_block_id:
+                  value:
+                    error: invalid block id
+                invalid_block_request:
+                  value:
+                    error: invalid block request
+                professional_not_found:
+                  value:
+                    error: professional not found
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '404':
+          description: Block not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                block_not_found:
+                  value:
+                    error: block not found
+        '409':
+          description: Block conflicts with the existing schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                block_conflict:
+                  value:
+                    error: block conflicts with existing schedule
+        '503':
+          description: Directory service unavailable while validating professional references
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                directory_service_unavailable:
+                  value:
+                    error: directory service unavailable
+        '500':
+          description: Unexpected failure while updating the block
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_update_block:
+                  value:
+                    error: failed to update block
+    delete:
+      summary: Delete a schedule block
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/BlockIDPath'
+      responses:
+        '204':
+          description: Block deleted
+        '400':
+          description: Invalid block ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_block_id:
+                  value:
+                    error: invalid block id
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '404':
+          description: Block not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                block_not_found:
+                  value:
+                    error: block not found
+        '500':
+          description: Unexpected failure while deleting the block
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_delete_block:
+                  value:
+                    error: failed to delete block
+
+  /consultations:
+    get:
+      summary: Get consultation by ID
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ConsultationIDFilter'
+      responses:
+        '200':
+          description: Consultation loaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consultation'
+        '400':
+          description: Invalid consultation filters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_consultation_filters:
+                  value:
+                    error: invalid consultation filters
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '404':
+          description: Consultation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                consultation_not_found:
+                  value:
+                    error: consultation not found
+        '500':
+          description: Unexpected failure while loading the consultation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_load_consultation:
+                  value:
+                    error: failed to load consultation
+    post:
+      summary: Create a consultation from a slot or explicit schedule range
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConsultationRequest'
+      responses:
+        '201':
+          description: Consultation created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consultation'
+        '400':
+          description: Invalid JSON body, validation failure, or missing external references
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_json_body:
+                  value:
+                    error: invalid json body
+                invalid_consultation_request:
+                  value:
+                    error: invalid consultation request
+                professional_not_found:
+                  value:
+                    error: professional not found
+                patient_not_found:
+                  value:
+                    error: patient not found
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '409':
+          description: Consultation conflicts with the existing schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                consultation_conflict:
+                  value:
+                    error: consultation conflicts with existing schedule
+        '503':
+          description: Directory service unavailable while validating external references
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                directory_service_unavailable:
+                  value:
+                    error: directory service unavailable
+        '500':
+          description: Unexpected failure while creating the consultation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_create_consultation:
+                  value:
+                    error: failed to create consultation
+    patch:
+      summary: Update consultation status
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateConsultationStatusRequest'
+      responses:
+        '200':
+          description: Consultation updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consultation'
+        '400':
+          description: Invalid JSON body or invalid status transition request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_json_body:
+                  value:
+                    error: invalid json body
+                invalid_consultation_status_update:
+                  value:
+                    error: invalid consultation status update
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot perform the requested consultation update
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+                insufficient_role:
+                  value:
+                    error: insufficient role
+        '404':
+          description: Consultation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                consultation_not_found:
+                  value:
+                    error: consultation not found
+        '409':
+          description: Consultation update conflicts with the current state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                status_conflict:
+                  value:
+                    error: consultation status update conflicts with existing state
+        '500':
+          description: Unexpected failure while updating the consultation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_update_consultation:
+                  value:
+                    error: failed to update consultation
+
+  /agenda/week:
+    get:
+      summary: Get merged week agenda for a professional
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ProfessionalIDFilter'
+        - $ref: '#/components/parameters/WeekStartFilter'
+      responses:
+        '200':
+          description: Week agenda loaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeekAgenda'
+        '400':
+          description: Invalid agenda week filters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_agenda_week_filters:
+                  value:
+                    error: invalid agenda week filters
+        '401':
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error: unauthorized
+        '403':
+          description: Authenticated actor cannot access the requested professional scope
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden_professional_scope:
+                  value:
+                    error: forbidden professional scope
+        '500':
+          description: Unexpected failure while loading the agenda week
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                failed_to_load_agenda_week:
+                  value:
+                    error: failed to load agenda week
+
   /appointments:
     get:
       summary: List appointments
@@ -296,6 +1165,12 @@ paths:
                     error: failed to cancel appointment
 
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
   parameters:
     ProfessionalIDFilter:
       name: professional_id
@@ -335,6 +1210,78 @@ components:
         type: string
         format: date
       description: Filter by UTC calendar date in YYYY-MM-DD format.
+
+    EffectiveDateFilter:
+      name: effective_date
+      in: query
+      required: true
+      schema:
+        type: string
+        format: date
+      description: Effective date used to resolve the active schedule version.
+      example: 2026-05-10
+
+    TemplateIDFilter:
+      name: template_id
+      in: query
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Schedule template identifier.
+      example: 550e8400-e29b-41d4-a716-446655440010
+
+    TemplateIDFilterOptional:
+      name: template_id
+      in: query
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description: Optional schedule template identifier.
+      example: 550e8400-e29b-41d4-a716-446655440010
+
+    BlockScopeFilter:
+      name: scope
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - single
+          - range
+          - template
+      description: Filter blocks by scope.
+
+    BlockIDPath:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Schedule block identifier.
+      example: 550e8400-e29b-41d4-a716-446655440501
+
+    ConsultationIDFilter:
+      name: id
+      in: query
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Consultation identifier.
+      example: 550e8400-e29b-41d4-a716-446655440411
+
+    WeekStartFilter:
+      name: week_start
+      in: query
+      required: true
+      schema:
+        type: string
+        format: date
+      description: UTC week start date in YYYY-MM-DD format.
+      example: 2026-04-06
 
   schemas:
     ErrorResponse:
@@ -450,6 +1397,478 @@ components:
         - items
       properties:
         items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Slot'
+
+    ScheduleRecurrenceWindow:
+      type: object
+      required:
+        - start_time
+        - end_time
+        - slot_duration_minutes
+      properties:
+        start_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+          example: '09:00'
+        end_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+          example: '12:00'
+        slot_duration_minutes:
+          type: integer
+          minimum: 1
+          example: 30
+
+    ScheduleRecurrence:
+      type: object
+      description: Weekly recurrence keyed by weekday name.
+      properties:
+        monday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+        tuesday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+        wednesday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+        thursday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+        friday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+        saturday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+        sunday:
+          $ref: '#/components/schemas/ScheduleRecurrenceWindow'
+      example:
+        monday:
+          start_time: '09:00'
+          end_time: '12:00'
+          slot_duration_minutes: 30
+        wednesday:
+          start_time: '10:00'
+          end_time: '13:00'
+          slot_duration_minutes: 30
+
+    ScheduleTemplateVersion:
+      type: object
+      required:
+        - id
+        - template_id
+        - version_number
+        - effective_from
+        - recurrence
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        template_id:
+          type: string
+          format: uuid
+        version_number:
+          type: integer
+          minimum: 1
+        effective_from:
+          type: string
+          format: date-time
+        recurrence:
+          $ref: '#/components/schemas/ScheduleRecurrence'
+        created_at:
+          type: string
+          format: date-time
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        reason:
+          type: string
+          nullable: true
+
+    ScheduleTemplate:
+      type: object
+      required:
+        - id
+        - professional_id
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        professional_id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleTemplateVersion'
+
+    ScheduleTemplateVersionListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleTemplateVersion'
+
+    CreateScheduleRequest:
+      type: object
+      required:
+        - professional_id
+        - effective_from
+        - recurrence
+      properties:
+        professional_id:
+          type: string
+          format: uuid
+        effective_from:
+          type: string
+          format: date
+        recurrence:
+          $ref: '#/components/schemas/ScheduleRecurrence'
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        reason:
+          type: string
+          nullable: true
+
+    Consultation:
+      type: object
+      required:
+        - id
+        - professional_id
+        - patient_id
+        - status
+        - source
+        - scheduled_start
+        - scheduled_end
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        slot_id:
+          type: string
+          format: uuid
+          nullable: true
+        professional_id:
+          type: string
+          format: uuid
+        patient_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+            - scheduled
+            - checked_in
+            - completed
+            - cancelled
+            - no_show
+        source:
+          type: string
+          enum:
+            - online
+            - secretary
+            - doctor
+        scheduled_start:
+          type: string
+          format: date-time
+        scheduled_end:
+          type: string
+          format: date-time
+        notes:
+          type: string
+          nullable: true
+        check_in_time:
+          type: string
+          format: date-time
+          nullable: true
+        reception_notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        cancelled_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    CreateConsultationRequest:
+      type: object
+      required:
+        - professional_id
+        - patient_id
+        - source
+      properties:
+        slot_id:
+          type: string
+          format: uuid
+          nullable: true
+        professional_id:
+          type: string
+          format: uuid
+        patient_id:
+          type: string
+          format: uuid
+        source:
+          type: string
+          enum:
+            - online
+            - secretary
+            - doctor
+        scheduled_start:
+          type: string
+          format: date-time
+          nullable: true
+        scheduled_end:
+          type: string
+          format: date-time
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+      description: Provide either `slot_id` or the pair `scheduled_start` + `scheduled_end`.
+      oneOf:
+        - required:
+            - slot_id
+        - required:
+            - scheduled_start
+            - scheduled_end
+
+    UpdateConsultationStatusRequest:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+            - scheduled
+            - checked_in
+            - completed
+            - cancelled
+            - no_show
+        source:
+          type: string
+          enum:
+            - online
+            - secretary
+            - doctor
+          nullable: true
+          description: Optional immutable source echo; changing it is rejected.
+        check_in_time:
+          type: string
+          format: date-time
+          nullable: true
+        reception_notes:
+          type: string
+          nullable: true
+
+    ScheduleBlock:
+      type: object
+      required:
+        - id
+        - professional_id
+        - scope
+        - start_time
+        - end_time
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        professional_id:
+          type: string
+          format: uuid
+        scope:
+          type: string
+          enum:
+            - single
+            - range
+            - template
+        block_date:
+          type: string
+          format: date-time
+          nullable: true
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        day_of_week:
+          type: integer
+          minimum: 1
+          maximum: 7
+          nullable: true
+        start_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+        end_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+        template_id:
+          type: string
+          format: uuid
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    ScheduleBlockListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleBlock'
+
+    CreateScheduleBlockRequest:
+      type: object
+      required:
+        - professional_id
+        - scope
+        - start_time
+        - end_time
+      properties:
+        professional_id:
+          type: string
+          format: uuid
+        scope:
+          type: string
+          enum:
+            - single
+            - range
+            - template
+        block_date:
+          type: string
+          format: date
+          nullable: true
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        end_date:
+          type: string
+          format: date
+          nullable: true
+        day_of_week:
+          type: integer
+          minimum: 1
+          maximum: 7
+          nullable: true
+        start_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+        end_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+        template_id:
+          type: string
+          format: uuid
+          nullable: true
+
+    UpdateScheduleBlockRequest:
+      type: object
+      required:
+        - scope
+        - start_time
+        - end_time
+      properties:
+        professional_id:
+          type: string
+          format: uuid
+        scope:
+          type: string
+          enum:
+            - single
+            - range
+            - template
+        block_date:
+          type: string
+          format: date
+          nullable: true
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        end_date:
+          type: string
+          format: date
+          nullable: true
+        day_of_week:
+          type: integer
+          minimum: 1
+          maximum: 7
+          nullable: true
+        start_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+        end_time:
+          type: string
+          pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+        template_id:
+          type: string
+          format: uuid
+          nullable: true
+
+    WeekAgenda:
+      type: object
+      required:
+        - professional_id
+        - week_start
+        - templates
+        - blocks
+        - consultations
+        - slots
+      properties:
+        professional_id:
+          type: string
+          format: uuid
+        week_start:
+          type: string
+          format: date
+        templates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleTemplate'
+        blocks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleBlock'
+        consultations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Consultation'
+        slots:
           type: array
           items:
             $ref: '#/components/schemas/Slot'

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 
@@ -29,6 +29,10 @@ vi.mock('./features/schedule/ScheduleDemo', () => ({
   ),
 }));
 
+vi.mock('./features/schedule/WeeklyScheduleWorkspace', () => ({
+  WeeklyScheduleWorkspace: ({ agendaMode }: { agendaMode: { kind: string } }) => <div>weekly-schedule:{agendaMode.kind}</div>,
+}));
+
 vi.mock('./features/patients/PatientsWorkspace', () => ({
   PatientsWorkspace: ({
     patientsMode,
@@ -53,7 +57,7 @@ describe('App actor-aware shell', () => {
     useAuthSessionMock.mockReset();
   });
 
-  it('shows agenda and patients for doctors, defaulting to agenda', () => {
+  it('shows agenda, weekly schedule and patients for doctors, defaulting to agenda', () => {
     useAuthSessionMock.mockReturnValue(authSession({ role: 'doctor', professional_id: 'professional-1' }));
 
     const { container } = render(<App />);
@@ -61,13 +65,15 @@ describe('App actor-aware shell', () => {
     expect(screen.getAllByText('Centro operativo clínico').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Amicus')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
-    const doctorNavButtons = screen.getAllByRole('button', { name: /Agenda|Pacientes/ });
-    expect(doctorNavButtons).toHaveLength(2);
+    const doctorNavButtons = screen.getAllByRole('button', { name: /Agenda|Agenda semanal|Pacientes/ });
+    expect(doctorNavButtons).toHaveLength(3);
     expect(doctorNavButtons[0]).toHaveTextContent('Práctica propia');
     expect(doctorNavButtons[0]).toHaveTextContent('Agenda');
-    expect(doctorNavButtons[1]).toHaveTextContent('Seguimiento clínico');
-    expect(doctorNavButtons[1]).toHaveTextContent('Pacientes');
-    expect(screen.getByRole('button', { name: /Agenda/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(doctorNavButtons[1]).toHaveTextContent('Plantilla semanal');
+    expect(doctorNavButtons[1]).toHaveTextContent('Agenda semanal');
+    expect(doctorNavButtons[2]).toHaveTextContent('Seguimiento clínico');
+    expect(doctorNavButtons[2]).toHaveTextContent('Pacientes');
+    expect(doctorNavButtons[0]).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByText('schedule:doctor-own')).toBeInTheDocument();
 
     const shellPage = container.querySelector('.page-app-shell');
@@ -80,20 +86,35 @@ describe('App actor-aware shell', () => {
     expect(container.querySelector('.app-shell-brand-mark-fallback')).toHaveTextContent('A');
   });
 
-  it('shows agenda and patients for secretaries without directory shell symmetry', () => {
+  it('shows agenda, weekly schedule and patients for secretaries without directory shell symmetry', () => {
     useAuthSessionMock.mockReturnValue(authSession({ role: 'secretary' }));
 
     render(<App />);
 
-    const secretaryNavButtons = screen.getAllByRole('button', { name: /Agenda|Pacientes/ });
-    expect(secretaryNavButtons).toHaveLength(2);
+    const secretaryNavButtons = screen.getAllByRole('button', { name: /Agenda|Agenda semanal|Pacientes/ });
+    expect(secretaryNavButtons).toHaveLength(3);
     expect(secretaryNavButtons[0]).toHaveTextContent('Operación diaria');
-    expect(secretaryNavButtons[1]).toHaveTextContent('Atención operativa');
     expect(secretaryNavButtons[0]).toHaveTextContent('Agenda');
-    expect(secretaryNavButtons[1]).toHaveTextContent('Pacientes');
+    expect(secretaryNavButtons[1]).toHaveTextContent('Configuración visible');
+    expect(secretaryNavButtons[1]).toHaveTextContent('Agenda semanal');
+    expect(secretaryNavButtons[2]).toHaveTextContent('Atención operativa');
+    expect(secretaryNavButtons[2]).toHaveTextContent('Pacientes');
     expect(screen.getByRole('heading', { name: 'Agenda' })).toBeInTheDocument();
     expect(screen.getByText('schedule:operational-shared')).toBeInTheDocument();
     expect(screen.queryByText('directory:setup-secretary-support')).not.toBeInTheDocument();
+  });
+
+  it('lets doctors reach the weekly schedule from the shell navigation', () => {
+    useAuthSessionMock.mockReturnValue(authSession({ role: 'doctor', professional_id: 'professional-1' }));
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Agenda semanal/i }));
+
+    expect(screen.getByRole('heading', { name: 'Agenda semanal' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Agenda semanal/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('weekly-schedule:doctor-own')).toBeInTheDocument();
+    expect(screen.queryByText('schedule:doctor-own')).not.toBeInTheDocument();
   });
 
   it('keeps the unauthenticated login surface unchanged', () => {
@@ -151,13 +172,15 @@ describe('App actor-aware shell', () => {
 
     render(<App />);
 
-    expect(screen.getAllByRole('button', { name: /Agenda|Pacientes/ })).toHaveLength(2);
+    const nav = screen.getByRole('navigation', { name: 'Áreas disponibles' });
+
+    expect(within(nav).getAllByRole('button')).toHaveLength(3);
     expect(screen.queryByText('directory:setup-secretary-support')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'schedule-open-directory' }));
 
     expect(screen.getByText('directory:setup-secretary-support')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: /Agenda|Pacientes/ })).toHaveLength(2);
+    expect(within(nav).getAllByRole('button')).toHaveLength(3);
     expect(screen.queryAllByRole('button', { name: /Directorio/ })).toHaveLength(0);
   });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { LoginScreen } from './features/auth/LoginScreen';
 import { DirectoryDemo } from './features/directory/DirectoryDemo';
 import { PatientsWorkspace } from './features/patients/PatientsWorkspace';
 import { ScheduleDemo } from './features/schedule/ScheduleDemo';
+import { WeeklyScheduleWorkspace } from './features/schedule/WeeklyScheduleWorkspace';
 
 export default function App() {
   const auth = useAuthSession();
@@ -88,6 +89,10 @@ export default function App() {
 
     if (normalizedActiveSurface === 'directory') {
       return <DirectoryDemo directoryMode={capabilities.directoryMode} onSessionInvalid={auth.logout} />;
+    }
+
+    if (normalizedActiveSurface === 'weekly-schedule') {
+      return <WeeklyScheduleWorkspace agendaMode={capabilities.agendaMode} onSessionInvalid={auth.logout} />;
     }
 
     if (normalizedActiveSurface === 'patients') {

--- a/web/src/api/appointments.test.ts
+++ b/web/src/api/appointments.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WeekAgenda } from '../types/appointments';
 
 const requestMock = vi.fn();
 
@@ -22,6 +23,20 @@ describe('appointments API auth transport', () => {
       patient_id: 'patient-1',
       professional_id: 'professional-1',
     });
+    await appointments.getScheduleTemplate({ professional_id: 'professional-1', effective_date: '2099-12-31' });
+    await appointments.listScheduleTemplateVersions({ template_id: 'template-1' });
+    await appointments.createScheduleTemplateVersion({
+      professional_id: 'professional-1',
+      effective_from: '2026-05-01',
+      recurrence: {
+        monday: {
+          start_time: '09:00',
+          end_time: '12:00',
+          slot_duration_minutes: 30,
+        },
+      },
+      reason: 'Nueva versión semanal',
+    });
 
     expect(requestMock).toHaveBeenNthCalledWith(1, '/appointments-api', '/slots', {
       query: { professional_id: 'professional-1', date: '2026-04-08' },
@@ -33,6 +48,30 @@ describe('appointments API auth transport', () => {
         slot_id: 'slot-1',
         patient_id: 'patient-1',
         professional_id: 'professional-1',
+      },
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(3, '/appointments-api', '/schedules', {
+      query: { professional_id: 'professional-1', effective_date: '2099-12-31' },
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(4, '/appointments-api', '/schedules/versions', {
+      query: { template_id: 'template-1' },
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(5, '/appointments-api', '/schedules', {
+      method: 'POST',
+      body: {
+        professional_id: 'professional-1',
+        effective_from: '2026-05-01',
+        recurrence: {
+          monday: {
+            start_time: '09:00',
+            end_time: '12:00',
+            slot_duration_minutes: 30,
+          },
+        },
+        reason: 'Nueva versión semanal',
       },
       auth: true,
     });
@@ -88,6 +127,74 @@ describe('appointments API auth transport', () => {
       appointments.listOperationalWeek({ professional_id: 'professional-1', date: '2026-04-08' }),
     ).rejects.toThrow('weekday slots unavailable');
 
-    expect(requestMock).toHaveBeenCalledTimes(10);
-  });
+		expect(requestMock).toHaveBeenCalledTimes(10);
+	});
+
+	it('fetches the new week agenda endpoint over authenticated transport', async () => {
+		const weekAgenda: WeekAgenda = {
+			professional_id: 'professional-1',
+			week_start: '2026-04-06',
+			templates: [{
+				id: 'template-1',
+				professional_id: 'professional-1',
+				created_at: '2026-04-01T08:00:00Z',
+				updated_at: '2026-04-01T08:00:00Z',
+				versions: [{
+					id: 'version-1',
+					template_id: 'template-1',
+					version_number: 1,
+					effective_from: '2026-04-01T00:00:00Z',
+					recurrence: {
+						monday: { start_time: '09:00', end_time: '12:00', slot_duration_minutes: 30 },
+					},
+					created_at: '2026-04-01T08:00:00Z',
+				}],
+			}],
+			blocks: [{
+				id: 'block-1',
+				professional_id: 'professional-1',
+				scope: 'single',
+				block_date: '2026-04-08T00:00:00Z',
+				start_time: '10:00',
+				end_time: '10:30',
+				created_at: '2026-04-01T08:00:00Z',
+				updated_at: '2026-04-01T08:00:00Z',
+			}],
+			consultations: [{
+				id: 'consultation-1',
+				slot_id: null,
+				professional_id: 'professional-1',
+				patient_id: 'patient-1',
+				status: 'scheduled',
+				source: 'doctor',
+				scheduled_start: '2026-04-08T09:00:00Z',
+				scheduled_end: '2026-04-08T09:20:00Z',
+				created_at: '2026-04-01T08:00:00Z',
+				updated_at: '2026-04-01T08:00:00Z',
+			}],
+			slots: [],
+		};
+		requestMock.mockResolvedValue(weekAgenda);
+
+		const appointments = await import('./appointments');
+
+		await expect(
+			appointments.fetchWeekAgenda({ professional_id: 'professional-1', week_start: '2026-04-06' }),
+		).resolves.toEqual(weekAgenda);
+
+		expect(requestMock).toHaveBeenCalledWith('/appointments-api', '/agenda/week', {
+			query: { professional_id: 'professional-1', week_start: '2026-04-06' },
+			auth: true,
+		});
+	});
+
+	it('surfaces week agenda transport failures without reshaping them', async () => {
+		requestMock.mockRejectedValue(new Error('agenda unavailable'));
+
+		const appointments = await import('./appointments');
+
+		await expect(
+			appointments.fetchWeekAgenda({ professional_id: 'professional-1', week_start: '2026-04-06' }),
+		).rejects.toThrow('agenda unavailable');
+	});
 });

--- a/web/src/api/appointments.ts
+++ b/web/src/api/appointments.ts
@@ -2,9 +2,15 @@ import { request } from './http';
 import type {
   Appointment,
   BulkCreateSlotsPayload,
+  CreateScheduleTemplateVersionPayload,
   CreateAppointmentPayload,
+  GetScheduleTemplateFilters,
   ListResponse,
+  ListScheduleTemplateVersionFilters,
+  ScheduleTemplate,
+  ScheduleTemplateVersion,
   Slot,
+  WeekAgenda,
 } from '../types/appointments';
 import { getOperationalWeekDays, normalizeOperationalTimeBands } from '../features/schedule/helpers';
 
@@ -21,6 +27,11 @@ type SlotFilters = {
   professional_id?: string;
   status?: string;
   date?: string;
+};
+
+type WeekAgendaFilters = {
+	professional_id: string;
+	week_start: string;
 };
 
 export type OperationalWeekDay = {
@@ -72,6 +83,36 @@ export function cancelAppointment(appointmentId: string) {
 	});
 }
 
+export function fetchWeekAgenda(filters: WeekAgendaFilters) {
+	return request<WeekAgenda>(APPOINTMENTS_API_BASE, '/agenda/week', { query: filters, auth: true });
+}
+
+export async function getScheduleTemplate(filters: GetScheduleTemplateFilters) {
+	const template = await request<ScheduleTemplate>(APPOINTMENTS_API_BASE, '/schedules', { query: filters, auth: true });
+	return normalizeScheduleTemplate(template);
+}
+
+export async function listScheduleTemplateVersions(filters: ListScheduleTemplateVersionFilters) {
+	const response = await request<ListResponse<ScheduleTemplateVersion>>(APPOINTMENTS_API_BASE, '/schedules/versions', {
+		query: filters,
+		auth: true,
+	});
+
+	return {
+		items: response.items.map(normalizeScheduleTemplateVersion),
+	};
+}
+
+export async function createScheduleTemplateVersion(payload: CreateScheduleTemplateVersionPayload) {
+	const template = await request<ScheduleTemplate>(APPOINTMENTS_API_BASE, '/schedules', {
+		method: 'POST',
+		body: payload,
+		auth: true,
+	});
+
+	return normalizeScheduleTemplate(template);
+}
+
 export async function listOperationalWeek(filters: Required<Pick<SlotFilters, 'professional_id' | 'date'>>) {
 	const weekDays = getOperationalWeekDays(filters.date);
 	const days = await Promise.all(
@@ -118,4 +159,22 @@ function compareBySlotOrder(slots: Slot[]) {
 
 		return leftOrder - rightOrder;
 	};
+}
+
+function normalizeScheduleTemplate(template: ScheduleTemplate): ScheduleTemplate {
+	return {
+		...template,
+		versions: template.versions?.map(normalizeScheduleTemplateVersion),
+	};
+}
+
+function normalizeScheduleTemplateVersion(version: ScheduleTemplateVersion): ScheduleTemplateVersion {
+	return {
+		...version,
+		effective_from: normalizeDateOnly(version.effective_from),
+	};
+}
+
+function normalizeDateOnly(value: string) {
+	return value.includes('T') ? value.slice(0, 10) : value;
 }

--- a/web/src/auth/actorCapabilities.test.ts
+++ b/web/src/auth/actorCapabilities.test.ts
@@ -5,9 +5,10 @@ describe('deriveActorCapabilities', () => {
   it('keeps doctor focused on own agenda and patients', () => {
     const capabilities = deriveActorCapabilities(user({ role: 'doctor', professional_id: 'professional-1' }));
     const agendaShell = resolveShellSurfaceMetadata('agenda', capabilities);
+    const weeklyScheduleShell = resolveShellSurfaceMetadata('weekly-schedule', capabilities);
     const patientsShell = resolveShellSurfaceMetadata('patients', capabilities);
 
-    expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
+    expect(capabilities.visibleSurfaces).toEqual(['agenda', 'weekly-schedule', 'patients']);
     expect(capabilities.supportSurfaces).toEqual([]);
     expect(capabilities.defaultSurface).toBe('agenda');
     expect(capabilities.agendaMode).toEqual({ kind: 'doctor-own', professionalId: 'professional-1' });
@@ -19,6 +20,11 @@ describe('deriveActorCapabilities', () => {
       eyebrow: 'Práctica propia',
       description: 'Turnos de tu consultorio.',
     });
+    expect(weeklyScheduleShell.intro).toEqual({
+      eyebrow: 'Plantilla semanal',
+      title: 'Agenda semanal',
+      description: 'Definí tu esquema semanal y su vigencia sin mezclarlo con la operación diaria.',
+    });
     expect(patientsShell.intro).toEqual({
       eyebrow: 'Seguimiento clínico',
       title: 'Pacientes',
@@ -29,7 +35,7 @@ describe('deriveActorCapabilities', () => {
   it('blocks malformed doctor without professional association', () => {
     const capabilities = deriveActorCapabilities(user({ role: 'doctor', professional_id: undefined }));
 
-    expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
+    expect(capabilities.visibleSurfaces).toEqual(['agenda', 'weekly-schedule', 'patients']);
     expect(capabilities.agendaMode).toEqual({
       kind: 'forbidden',
       message: 'Tu usuario doctor no tiene professional_id asociado.',
@@ -43,16 +49,23 @@ describe('deriveActorCapabilities', () => {
   it('gives secretary operational agenda and patient access without admin symmetry', () => {
     const capabilities = deriveActorCapabilities(user({ role: 'secretary' }));
     const agendaShell = resolveShellSurfaceMetadata('agenda', capabilities);
+    const weeklyScheduleShell = resolveShellSurfaceMetadata('weekly-schedule', capabilities);
     const patientsShell = resolveShellSurfaceMetadata('patients', capabilities);
     const directoryShell = resolveShellSurfaceMetadata('directory', capabilities);
 
-    expect(capabilities.visibleSurfaces).toEqual(['agenda', 'patients']);
+    expect(capabilities.visibleSurfaces).toEqual(['agenda', 'weekly-schedule', 'patients']);
     expect(capabilities.supportSurfaces).toEqual(['directory']);
     expect(capabilities.defaultSurface).toBe('agenda');
     expect(capabilities.agendaMode).toEqual({ kind: 'operational-shared' });
     expect(capabilities.patientsMode).toEqual({ kind: 'secretary-operational' });
     expect(capabilities.directoryMode).toEqual({ kind: 'setup-secretary-support' });
     expect(agendaShell.navItem.label).toBe('Agenda');
+    expect(weeklyScheduleShell.navItem).toEqual({
+      id: 'weekly-schedule',
+      label: 'Agenda semanal',
+      eyebrow: 'Configuración visible',
+      description: 'Template, vigencia y preview futuro.',
+    });
     expect(patientsShell.intro).toEqual({
       eyebrow: 'Atención operativa',
       title: 'Pacientes',

--- a/web/src/auth/actorCapabilities.ts
+++ b/web/src/auth/actorCapabilities.ts
@@ -1,6 +1,6 @@
 import type { AuthUser } from '../types/auth';
 
-export type SurfaceId = 'agenda' | 'directory' | 'patients';
+export type SurfaceId = 'agenda' | 'weekly-schedule' | 'directory' | 'patients';
 
 export type AgendaMode =
   | { kind: 'doctor-own'; professionalId: string }
@@ -53,7 +53,7 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
   if (user.role === 'doctor') {
     if (!professionalId) {
       return {
-        visibleSurfaces: ['agenda', 'patients'],
+        visibleSurfaces: ['agenda', 'weekly-schedule', 'patients'],
         supportSurfaces: [],
         defaultSurface: 'agenda',
         agendaMode: { kind: 'forbidden', message: DOCTOR_ASSOCIATION_MESSAGE },
@@ -63,7 +63,7 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
     }
 
     return {
-      visibleSurfaces: ['agenda', 'patients'],
+      visibleSurfaces: ['agenda', 'weekly-schedule', 'patients'],
       supportSurfaces: [],
       defaultSurface: 'agenda',
       agendaMode: { kind: 'doctor-own', professionalId },
@@ -74,7 +74,7 @@ export function deriveActorCapabilities(user: AuthUser): ActorCapabilities {
 
   if (user.role === 'secretary') {
     return {
-      visibleSurfaces: ['agenda', 'patients'],
+      visibleSurfaces: ['agenda', 'weekly-schedule', 'patients'],
       supportSurfaces: ['directory'],
       defaultSurface: 'agenda',
       agendaMode: { kind: 'operational-shared' },
@@ -199,6 +199,54 @@ export function resolveShellSurfaceMetadata(
       intro: {
         eyebrow: 'Acceso restringido',
         title: 'Pacientes',
+        description: 'Esta superficie queda visible solo para comunicar el bloqueo actual.',
+      },
+    };
+  }
+
+  if (surfaceId === 'weekly-schedule') {
+    if (capabilities.agendaMode.kind === 'doctor-own') {
+      return {
+        navItem: {
+          id: 'weekly-schedule',
+          label: 'Agenda semanal',
+          eyebrow: 'Plantilla semanal',
+          description: 'Template, vigencia y preview futuro.',
+        },
+        intro: {
+          eyebrow: 'Plantilla semanal',
+          title: 'Agenda semanal',
+          description: 'Definí tu esquema semanal y su vigencia sin mezclarlo con la operación diaria.',
+        },
+      };
+    }
+
+    if (capabilities.agendaMode.kind === 'operational-shared') {
+      return {
+        navItem: {
+          id: 'weekly-schedule',
+          label: 'Agenda semanal',
+          eyebrow: 'Configuración visible',
+          description: 'Template, vigencia y preview futuro.',
+        },
+        intro: {
+          eyebrow: 'Configuración visible',
+          title: 'Agenda semanal',
+          description: 'Editá la plantilla semanal por profesional en una superficie dedicada y explícita.',
+        },
+      };
+    }
+
+    return {
+      navItem: {
+        id: 'weekly-schedule',
+        label: 'Agenda semanal',
+        eyebrow: 'Acceso restringido',
+        description: 'Superficie bloqueada.',
+      },
+      intro: {
+        eyebrow: 'Acceso restringido',
+        title: 'Agenda semanal',
         description: 'Esta superficie queda visible solo para comunicar el bloqueo actual.',
       },
     };

--- a/web/src/features/schedule/EffectiveFromPanel.tsx
+++ b/web/src/features/schedule/EffectiveFromPanel.tsx
@@ -1,0 +1,37 @@
+import { SectionCard } from '../../app-shell/AppShell.primitives';
+import type { EffectiveFromPanelProps } from './weeklyScheduleModels';
+
+export function EffectiveFromPanel({ effectiveFrom, reason, onEffectiveFromChange, onReasonChange }: EffectiveFromPanelProps) {
+  return (
+    <SectionCard className="stack">
+      <div className="section-header">
+        <span className="hero-kicker">Effective from</span>
+        <h2>Vigencia de la nueva versión</h2>
+        <p>La fecha de activación es parte central del flujo. No queda escondida como un dato técnico.</p>
+      </div>
+
+      <div className="field">
+        <label htmlFor="weekly-schedule-effective-from">Vigencia desde</label>
+        <input
+          id="weekly-schedule-effective-from"
+          aria-label="Vigencia desde"
+          type="date"
+          value={effectiveFrom}
+          onChange={(event) => onEffectiveFromChange(event.target.value)}
+        />
+        <span className="helper">Todo cambio impacta la agenda futura desde esta fecha en adelante.</span>
+      </div>
+
+      <div className="field">
+        <label htmlFor="weekly-schedule-reason">Motivo visible para el equipo</label>
+        <textarea
+          id="weekly-schedule-reason"
+          rows={3}
+          value={reason}
+          onChange={(event) => onReasonChange(event.target.value)}
+          placeholder="Ej.: cambio de consultorio, nueva disponibilidad, reducción horaria"
+        />
+      </div>
+    </SectionCard>
+  );
+}

--- a/web/src/features/schedule/ProfessionalScheduleContext.tsx
+++ b/web/src/features/schedule/ProfessionalScheduleContext.tsx
@@ -1,0 +1,73 @@
+import { Badge, SectionCard, SummaryTile } from '../../app-shell/AppShell.primitives';
+import type { ProfessionalScheduleContextProps } from './weeklyScheduleModels';
+import { buildVersionSummaryCard } from './weeklyScheduleState';
+
+export function ProfessionalScheduleContext({
+  actor,
+  professionalOptions,
+  selectedProfessionalId,
+  currentVersion,
+  futureVersion,
+  onProfessionalChange,
+}: ProfessionalScheduleContextProps) {
+  const currentCard = buildVersionSummaryCard(currentVersion, 'current');
+  const futureCard = buildVersionSummaryCard(futureVersion, 'future');
+
+  return (
+    <SectionCard className="stack">
+      <div className="section-header">
+        <span className="hero-kicker">Professional schedule context</span>
+        <h2>Contexto profesional</h2>
+        <p>Separá quién opera la edición, qué agenda está vigente hoy y si ya existe una versión futura preparada.</p>
+      </div>
+
+      <div className="status-bar">
+        <Badge tone="info">{actor.kind === 'secretary' ? 'Secretaría' : 'Agenda propia'}</Badge>
+        <Badge>{actor.kind === 'secretary' ? actor.actorLabel : 'Edición personal'}</Badge>
+      </div>
+
+      {actor.kind === 'secretary' ? (
+        <div className="field">
+          <label htmlFor="weekly-schedule-professional">Profesional</label>
+          <select
+            id="weekly-schedule-professional"
+            aria-label="Profesional"
+            value={selectedProfessionalId}
+            onChange={(event) => onProfessionalChange(event.target.value)}
+          >
+            {professionalOptions.map((professional) => (
+              <option key={professional.id} value={professional.id}>
+                {professional.label}
+                {professional.subtitle ? ` — ${professional.subtitle}` : ''}
+              </option>
+            ))}
+          </select>
+          <span className="helper">La secretaría puede cambiar de profesional sin mezclar esta edición con la operatoria diaria.</span>
+        </div>
+      ) : (
+        <div className="inline-note">
+          <strong>{actor.professionalName}</strong>
+          <span className="helper">Solo podés preparar versiones sobre tu agenda profesional.</span>
+        </div>
+      )}
+
+      <div className="foundation-content-split" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+        {currentCard ? <VersionSummary card={currentCard} /> : null}
+        {futureCard ? <VersionSummary card={futureCard} /> : null}
+      </div>
+    </SectionCard>
+  );
+}
+
+function VersionSummary({ card }: { card: NonNullable<ReturnType<typeof buildVersionSummaryCard>> }) {
+  return (
+    <SummaryTile className="stack-tight">
+      <span className="summary-label">{card.eyebrow}</span>
+      <strong>{card.title}</strong>
+      <span>{card.versionLabel}</span>
+      <small>Vigencia: {card.effectiveFromLabel}</small>
+      <small>{card.scheduleLabel}</small>
+      <small>{card.reasonLabel}</small>
+    </SummaryTile>
+  );
+}

--- a/web/src/features/schedule/ScheduleConflictPanel.tsx
+++ b/web/src/features/schedule/ScheduleConflictPanel.tsx
@@ -1,0 +1,41 @@
+import { Badge, EmptyState, SectionCard } from '../../app-shell/AppShell.primitives';
+import type { ScheduleConflictPanelProps } from './weeklyScheduleModels';
+
+export function ScheduleConflictPanel({ conflicts, effectiveFrom }: ScheduleConflictPanelProps) {
+  return (
+    <SectionCard className="stack">
+      <div className="section-header">
+        <span className="hero-kicker">Conflict summary</span>
+        <h2>Conflictos futuros</h2>
+        <p>
+          El panel reserva espacio para advertencias contra consultas ya cargadas
+          {effectiveFrom ? ` desde ${effectiveFrom}` : ''}.
+        </p>
+      </div>
+
+      {conflicts.length === 0 ? (
+        <EmptyState
+          title="Sin conflictos visibles"
+          description="Cuando exista detección real de conflictos, este bloque mostrará fechas y ventanas afectadas antes de guardar."
+        />
+      ) : (
+        <div className="list">
+          {conflicts.map((conflict) => (
+            <article key={conflict.id} className="appointment-item">
+              <div className="status-bar">
+                <strong>
+                  {conflict.date} · {conflict.startTime}–{conflict.endTime}
+                </strong>
+                <Badge tone={conflict.severity === 'critical' ? 'error' : 'info'}>
+                  {conflict.severity === 'critical' ? 'Crítico' : 'Advertencia'}
+                </Badge>
+              </div>
+              <span>{conflict.summary}</span>
+              {conflict.patientLabel ? <small>Paciente afectado: {conflict.patientLabel}</small> : null}
+            </article>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/web/src/features/schedule/ScheduleDemo.test.tsx
+++ b/web/src/features/schedule/ScheduleDemo.test.tsx
@@ -1,582 +1,371 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../../api/http';
-import type { Appointment, Slot } from '../../types/appointments';
+import type { Consultation, Slot, WeekAgenda } from '../../types/appointments';
 import { ScheduleDemo } from './ScheduleDemo';
 
 const {
-  cancelAppointmentMock,
-  createAppointmentMock,
-  createSlotsBulkMock,
-  listSlotsMock,
-  listAppointmentsMock,
-  listProfessionalsMock,
-  listPatientsMock,
+	cancelAppointmentMock,
+	createAppointmentMock,
+	createSlotsBulkMock,
+	fetchWeekAgendaMock,
+	listProfessionalsMock,
+	listPatientsMock,
 } = vi.hoisted(() => ({
-  cancelAppointmentMock: vi.fn(),
-  createAppointmentMock: vi.fn(),
-  createSlotsBulkMock: vi.fn(),
-  listSlotsMock: vi.fn(),
-  listAppointmentsMock: vi.fn(),
-  listProfessionalsMock: vi.fn(),
-  listPatientsMock: vi.fn(),
+	cancelAppointmentMock: vi.fn(),
+	createAppointmentMock: vi.fn(),
+	createSlotsBulkMock: vi.fn(),
+	fetchWeekAgendaMock: vi.fn(),
+	listProfessionalsMock: vi.fn(),
+	listPatientsMock: vi.fn(),
 }));
 
 vi.mock('../../api/appointments', () => ({
-  cancelAppointment: cancelAppointmentMock,
-  createAppointment: createAppointmentMock,
-  createSlotsBulk: createSlotsBulkMock,
-  listAppointments: listAppointmentsMock,
-  listSlots: listSlotsMock,
-  listOperationalWeek: async ({ professional_id, date }: { professional_id: string; date: string }) => {
-    const weekDays = getWeekDays(date);
-    const days = await Promise.all(
-      weekDays.map(async (day) => {
-        const [slotsResponse, appointmentsResponse] = await Promise.all([
-          listSlotsMock({ professional_id, date: day.date }),
-          listAppointmentsMock({ professional_id, date: day.date }),
-        ]);
-
-        return {
-          date: day.date,
-          weekdayLabel: day.weekdayLabel,
-          slots: slotsResponse.items,
-          appointments: appointmentsResponse.items,
-          summary: {
-            available: slotsResponse.items.filter((slot: Slot) => slot.status === 'available').length,
-            booked: appointmentsResponse.items.filter((appointment: { status: string }) => appointment.status === 'booked').length,
-            cancelled: appointmentsResponse.items.filter((appointment: { status: string }) => appointment.status === 'cancelled').length,
-          },
-        };
-      }),
-    );
-
-    return {
-      weekStart: weekDays[0]?.date ?? date,
-      days,
-      timeBands: [...new Set(days.flatMap((day) => day.slots.map((slot: Slot) => slot.start_time.slice(11, 16))))].sort(),
-    };
-  },
+	cancelAppointment: cancelAppointmentMock,
+	createAppointment: createAppointmentMock,
+	createSlotsBulk: createSlotsBulkMock,
+	fetchWeekAgenda: fetchWeekAgendaMock,
 }));
 
 vi.mock('../../api/directory', () => ({
-  listPatients: listPatientsMock,
-  listProfessionals: listProfessionalsMock,
+	listPatients: listPatientsMock,
+	listProfessionals: listProfessionalsMock,
 }));
 
 vi.mock('./helpers', async () => {
-  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+	const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
 
-  return {
-    ...actual,
-    formatDateInputValue: (date?: Date) => actual.formatDateInputValue(date ?? new Date('2026-04-08T12:00:00Z')),
-  };
+	return {
+		...actual,
+		formatDateInputValue: (date?: Date) => actual.formatDateInputValue(date ?? new Date('2026-04-08T12:00:00Z')),
+	};
 });
 
 describe('ScheduleDemo weekly operational board', () => {
-  beforeEach(() => {
-    cancelAppointmentMock.mockReset();
-    createAppointmentMock.mockReset();
-    createSlotsBulkMock.mockReset();
-    listSlotsMock.mockReset();
-    listAppointmentsMock.mockReset();
-    listProfessionalsMock.mockReset();
-    listPatientsMock.mockReset();
-  });
-
-  it('renders the explicit forbidden agenda branch without bootstrapping schedule data', () => {
-    render(
-      <ScheduleDemo
-        agendaMode={{ kind: 'forbidden', message: 'Tu perfil no tiene permisos para usar esta agenda.' }}
-        onSessionInvalid={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText('Agenda bloqueada')).toBeInTheDocument();
-    expect(screen.getByText('Acceso denegado')).toBeInTheDocument();
-    expect(screen.getByText('Tu perfil no tiene permisos para usar esta agenda.')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Actualizar/i })).not.toBeInTheDocument();
-    expect(listProfessionalsMock).not.toHaveBeenCalled();
-    expect(listPatientsMock).not.toHaveBeenCalled();
-    expect(listSlotsMock).not.toHaveBeenCalled();
-    expect(listAppointmentsMock).not.toHaveBeenCalled();
-  });
-
-  it('invalidates the session on 401 weekly load failures without showing denial feedback', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    listSlotsMock.mockRejectedValue(new ApiError('Sesión vencida', 401));
-    listAppointmentsMock.mockResolvedValue({ items: [] });
-
-    const onSessionInvalid = vi.fn();
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={onSessionInvalid} />);
-
-    await waitFor(() => {
-      expect(onSessionInvalid).toHaveBeenCalledTimes(1);
-    });
-
-    expect(screen.queryByText(/Acceso denegado:/i)).not.toBeInTheDocument();
-  });
-
-  it('locks doctors to their own professional agenda while loading the visible monday-friday week', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional(), secondProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    mockWeekSlices({});
-
-    render(
-      <ScheduleDemo agendaMode={{ kind: 'doctor-own', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />,
-    );
-
-    expect((await screen.findAllByText('Lun 06/04')).length).toBeGreaterThan(0);
-
-    expect(screen.queryByRole('combobox', { name: 'Profesional' })).not.toBeInTheDocument();
-    expect(screen.getByText(/agenda clínica propia/i)).toBeInTheDocument();
-    expect(listSlotsMock).toHaveBeenCalledTimes(5);
-    expect(listSlotsMock.mock.calls.map(([filters]) => filters)).toEqual([
-      { professional_id: 'professional-1', date: '2026-04-06' },
-      { professional_id: 'professional-1', date: '2026-04-07' },
-      { professional_id: 'professional-1', date: '2026-04-08' },
-      { professional_id: 'professional-1', date: '2026-04-09' },
-      { professional_id: 'professional-1', date: '2026-04-10' },
-    ]);
-  });
-
-  it('offers secretary a hidden directory support entry when setup data is missing', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [] });
-    listPatientsMock.mockResolvedValue({ items: [] });
-    mockWeekSlices({});
-
-    const onOpenDirectorySupport = vi.fn();
-
-    render(
-      <ScheduleDemo
-        agendaMode={{ kind: 'operational-shared' }}
-        onSessionInvalid={vi.fn()}
-        onOpenDirectorySupport={onOpenDirectorySupport}
-      />,
-    );
-
-    expect(await screen.findByText(/faltan profesionales y pacientes para operar la agenda/i)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: /abrir soporte de directorio/i }));
-
-    expect(onOpenDirectorySupport).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows a monday-friday weekly board with explicit empty weekdays', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    mockWeekSlices({
-      '2026-04-06': { slots: [availableSlot('slot-mon', '2026-04-06T09:00:00Z', '2026-04-06T09:30:00Z')] },
-      '2026-04-08': { slots: [availableSlot('slot-wed', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
-    });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
-    expect((await screen.findAllByText('Lun 06/04')).length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Mar 07/04').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Mié 08/04').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Jue 09/04').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Vie 10/04').length).toBeGreaterThan(0);
-    expect(screen.queryByText(/Sáb/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Dom/i)).not.toBeInTheDocument();
-    expect(screen.getAllByText('Sin actividad para este día').length).toBeGreaterThan(0);
-    expect(screen.queryByText('Contexto de agenda')).not.toBeInTheDocument();
-    expect(screen.queryByText('Filtros de agenda')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
-  });
-
-  it('keeps a single compact context surface on constrained viewports', async () => {
-    const originalInnerWidth = window.innerWidth;
-
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      value: 375,
-      writable: true,
-    });
-    window.dispatchEvent(new Event('resize'));
-
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    mockWeekSlices({
-      '2026-04-08': { slots: [availableSlot('slot-wed', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
-    });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
-    expect(screen.getAllByText(/Semana UTC/i)).toHaveLength(1);
-    expect(screen.getAllByRole('button', { name: 'Reservar turno' })).toHaveLength(1);
-    expect(screen.getAllByRole('button', { name: 'Generar slots' })).toHaveLength(1);
-    expect(screen.queryByText('Contexto de agenda')).not.toBeInTheDocument();
-    expect(screen.queryByText('Filtros de agenda')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
-
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      value: originalInnerWidth,
-      writable: true,
-    });
-    window.dispatchEvent(new Event('resize'));
-  });
-
-  it('opens booking through a modal launched from the selected slot context', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
-    mockWeekRefreshes([
-      {
-        '2026-04-08': {
-          slots: [
-            availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z'),
-            availableSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z'),
-          ],
-        },
-      },
-      {
-        '2026-04-08': {
-          slots: [bookedSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')],
-          appointments: [bookedAppointment('appointment-1', 'slot-2')],
-        },
-      },
-    ]);
-    createAppointmentMock.mockResolvedValue({ id: 'appointment-1' });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    fireEvent.click((await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0]);
-
-    const slotCell = await screen.findByRole('button', { name: /Mié 08\/04 .*10:00 - 10:30 UTC/i });
-
-    const bookTrigger = screen.getByRole('button', { name: 'Reservar turno' });
-
-    expect(bookTrigger).toBeDisabled();
-    expect(screen.queryByRole('button', { name: /Reprogramar/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Ver detalle/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
-
-    fireEvent.click(slotCell);
-
-    expect(bookTrigger).toBeEnabled();
-
-    fireEvent.click(bookTrigger);
-
-    const bookingDialog = await screen.findByRole('dialog', { name: /Reservar turno/i });
-
-    expect(within(bookingDialog).getByLabelText('Buscar paciente')).toBeInTheDocument();
-    expect(within(bookingDialog).getByText(/Mié 08\/04/i)).toBeInTheDocument();
-
-    fireEvent.change(within(bookingDialog).getByLabelText('Buscar paciente'), { target: { value: 'maria' } });
-    fireEvent.click(within(bookingDialog).getByRole('button', { name: /María Gómez/i }));
-
-    fireEvent.click(within(bookingDialog).getByRole('button', { name: 'Confirmar reserva' }));
-
-    await waitFor(() => {
-      expect(createAppointmentMock).toHaveBeenCalledWith({
-        slot_id: 'slot-2',
-        patient_id: 'patient-2',
-        professional_id: 'professional-1',
-      });
-    });
-
-    expect(await screen.findByText('Turno reservado correctamente.')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Reservar turno/i })).not.toBeInTheDocument();
-    });
-    expect(await screen.findByText('Juan Pérez')).toBeInTheDocument();
-    expect(screen.getByText('Reservado')).toBeInTheDocument();
-  });
-
-  it('keeps the selected booking patient when the filter hides it and shows the empty-results state', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
-    mockWeekSlices({
-      '2026-04-08': { slots: [availableSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
-    });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    fireEvent.click((await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0]);
-    fireEvent.click(await screen.findByRole('button', { name: /Mié 08\/04 .*10:00 - 10:30 UTC/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Reservar turno' }));
-
-    const bookingDialog = await screen.findByRole('dialog', { name: /Reservar turno/i });
-    const searchInput = within(bookingDialog).getByLabelText('Buscar paciente');
-
-    fireEvent.change(searchInput, { target: { value: 'maria' } });
-    fireEvent.click(within(bookingDialog).getByRole('button', { name: /María Gómez/i }));
-
-    fireEvent.change(searchInput, { target: { value: 'juan' } });
-
-    expect(within(bookingDialog).getByText(/Paciente seleccionado: María Gómez. No aparece en estos resultados por el filtro actual./i)).toBeInTheDocument();
-    expect(within(bookingDialog).queryByRole('button', { name: /María Gómez/i })).not.toBeInTheDocument();
-
-    fireEvent.change(searchInput, { target: { value: 'zzzz' } });
-
-    expect(within(bookingDialog).getByText(/No encontramos pacientes para “zzzz”./i)).toBeInTheDocument();
-    expect(within(bookingDialog).getByText(/Probá con nombre o documento./i)).toBeInTheDocument();
-    expect(within(bookingDialog).getByText(/Paciente seleccionado: María Gómez. No aparece en estos resultados por el filtro actual./i)).toBeInTheDocument();
-  });
-
-  it('opens slot generation through a modal bound to the selected day', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    mockWeekRefreshes([
-      {},
-      { '2026-04-08': { slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')] } },
-    ]);
-    createSlotsBulkMock.mockResolvedValue({
-      items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
-    });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    const weekdayCard = (await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0];
-    fireEvent.click(weekdayCard);
-
-    expect(weekdayCard).toHaveAttribute('aria-pressed', 'true');
-    expect(await screen.findAllByText('Sin actividad para este día')).not.toHaveLength(0);
-
-    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Generar slots' }));
-
-    const generateDialog = await screen.findByRole('dialog', { name: /Generar slots/i });
-
-    expect(within(generateDialog).getByLabelText('Desde')).toBeInTheDocument();
-    expect(within(generateDialog).getByLabelText('Hasta')).toBeInTheDocument();
-    expect(within(generateDialog).getAllByText(/Mié 08\/04/i).length).toBeGreaterThan(0);
-
-    fireEvent.click(within(generateDialog).getByRole('button', { name: 'Confirmar generación' }));
-
-    await waitFor(() => {
-      expect(createSlotsBulkMock).toHaveBeenCalledWith({
-        professional_id: 'professional-1',
-        date: '2026-04-08',
-        start_time: '09:00',
-        end_time: '12:00',
-        slot_duration_minutes: 30,
-      });
-    });
-
-    expect(await screen.findByText('Se generaron 1 slot correctamente.')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Generar slots/i })).not.toBeInTheDocument();
-    });
-    expect(await screen.findByRole('button', { name: /Mié 08\/04 .*09:00 - 09:30 UTC/i })).toBeInTheDocument();
-  });
-
-  it('supports week browsing and cancellation while keeping released slot feedback intact', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    mockWeekRefreshes([
-      { '2026-04-08': { slots: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')], appointments: [bookedAppointment('appointment-1', 'slot-1')] } },
-      { '2026-04-13': { slots: [availableSlot('slot-next', '2026-04-13T09:00:00Z', '2026-04-13T09:30:00Z')] } },
-      { '2026-04-08': { slots: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')], appointments: [bookedAppointment('appointment-1', 'slot-1')] } },
-      { '2026-04-08': { slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')], appointments: [cancelledAppointment('appointment-1', 'slot-1')] } },
-    ]);
-    cancelAppointmentMock.mockResolvedValue(undefined);
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    const appointmentCell = await screen.findByTestId('board-cell-2026-04-08-09:00');
-    expect(within(appointmentCell).getByText('Juan Pérez')).toBeInTheDocument();
-    fireEvent.click(screen.getAllByRole('button', { name: /Mié 08\/04/i })[0]);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Semana siguiente' }));
-    expect(await screen.findByText('Lun 13/04')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Mié 15\/04/i })).toHaveAttribute('aria-pressed', 'true');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Semana anterior' }));
-    expect(await screen.findByRole('button', { name: /Mié 08\/04/i })).toHaveAttribute('aria-pressed', 'true');
-    fireEvent.click(await screen.findByRole('button', { name: 'Cancelar' }));
-
-    await waitFor(() => {
-      expect(cancelAppointmentMock).toHaveBeenCalledWith('appointment-1');
-    });
-
-    expect(await screen.findByText(/volvió a quedar disponible/i)).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: /Mié 08\/04 .*09:00 - 09:30 UTC/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(within(screen.getByTestId('board-cell-2026-04-08-09:00')).getByText('Cancelado')).toBeInTheDocument();
-    expect(screen.queryByText(/Appointment:/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Slot:/i)).not.toBeInTheDocument();
-  });
-
-  it('keeps the redesign on existing agenda capabilities and backend contracts only', async () => {
-    listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
-    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
-    mockWeekSlices({
-      '2026-04-08': { slots: [availableSlot('slot-wed', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
-    });
-
-    render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
-
-    expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
-    expect(listSlotsMock).toHaveBeenCalledTimes(5);
-    expect(listAppointmentsMock).toHaveBeenCalledTimes(5);
-    expect(createAppointmentMock).not.toHaveBeenCalled();
-    expect(createSlotsBulkMock).not.toHaveBeenCalled();
-    expect(cancelAppointmentMock).not.toHaveBeenCalled();
-    expect(screen.queryByRole('button', { name: /Reprogramar/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Ver detalle/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Paciente')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Actualizar agenda' }));
-
-    await waitFor(() => {
-      expect(listSlotsMock).toHaveBeenCalledTimes(10);
-      expect(listAppointmentsMock).toHaveBeenCalledTimes(10);
-    });
-
-    expect(createAppointmentMock).not.toHaveBeenCalled();
-    expect(createSlotsBulkMock).not.toHaveBeenCalled();
-    expect(cancelAppointmentMock).not.toHaveBeenCalled();
-  });
+	beforeEach(() => {
+		cancelAppointmentMock.mockReset();
+		createAppointmentMock.mockReset();
+		createSlotsBulkMock.mockReset();
+		fetchWeekAgendaMock.mockReset();
+		listProfessionalsMock.mockReset();
+		listPatientsMock.mockReset();
+	});
+
+	it('renders the explicit forbidden agenda branch without bootstrapping schedule data', () => {
+		render(
+			<ScheduleDemo
+				agendaMode={{ kind: 'forbidden', message: 'Tu perfil no tiene permisos para usar esta agenda.' }}
+				onSessionInvalid={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('Agenda bloqueada')).toBeInTheDocument();
+		expect(screen.getByText('Acceso denegado')).toBeInTheDocument();
+		expect(screen.getByText('Tu perfil no tiene permisos para usar esta agenda.')).toBeInTheDocument();
+		expect(fetchWeekAgendaMock).not.toHaveBeenCalled();
+		expect(listProfessionalsMock).not.toHaveBeenCalled();
+		expect(listPatientsMock).not.toHaveBeenCalled();
+	});
+
+	it('invalidates the session on 401 weekly load failures without showing denial feedback', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+		fetchWeekAgendaMock.mockRejectedValue(new ApiError('Sesión vencida', 401));
+
+		const onSessionInvalid = vi.fn();
+
+		render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={onSessionInvalid} />);
+
+		await waitFor(() => {
+			expect(onSessionInvalid).toHaveBeenCalledTimes(1);
+		});
+
+		expect(screen.queryByText(/Acceso denegado:/i)).not.toBeInTheDocument();
+	});
+
+	it('locks doctors to their own professional agenda while loading the visible monday-friday week', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional(), secondProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+		fetchWeekAgendaMock.mockResolvedValue(weekAgenda({}));
+
+		render(
+			<ScheduleDemo agendaMode={{ kind: 'doctor-own', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />,
+		);
+
+		expect((await screen.findAllByText('Lun 06/04')).length).toBeGreaterThan(0);
+		expect(screen.queryByRole('combobox', { name: 'Profesional' })).not.toBeInTheDocument();
+		expect(screen.getByText(/agenda clínica propia/i)).toBeInTheDocument();
+		expect(fetchWeekAgendaMock).toHaveBeenCalledWith({ professional_id: 'professional-1', week_start: '2026-04-06' });
+	});
+
+	it('offers secretary a hidden directory support entry when setup data is missing', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [] });
+		listPatientsMock.mockResolvedValue({ items: [] });
+		fetchWeekAgendaMock.mockResolvedValue(weekAgenda({}));
+
+		const onOpenDirectorySupport = vi.fn();
+
+		render(
+			<ScheduleDemo
+				agendaMode={{ kind: 'operational-shared' }}
+				onSessionInvalid={vi.fn()}
+				onOpenDirectorySupport={onOpenDirectorySupport}
+			/>,
+		);
+
+		expect(await screen.findByText(/faltan profesionales y pacientes para operar la agenda/i)).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: /abrir soporte de directorio/i }));
+
+		expect(onOpenDirectorySupport).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the agenda board focused on daily operations without embedding weekly template editing', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional(), secondProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+		fetchWeekAgendaMock.mockResolvedValue(weekAgenda({}));
+
+		render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+		expect(await screen.findByRole('heading', { name: 'Agenda semanal operativa' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Editar agenda semanal' })).not.toBeInTheDocument();
+	});
+
+	it('keeps doctors on the daily board without a duplicated weekly editor entry', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional(), secondProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+		fetchWeekAgendaMock.mockResolvedValue(weekAgenda({}));
+
+			render(
+			<ScheduleDemo agendaMode={{ kind: 'doctor-own', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />,
+		);
+
+		expect(await screen.findByText(/agenda clínica propia/i)).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Editar agenda semanal' })).not.toBeInTheDocument();
+	});
+
+	it('opens booking from an available slot and refreshes the weekly board', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
+		fetchWeekAgendaMock
+			.mockResolvedValueOnce(weekAgenda({
+				'2026-04-08': { slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z'), availableSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')] },
+			}))
+			.mockResolvedValueOnce(weekAgenda({
+				'2026-04-08': {
+					slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z'), bookedSlot('slot-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')],
+					consultations: [scheduledConsultation('appointment-1', 'slot-2', 'patient-2', '2026-04-08T10:00:00Z', '2026-04-08T10:30:00Z')],
+				},
+			}));
+		createAppointmentMock.mockResolvedValue({ id: 'appointment-1' });
+
+		render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+		fireEvent.click((await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0]);
+		const slotCell = await screen.findByRole('button', { name: /Mié 08\/04 .*10:00 - 10:30 UTC/i });
+		fireEvent.click(slotCell);
+		fireEvent.click(screen.getByRole('button', { name: 'Reservar turno' }));
+
+		const bookingDialog = await screen.findByRole('dialog', { name: /Reservar turno/i });
+		fireEvent.change(within(bookingDialog).getByLabelText('Buscar paciente'), { target: { value: 'maria' } });
+		fireEvent.click(within(bookingDialog).getByRole('button', { name: /María Gómez/i }));
+		fireEvent.click(within(bookingDialog).getByRole('button', { name: 'Confirmar reserva' }));
+
+		await waitFor(() => {
+			expect(createAppointmentMock).toHaveBeenCalledWith({
+				slot_id: 'slot-2',
+				patient_id: 'patient-2',
+				professional_id: 'professional-1',
+			});
+		});
+
+		expect(await screen.findByText('Turno reservado correctamente.')).toBeInTheDocument();
+		expect(await screen.findByText('María Gómez')).toBeInTheDocument();
+		expect(screen.getByText('Reservado')).toBeInTheDocument();
+		expect(fetchWeekAgendaMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('opens slot generation through a modal bound to the selected day', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+		fetchWeekAgendaMock
+			.mockResolvedValueOnce(weekAgenda({}))
+			.mockResolvedValueOnce(weekAgenda({ '2026-04-08': { slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')] } }));
+		createSlotsBulkMock.mockResolvedValue({ items: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')] });
+
+		render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+		fireEvent.click((await screen.findAllByRole('button', { name: /Mié 08\/04/i }))[0]);
+		fireEvent.click(screen.getByRole('button', { name: 'Generar slots' }));
+
+		const generateDialog = await screen.findByRole('dialog', { name: /Generar slots/i });
+		fireEvent.click(within(generateDialog).getByRole('button', { name: 'Confirmar generación' }));
+
+		await waitFor(() => {
+			expect(createSlotsBulkMock).toHaveBeenCalledWith({
+				professional_id: 'professional-1',
+				date: '2026-04-08',
+				start_time: '09:00',
+				end_time: '12:00',
+				slot_duration_minutes: 30,
+			});
+		});
+
+		expect(await screen.findByText('Se generaron 1 slot correctamente.')).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: /Mié 08\/04 .*09:00 - 09:30 UTC/i })).toBeInTheDocument();
+	});
+
+	it('supports week browsing and cancellation while keeping released slot feedback intact', async () => {
+		listProfessionalsMock.mockResolvedValue({ items: [activeProfessional()] });
+		listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+		fetchWeekAgendaMock
+			.mockResolvedValueOnce(weekAgenda({
+				'2026-04-08': {
+					slots: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+					consultations: [scheduledConsultation('appointment-1', 'slot-1', 'patient-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+				},
+			}))
+			.mockResolvedValueOnce(weekAgenda({
+				'2026-04-13': { slots: [availableSlot('slot-next', '2026-04-13T09:00:00Z', '2026-04-13T09:30:00Z')] },
+			}, '2026-04-13'))
+			.mockResolvedValueOnce(weekAgenda({
+				'2026-04-06': {
+					slots: [bookedSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+					consultations: [scheduledConsultation('appointment-1', 'slot-1', 'patient-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+				},
+			}))
+			.mockResolvedValueOnce(weekAgenda({
+				'2026-04-08': {
+					slots: [availableSlot('slot-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+					consultations: [cancelledConsultation('appointment-1', 'slot-1', 'patient-1', '2026-04-08T09:00:00Z', '2026-04-08T09:30:00Z')],
+				},
+			}));
+		cancelAppointmentMock.mockResolvedValue(undefined);
+
+		render(<ScheduleDemo agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+		expect(await screen.findByText('Juan Pérez')).toBeInTheDocument();
+		fireEvent.click(screen.getAllByRole('button', { name: /Mié 08\/04/i })[0]);
+		fireEvent.click(screen.getByRole('button', { name: 'Semana siguiente' }));
+		expect(await screen.findByText('Lun 13/04')).toBeInTheDocument();
+		fireEvent.click(screen.getByRole('button', { name: 'Semana anterior' }));
+		fireEvent.click(await screen.findByRole('button', { name: 'Cancelar' }));
+
+		await waitFor(() => {
+			expect(cancelAppointmentMock).toHaveBeenCalledWith('appointment-1');
+		});
+
+		expect(await screen.findByText(/volvió a quedar disponible/i)).toBeInTheDocument();
+		expect(within(screen.getByTestId('board-cell-2026-04-08-09:00')).getByText('Cancelado')).toBeInTheDocument();
+	});
 });
 
-function mockWeekSlices(days: Record<string, { slots?: Slot[]; appointments?: Appointment[] }>) {
-  listSlotsMock.mockImplementation(({ date }: { date: string }) => Promise.resolve({ items: days[date]?.slots ?? [] }));
-  listAppointmentsMock.mockImplementation(({ date }: { date: string }) => Promise.resolve({ items: days[date]?.appointments ?? [] }));
+function weekAgenda(
+	days: Record<string, { slots?: Slot[]; consultations?: Consultation[] }>,
+	weekStart = '2026-04-06',
+): WeekAgenda {
+	return {
+		professional_id: 'professional-1',
+		week_start: weekStart,
+		templates: [],
+		blocks: [],
+		consultations: Object.values(days).flatMap((day) => day.consultations ?? []),
+		slots: Object.values(days).flatMap((day) => day.slots ?? []),
+	};
 }
 
-function mockWeekRefreshes(weeks: Array<Record<string, { slots?: Slot[]; appointments?: Appointment[] }>>) {
-  let activeWeekIndex = 0;
-  let callsInWeek = 0;
-
-  const advanceWeekIfNeeded = () => {
-    callsInWeek += 1;
-    if (callsInWeek === 10) {
-      callsInWeek = 0;
-      if (activeWeekIndex < weeks.length - 1) {
-        activeWeekIndex += 1;
-      }
-    }
-  };
-
-  listSlotsMock.mockImplementation(({ date }: { date: string }) => {
-    const result = Promise.resolve({ items: weeks[activeWeekIndex]?.[date]?.slots ?? [] });
-    advanceWeekIfNeeded();
-    return result;
-  });
-
-  listAppointmentsMock.mockImplementation(({ date }: { date: string }) => {
-    const result = Promise.resolve({ items: weeks[activeWeekIndex]?.[date]?.appointments ?? [] });
-    advanceWeekIfNeeded();
-    return result;
-  });
+function availableSlot(id: string, startTime: string, endTime: string): Slot {
+	return {
+		id,
+		professional_id: 'professional-1',
+		start_time: startTime,
+		end_time: endTime,
+		status: 'available',
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
 }
 
-function availableSlot(id: string, startTime: string, endTime: string) {
-  return {
-    id,
-    professional_id: 'professional-1',
-    start_time: startTime,
-    end_time: endTime,
-    status: 'available' as const,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  };
+function bookedSlot(id: string, startTime: string, endTime: string): Slot {
+	return {
+		...availableSlot(id, startTime, endTime),
+		status: 'booked',
+	};
 }
 
-function bookedSlot(id: string, startTime: string, endTime: string) {
-  return {
-    ...availableSlot(id, startTime, endTime),
-    status: 'booked' as const,
-  };
+function scheduledConsultation(id: string, slotId: string | null, patientId: string, startTime: string, endTime: string): Consultation {
+	return {
+		id,
+		slot_id: slotId,
+		professional_id: 'professional-1',
+		patient_id: patientId,
+		status: 'scheduled',
+		source: 'secretary',
+		scheduled_start: startTime,
+		scheduled_end: endTime,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
 }
 
-function bookedAppointment(id: string, slotId: string) {
-  return {
-    id,
-    slot_id: slotId,
-    patient_id: 'patient-1',
-    professional_id: 'professional-1',
-    status: 'booked' as const,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  };
-}
-
-function cancelledAppointment(id: string, slotId: string) {
-  return {
-    ...bookedAppointment(id, slotId),
-    status: 'cancelled' as const,
-  };
+function cancelledConsultation(id: string, slotId: string | null, patientId: string, startTime: string, endTime: string): Consultation {
+	return {
+		...scheduledConsultation(id, slotId, patientId, startTime, endTime),
+		status: 'cancelled',
+		cancelled_at: '2026-01-02T00:00:00Z',
+	};
 }
 
 function secondProfessional() {
-  return {
-    id: 'professional-2',
-    first_name: 'Beto',
-    last_name: 'Trauma',
-    specialty: 'Traumatología',
-    active: true,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  };
+	return {
+		id: 'professional-2',
+		first_name: 'Beto',
+		last_name: 'Trauma',
+		specialty: 'Traumatología',
+		active: true,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
 }
 
 function activeProfessional() {
-  return {
-    id: 'professional-1',
-    first_name: 'Ana',
-    last_name: 'Médica',
-    specialty: 'Clínica',
-    active: true,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  };
+	return {
+		id: 'professional-1',
+		first_name: 'Ana',
+		last_name: 'Médica',
+		specialty: 'Clínica',
+		active: true,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
 }
 
 function activePatient() {
-  return {
-    id: 'patient-1',
-    first_name: 'Juan',
-    last_name: 'Pérez',
-    document: '12345678',
-    birth_date: '1990-01-01',
-    phone: '555-1234',
-    email: 'juan@example.com',
-    active: true,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  };
+	return {
+		id: 'patient-1',
+		first_name: 'Juan',
+		last_name: 'Pérez',
+		document: '12345678',
+		birth_date: '1990-01-01',
+		phone: '555-1234',
+		email: 'juan@example.com',
+		active: true,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
 }
 
 function secondPatient() {
-  return {
-    id: 'patient-2',
-    first_name: 'María',
-    last_name: 'Gómez',
-    document: '20999111',
-    birth_date: '1991-02-02',
-    phone: '555-9876',
-    email: 'maria@example.com',
-    active: true,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-  };
-}
-
-function getWeekDays(date: string) {
-  const parsedDate = new Date(`${date}T00:00:00Z`);
-  const dayOfWeek = parsedDate.getUTCDay();
-  const offsetToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-  parsedDate.setUTCDate(parsedDate.getUTCDate() + offsetToMonday);
-
-  return Array.from({ length: 5 }, (_, index) => {
-    const currentDate = new Date(parsedDate);
-    currentDate.setUTCDate(parsedDate.getUTCDate() + index);
-
-    return {
-      date: currentDate.toISOString().slice(0, 10),
-      weekdayLabel: ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'][currentDate.getUTCDay()] + ` ${currentDate.toISOString().slice(8, 10)}/${currentDate.toISOString().slice(5, 7)}`,
-    };
-  });
+	return {
+		id: 'patient-2',
+		first_name: 'María',
+		last_name: 'Gómez',
+		document: '20999111',
+		birth_date: '1991-02-02',
+		phone: '555-9876',
+		email: 'maria@example.com',
+		active: true,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
 }

--- a/web/src/features/schedule/ScheduleDemo.tsx
+++ b/web/src/features/schedule/ScheduleDemo.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { cancelAppointment, createAppointment, createSlotsBulk, listOperationalWeek, type OperationalWeekDay } from '../../api/appointments';
+import { cancelAppointment, createAppointment, createSlotsBulk, fetchWeekAgenda } from '../../api/appointments';
 import { listPatients, listProfessionals } from '../../api/directory';
 import { type AgendaMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
 import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import type { Appointment, BulkCreateSlotsPayload, Slot } from '../../types/appointments';
 import type { Patient, Professional } from '../../types/directory';
+import { buildScheduleBoardModel, type ScheduleBoardAppointment, type ScheduleBoardDay } from './agendaAdapter';
 import { filterPatients, normalizePatientSearchValue } from '../patient-search/matching';
 import {
   formatDateInputValue,
@@ -30,7 +31,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
   const [selectedPatientId, setSelectedPatientId] = useState('');
   const [selectedDate, setSelectedDate] = useState(initialSelectedDate);
   const [weekStart, setWeekStart] = useState(getUtcWeekStart(initialSelectedDate));
-  const [days, setDays] = useState<OperationalWeekDay[]>([]);
+  const [days, setDays] = useState<ScheduleBoardDay[]>([]);
   const [timeBands, setTimeBands] = useState<string[]>([]);
   const [focusedBand, setFocusedBand] = useState('');
   const [selectedSlotId, setSelectedSlotId] = useState('');
@@ -160,18 +161,19 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
       setErrorMessage('');
       setAccessDeniedMessage('');
 
-      const nextWeek = await listOperationalWeek({ professional_id: selectedProfessionalId, date: weekStart });
-      const nextSlots = nextWeek.days.flatMap((day) => day.slots);
+      const nextWeek = await fetchWeekAgenda({ professional_id: selectedProfessionalId, week_start: weekStart });
+      const board = buildScheduleBoardModel(nextWeek);
+      const nextSlots = board.days.flatMap((day) => day.slots);
 
-      setWeekStart(nextWeek.weekStart);
-      setDays(nextWeek.days);
-      setTimeBands(nextWeek.timeBands);
+      setWeekStart(board.weekStart);
+      setDays(board.days);
+      setTimeBands(board.timeBands);
       setSelectedDate((current) => {
-        if (nextWeek.days.some((day) => day.date === current)) {
+        if (board.days.some((day) => day.date === current)) {
           return current;
         }
 
-        return nextWeek.days[0]?.date ?? current;
+        return board.days[0]?.date ?? current;
       });
       setSelectedSlotId((current) =>
         nextSlots.find((slot) => slot.id === releasedSlotIdRef.current && slot.status === 'available')?.id ||
@@ -179,7 +181,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
         nextSlots.find((slot) => slot.status === 'available')?.id ||
         '',
       );
-      setFocusedBand((current) => current || nextWeek.timeBands[0] || '');
+      setFocusedBand((current) => current || board.timeBands[0] || '');
     } catch (error) {
       const nextError = handleApiFailure(error, 'No se pudo cargar la agenda seleccionada.');
       setErrorMessage(nextError.errorMessage);
@@ -356,6 +358,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
         </div>
       )}
 
+      <>
       <SectionCard className="card-accent schedule-context-bar">
         <div className="schedule-context-bar-main">
           <div>
@@ -563,7 +566,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
                               {selectedProfessional.first_name} {selectedProfessional.last_name} · {formatLongDate(day.date)}
                             </small>
                           ) : null}
-                          <span className={`pill${appointment.status === 'cancelled' ? ' cancelled' : ''}`}>{appointment.status === 'cancelled' ? 'Cancelado' : 'Reservado'}</span>
+                          <span className={`pill${appointment.status === 'cancelled' ? ' cancelled' : ''}`}>{appointment.status_label}</span>
                           <button
                             className="button ghost"
                             type="button"
@@ -572,7 +575,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
                               setFocusedBand(band);
                               void handleCancelAppointment(appointment.id);
                             }}
-                            disabled={appointment.status === 'cancelled' || cancellingAppointmentId === appointment.id}
+                            disabled={!appointment.can_cancel || appointment.status === 'cancelled' || cancellingAppointmentId === appointment.id}
                           >
                             {cancellingAppointmentId === appointment.id ? 'Cancelando...' : 'Cancelar'}
                           </button>
@@ -728,6 +731,7 @@ export function ScheduleDemo({ agendaMode, onSessionInvalid, onOpenDirectorySupp
           </section>
         </div>
       ) : null}
+      </>
     </PageContainer>
   );
 }

--- a/web/src/features/schedule/WeeklyScheduleActions.tsx
+++ b/web/src/features/schedule/WeeklyScheduleActions.tsx
@@ -1,0 +1,39 @@
+import { ActionBar, InlineNotice, SectionCard } from '../../app-shell/AppShell.primitives';
+import type { WeeklyScheduleActionsProps } from './weeklyScheduleModels';
+
+export function WeeklyScheduleActions({ canSave, isSaving = false, onSave, onCancel }: WeeklyScheduleActionsProps) {
+  const isSaveDisabled = !canSave || isSaving;
+
+  return (
+    <SectionCard className="stack">
+      <div className="section-header">
+        <span className="hero-kicker">Weekly schedule actions</span>
+        <h2>Acciones</h2>
+        <p>La skeleton deja explícito qué falta completar antes de intentar persistir una nueva versión.</p>
+      </div>
+
+      {!canSave ? (
+        <InlineNotice>
+          Completá una fecha de vigencia y al menos un día con ventana válida para habilitar el guardado de la versión semanal.
+        </InlineNotice>
+      ) : null}
+
+      {isSaving ? (
+        <InlineNotice>
+          Guardando la nueva versión semanal contra el backend real y recargando el estado visible.
+        </InlineNotice>
+      ) : null}
+
+      <ActionBar style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, max-content))' }}>
+        <button type="button" className="button" onClick={onSave} disabled={isSaveDisabled}>
+          {isSaving ? 'Guardando versión semanal…' : 'Guardar versión semanal'}
+        </button>
+        {onCancel ? (
+          <button type="button" className="button secondary" onClick={onCancel}>
+            Cancelar edición
+          </button>
+        ) : null}
+      </ActionBar>
+    </SectionCard>
+  );
+}

--- a/web/src/features/schedule/WeeklySchedulePage.test.tsx
+++ b/web/src/features/schedule/WeeklySchedulePage.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ScheduleTemplateVersion } from '../../types/appointments';
+import { WeeklySchedulePage } from './WeeklySchedulePage';
+
+describe('WeeklySchedulePage', () => {
+  it('lets secretariat choose the target professional and submit a weekly draft once effective_from is set', () => {
+    const onSave = vi.fn();
+
+    render(
+      <WeeklySchedulePage
+        actor={{ kind: 'secretary', actorLabel: 'Secretaría central', workspaceLabel: 'Agenda operativa multi-profesional' }}
+        professionalOptions={[
+          { id: 'professional-1', label: 'Dra. Julia Núñez', subtitle: 'Clínica médica' },
+          { id: 'professional-2', label: 'Dr. Tomás Suárez', subtitle: 'Cardiología' },
+        ]}
+        initialSelectedProfessionalId="professional-2"
+        currentVersion={activeVersion()}
+        futureVersion={futureVersion()}
+        knownConflicts={[
+          {
+            id: 'conflict-1',
+            date: '2026-05-06',
+            startTime: '10:00',
+            endTime: '10:30',
+            patientLabel: 'María Gómez',
+            summary: 'Hay una consulta futura que quedaría fuera del nuevo template.',
+            severity: 'critical',
+          },
+        ]}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Profesional' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /editor semanal/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /preview semanal/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /conflictos futuros/i })).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', { name: /guardar versión semanal/i });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Vigencia desde'), { target: { value: '2026-05-01' } });
+
+    expect(saveButton).toBeEnabled();
+
+    fireEvent.click(saveButton);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        professionalId: 'professional-2',
+        effectiveFrom: '2026-05-01',
+      }),
+    );
+    expect(onSave.mock.calls[0]?.[0].previewDays).toEqual(
+      expect.arrayContaining([expect.objectContaining({ dayKey: 'monday', slotCount: 6 })]),
+    );
+  });
+
+  it('keeps doctors scoped to their own professional agenda without a cross-professional selector', () => {
+    render(
+      <WeeklySchedulePage
+        actor={{
+          kind: 'doctor',
+          actorLabel: 'Dr. Gregory House',
+          professionalId: 'professional-1',
+          professionalName: 'Dr. Gregory House',
+        }}
+        currentVersion={activeVersion()}
+      />,
+    );
+
+    expect(screen.queryByRole('combobox', { name: 'Profesional' })).not.toBeInTheDocument();
+    expect(screen.getByText('Dr. Gregory House')).toBeInTheDocument();
+    expect(screen.getByText(/agenda propia/i)).toBeInTheDocument();
+    expect(screen.getByText(/solo podés preparar versiones sobre tu agenda profesional/i)).toBeInTheDocument();
+  });
+
+  it('re-seeds the draft when the loaded future version changes after a save or reload', () => {
+    const onSave = vi.fn();
+    const { rerender } = render(
+      <WeeklySchedulePage
+        actor={{ kind: 'secretary', actorLabel: 'Secretaría central', workspaceLabel: 'Agenda operativa multi-profesional' }}
+        professionalOptions={[{ id: 'professional-1', label: 'Dra. Julia Núñez', subtitle: 'Clínica médica' }]}
+        initialSelectedProfessionalId="professional-1"
+        currentVersion={activeVersion()}
+        futureVersion={futureVersion()}
+        onSave={onSave}
+      />,
+    );
+
+    rerender(
+      <WeeklySchedulePage
+        actor={{ kind: 'secretary', actorLabel: 'Secretaría central', workspaceLabel: 'Agenda operativa multi-profesional' }}
+        professionalOptions={[{ id: 'professional-1', label: 'Dra. Julia Núñez', subtitle: 'Clínica médica' }]}
+        initialSelectedProfessionalId="professional-1"
+        currentVersion={activeVersion()}
+        futureVersion={reloadedFutureVersion()}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Vigencia desde'), { target: { value: '2026-06-01' } });
+    fireEvent.click(screen.getByRole('button', { name: /guardar versión semanal/i }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        professionalId: 'professional-1',
+        effectiveFrom: '2026-06-01',
+        recurrence: {
+          tuesday: {
+            start_time: '08:00',
+            end_time: '11:00',
+            slot_duration_minutes: 30,
+          },
+        },
+      }),
+    );
+  });
+});
+
+function activeVersion(): ScheduleTemplateVersion {
+  return {
+    id: 'version-1',
+    template_id: 'template-1',
+    version_number: 3,
+    effective_from: '2026-04-01',
+    recurrence: {
+      monday: {
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      },
+      thursday: {
+        start_time: '15:00',
+        end_time: '18:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-03-25T10:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Base operativa vigente',
+  };
+}
+
+function futureVersion(): ScheduleTemplateVersion {
+  return {
+    id: 'version-2',
+    template_id: 'template-1',
+    version_number: 4,
+    effective_from: '2026-05-15',
+    recurrence: {
+      monday: {
+        start_time: '10:00',
+        end_time: '13:00',
+        slot_duration_minutes: 30,
+      },
+      friday: {
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-04-20T09:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Cambio por consultorio nuevo',
+  };
+}
+
+function reloadedFutureVersion(): ScheduleTemplateVersion {
+  return {
+    id: 'version-3',
+    template_id: 'template-1',
+    version_number: 5,
+    effective_from: '2026-06-15',
+    recurrence: {
+      tuesday: {
+        start_time: '08:00',
+        end_time: '11:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-05-20T09:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Cambio re-cargado desde backend',
+  };
+}

--- a/web/src/features/schedule/WeeklySchedulePage.tsx
+++ b/web/src/features/schedule/WeeklySchedulePage.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ContentSplit, PageContainer } from '../../app-shell/AppShell.primitives';
+import { EffectiveFromPanel } from './EffectiveFromPanel';
+import { ProfessionalScheduleContext } from './ProfessionalScheduleContext';
+import { ScheduleConflictPanel } from './ScheduleConflictPanel';
+import { WeeklyScheduleActions } from './WeeklyScheduleActions';
+import { WeeklySchedulePreview } from './WeeklySchedulePreview';
+import { WeeklyTemplateEditor } from './WeeklyTemplateEditor';
+import type { WeeklySchedulePageProps } from './weeklyScheduleModels';
+import {
+  addWindowToDraftDay,
+  cloneDraftForNewVersion,
+  createWeeklyScheduleSaveRequest,
+  filterVisibleScheduleConflicts,
+  isWeeklyScheduleReadyToSave,
+  removeWindowFromDraftDay,
+  toggleDraftDay,
+  updateDraftWindow,
+  buildWeeklySchedulePreview,
+} from './weeklyScheduleState';
+
+export function WeeklySchedulePage({
+  actor,
+  professionalOptions = [],
+  initialSelectedProfessionalId,
+  currentVersion,
+  futureVersion,
+  knownConflicts = [],
+  isSaving = false,
+  onCancel,
+  onProfessionalChange,
+  onSave,
+}: WeeklySchedulePageProps) {
+  const resolvedProfessionalOptions =
+    actor.kind === 'doctor'
+      ? [{ id: actor.professionalId, label: actor.professionalName }]
+      : professionalOptions;
+  const fallbackProfessionalId =
+    actor.kind === 'doctor' ? actor.professionalId : initialSelectedProfessionalId ?? resolvedProfessionalOptions[0]?.id ?? '';
+  const seedVersion = futureVersion ?? currentVersion;
+
+  const [selectedProfessionalId, setSelectedProfessionalId] = useState(fallbackProfessionalId);
+  const [draft, setDraft] = useState(() => cloneDraftForNewVersion(seedVersion));
+
+  useEffect(() => {
+    setDraft(cloneDraftForNewVersion(seedVersion));
+  }, [seedVersion]);
+
+  useEffect(() => {
+    setSelectedProfessionalId(fallbackProfessionalId);
+  }, [fallbackProfessionalId]);
+
+  function handleProfessionalChange(professionalId: string) {
+    setSelectedProfessionalId(professionalId);
+    onProfessionalChange?.(professionalId);
+  }
+
+  const previewDays = useMemo(() => buildWeeklySchedulePreview(draft), [draft]);
+  const visibleConflicts = useMemo(
+    () => filterVisibleScheduleConflicts(knownConflicts, draft.effectiveFrom),
+    [draft.effectiveFrom, knownConflicts],
+  );
+  const canSave = isWeeklyScheduleReadyToSave(draft) && Boolean(selectedProfessionalId);
+
+  function handleSave() {
+    if (!onSave || !canSave) {
+      return;
+    }
+
+    onSave(
+      createWeeklyScheduleSaveRequest({
+        professionalId: selectedProfessionalId,
+        draft,
+        conflicts: knownConflicts,
+      }),
+    );
+  }
+
+  return (
+    <PageContainer className="stack">
+      <ProfessionalScheduleContext
+        actor={actor}
+        professionalOptions={resolvedProfessionalOptions}
+        selectedProfessionalId={selectedProfessionalId}
+        currentVersion={currentVersion}
+        futureVersion={futureVersion}
+        onProfessionalChange={handleProfessionalChange}
+      />
+
+      <ContentSplit style={{ gridTemplateColumns: 'minmax(0, 1.7fr) minmax(320px, 1fr)' }}>
+        <div className="stack">
+          <WeeklyTemplateEditor
+            draft={draft}
+            onToggleDay={(dayKey, nextValue) => setDraft((current) => toggleDraftDay(current, dayKey, nextValue))}
+            onAddWindow={(dayKey) => setDraft((current) => addWindowToDraftDay(current, dayKey))}
+            onRemoveWindow={(dayKey, windowId) => setDraft((current) => removeWindowFromDraftDay(current, dayKey, windowId))}
+            onWindowChange={(dayKey, windowId, field, value) =>
+              setDraft((current) => updateDraftWindow(current, dayKey, windowId, field, value))
+            }
+          />
+          <WeeklyScheduleActions canSave={canSave} isSaving={isSaving} onSave={handleSave} onCancel={onCancel} />
+        </div>
+
+        <div className="stack">
+          <EffectiveFromPanel
+            effectiveFrom={draft.effectiveFrom}
+            reason={draft.reason}
+            onEffectiveFromChange={(value) => setDraft((current) => ({ ...current, effectiveFrom: value }))}
+            onReasonChange={(value) => setDraft((current) => ({ ...current, reason: value }))}
+          />
+          <WeeklySchedulePreview previewDays={previewDays} />
+          <ScheduleConflictPanel conflicts={visibleConflicts} effectiveFrom={draft.effectiveFrom} />
+        </div>
+      </ContentSplit>
+    </PageContainer>
+  );
+}

--- a/web/src/features/schedule/WeeklySchedulePreview.tsx
+++ b/web/src/features/schedule/WeeklySchedulePreview.tsx
@@ -1,0 +1,46 @@
+import { EmptyState, SectionCard, SummaryTile } from '../../app-shell/AppShell.primitives';
+import type { WeeklySchedulePreviewProps } from './weeklyScheduleModels';
+
+export function WeeklySchedulePreview({ previewDays }: WeeklySchedulePreviewProps) {
+  const activeDays = previewDays.filter((day) => day.windowCount > 0);
+  const totalSlots = activeDays.reduce((total, day) => total + day.slotCount, 0);
+
+  return (
+    <SectionCard className="stack">
+      <div className="section-header">
+        <span className="hero-kicker">Weekly preview</span>
+        <h2>Preview semanal</h2>
+        <p>Mostrá la forma futura de la agenda antes de confirmar la nueva versión.</p>
+      </div>
+
+      <div className="foundation-content-split" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))' }}>
+        <SummaryTile className="stack-tight">
+          <span className="summary-label">Días activos</span>
+          <strong>{activeDays.length}</strong>
+        </SummaryTile>
+        <SummaryTile className="stack-tight">
+          <span className="summary-label">Ventanas válidas</span>
+          <strong>{activeDays.reduce((total, day) => total + day.windowCount, 0)}</strong>
+        </SummaryTile>
+        <SummaryTile className="stack-tight">
+          <span className="summary-label">Slots estimados</span>
+          <strong>{totalSlots}</strong>
+        </SummaryTile>
+      </div>
+
+      {activeDays.length === 0 ? (
+        <EmptyState title="Sin días activos todavía" description="Activá al menos un día y definí una ventana para obtener vista previa." />
+      ) : (
+        <div className="list">
+          {activeDays.map((day) => (
+            <article key={day.dayKey} className="appointment-item">
+              <strong>{day.label}</strong>
+              <span>{day.windows.join(' · ')}</span>
+              <small>{day.slotCount} slots estimados</small>
+            </article>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/web/src/features/schedule/WeeklyScheduleWorkspace.test.tsx
+++ b/web/src/features/schedule/WeeklyScheduleWorkspace.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../../api/http';
+import { WeeklyScheduleWorkspace } from './WeeklyScheduleWorkspace';
+
+const {
+  listProfessionalsMock,
+  getScheduleTemplateMock,
+  listScheduleTemplateVersionsMock,
+  createScheduleTemplateVersionMock,
+} = vi.hoisted(() => ({
+  listProfessionalsMock: vi.fn(),
+  getScheduleTemplateMock: vi.fn(),
+  listScheduleTemplateVersionsMock: vi.fn(),
+  createScheduleTemplateVersionMock: vi.fn(),
+}));
+
+vi.mock('../../api/directory', () => ({
+  listProfessionals: listProfessionalsMock,
+}));
+
+vi.mock('../../api/appointments', () => ({
+  getScheduleTemplate: getScheduleTemplateMock,
+  listScheduleTemplateVersions: listScheduleTemplateVersionsMock,
+  createScheduleTemplateVersion: createScheduleTemplateVersionMock,
+}));
+
+describe('WeeklyScheduleWorkspace', () => {
+  beforeEach(() => {
+    listProfessionalsMock.mockReset();
+    getScheduleTemplateMock.mockReset();
+    listScheduleTemplateVersionsMock.mockReset();
+    createScheduleTemplateVersionMock.mockReset();
+  });
+
+  it('shows a dedicated weekly schedule surface for secretaries with professional selection', async () => {
+    listProfessionalsMock.mockResolvedValue({
+      items: [
+        activeProfessional(),
+        secondProfessional(),
+      ],
+    });
+    getScheduleTemplateMock.mockResolvedValue({ id: 'template-1', professional_id: 'professional-1', created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-01T00:00:00Z', versions: [] });
+    listScheduleTemplateVersionsMock.mockResolvedValue({ items: [] });
+
+    render(<WeeklyScheduleWorkspace agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(listProfessionalsMock).toHaveBeenCalledTimes(1);
+      expect(getScheduleTemplateMock).toHaveBeenCalledWith({
+        professional_id: 'professional-1',
+        effective_date: '2099-12-31',
+      });
+    });
+
+    expect(screen.getByText(/guardá una nueva versión que impacte desde la fecha elegida/i)).toBeInTheDocument();
+  });
+
+  it('keeps doctors scoped to their own weekly surface without cross-professional selection', async () => {
+    listProfessionalsMock.mockResolvedValue({
+      items: [
+        activeProfessional(),
+        secondProfessional(),
+      ],
+    });
+    getScheduleTemplateMock.mockResolvedValue({ id: 'template-1', professional_id: 'professional-1', created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-01T00:00:00Z', versions: [] });
+    listScheduleTemplateVersionsMock.mockResolvedValue({ items: [] });
+
+    render(
+      <WeeklyScheduleWorkspace
+        agendaMode={{ kind: 'doctor-own', professionalId: 'professional-1' }}
+        onSessionInvalid={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText('Ana Médica')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Profesional' })).not.toBeInTheDocument();
+    expect(screen.getByText(/solo podés preparar versiones sobre tu agenda profesional/i)).toBeInTheDocument();
+  });
+
+  it('invalidates the session on 401 failures while bootstrapping the weekly surface', async () => {
+    listProfessionalsMock.mockRejectedValue(new ApiError('Sesión vencida', 401));
+    const onSessionInvalid = vi.fn();
+
+    render(<WeeklyScheduleWorkspace agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={onSessionInvalid} />);
+
+    await waitFor(() => {
+      expect(onSessionInvalid).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByText(/Acceso denegado:/i)).not.toBeInTheDocument();
+  });
+
+  it('loads current and future versions from backend contracts and refreshes them after save', async () => {
+    listProfessionalsMock.mockResolvedValue({
+      items: [activeProfessional()],
+    });
+    getScheduleTemplateMock.mockResolvedValue({
+      id: 'template-1',
+      professional_id: 'professional-1',
+      created_at: '2026-04-01T00:00:00Z',
+      updated_at: '2026-04-01T00:00:00Z',
+      versions: [],
+    });
+    listScheduleTemplateVersionsMock
+      .mockResolvedValueOnce({
+        items: [futureVersion(), activeVersion()],
+      })
+      .mockResolvedValueOnce({
+        items: [savedFutureVersion(), futureVersion(), activeVersion()],
+      });
+    createScheduleTemplateVersionMock.mockResolvedValue({
+      id: 'template-1',
+      professional_id: 'professional-1',
+      created_at: '2026-04-01T00:00:00Z',
+      updated_at: '2026-05-21T00:00:00Z',
+      versions: [savedFutureVersion()],
+    });
+
+    render(<WeeklyScheduleWorkspace agendaMode={{ kind: 'operational-shared' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByText('Versión 3')).toBeInTheDocument();
+    expect(screen.getByText('Versión 4')).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', { name: /guardar versión semanal/i });
+    fireEvent.change(screen.getByLabelText('Vigencia desde'), { target: { value: '2026-06-01' } });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(createScheduleTemplateVersionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          professional_id: 'professional-1',
+          effective_from: '2026-06-01',
+        }),
+      );
+    });
+
+    expect(await screen.findByText('Versión 5')).toBeInTheDocument();
+    expect(screen.getByText(/versión semanal guardada y recargada desde backend/i)).toBeInTheDocument();
+  });
+});
+
+function activeProfessional() {
+  return {
+    id: 'professional-1',
+    first_name: 'Ana',
+    last_name: 'Médica',
+    specialty: 'Clínica médica',
+    active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function secondProfessional() {
+  return {
+    id: 'professional-2',
+    first_name: 'Tomás',
+    last_name: 'Suárez',
+    specialty: 'Cardiología',
+    active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function activeVersion() {
+  return {
+    id: 'version-1',
+    template_id: 'template-1',
+    version_number: 3,
+    effective_from: '2026-04-01T00:00:00Z',
+    recurrence: {
+      monday: {
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-03-25T10:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Base operativa vigente',
+  };
+}
+
+function futureVersion() {
+  return {
+    id: 'version-2',
+    template_id: 'template-1',
+    version_number: 4,
+    effective_from: '2026-05-15T00:00:00Z',
+    recurrence: {
+      friday: {
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-04-20T09:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Cambio por consultorio nuevo',
+  };
+}
+
+function savedFutureVersion() {
+  return {
+    id: 'version-3',
+    template_id: 'template-1',
+    version_number: 5,
+    effective_from: '2026-06-01T00:00:00Z',
+    recurrence: {
+      friday: {
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-05-20T09:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Versión recargada desde backend',
+  };
+}

--- a/web/src/features/schedule/WeeklyScheduleWorkspace.tsx
+++ b/web/src/features/schedule/WeeklyScheduleWorkspace.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ApiError } from '../../api/http';
+import {
+  createScheduleTemplateVersion,
+  getScheduleTemplate,
+  listScheduleTemplateVersions,
+} from '../../api/appointments';
+import { listProfessionals } from '../../api/directory';
+import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
+import type { AgendaMode } from '../../auth/actorCapabilities';
+import { Badge, EmptyState, PageContainer } from '../../app-shell/AppShell.primitives';
+import type { Professional } from '../../types/directory';
+import type { ScheduleTemplateVersion } from '../../types/appointments';
+import { WeeklySchedulePage } from './WeeklySchedulePage';
+import { buildWeeklyScheduleFlowContext } from './weeklyScheduleFlowAdapter';
+
+const SCHEDULE_LOOKUP_DATE = '2099-12-31';
+
+type WeeklyScheduleWorkspaceProps = {
+  agendaMode: AgendaMode;
+  onSessionInvalid: () => void;
+};
+
+export function WeeklyScheduleWorkspace({ agendaMode, onSessionInvalid }: WeeklyScheduleWorkspaceProps) {
+  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const [selectedProfessionalId, setSelectedProfessionalId] = useState('');
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+  const [isScheduleLoading, setIsScheduleLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [accessDeniedMessage, setAccessDeniedMessage] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [currentVersion, setCurrentVersion] = useState<ScheduleTemplateVersion | null>(null);
+  const [futureVersion, setFutureVersion] = useState<ScheduleTemplateVersion | null>(null);
+
+  useEffect(() => {
+    async function bootstrap() {
+      if (agendaMode.kind === 'forbidden') {
+        setProfessionals([]);
+        setSelectedProfessionalId('');
+        setAccessDeniedMessage(agendaMode.message);
+        setIsBootstrapping(false);
+        return;
+      }
+
+      try {
+        setIsBootstrapping(true);
+        setErrorMessage('');
+        setAccessDeniedMessage('');
+
+        const response = await listProfessionals();
+        const nextProfessionals = response.items.filter((professional) => professional.active);
+
+        setProfessionals(nextProfessionals);
+        setSelectedProfessionalId((current) => {
+          if (agendaMode.kind === 'doctor-own') {
+            return agendaMode.professionalId;
+          }
+
+          return nextProfessionals.some((professional) => professional.id === current) ? current : nextProfessionals[0]?.id ?? '';
+        });
+      } catch (error) {
+        const resolution = resolveAuthenticatedViewError(error, onSessionInvalid, 'No se pudo cargar la base profesional.', 'No podés editar esta agenda semanal.');
+
+        if (resolution.kind === 'session-invalid') {
+          return;
+        }
+
+        if (resolution.kind === 'forbidden') {
+          setAccessDeniedMessage(resolution.message);
+          return;
+        }
+
+        setErrorMessage(resolution.message);
+      } finally {
+        setIsBootstrapping(false);
+      }
+    }
+
+    void bootstrap();
+  }, [agendaMode, onSessionInvalid]);
+
+  const flowContext = useMemo(
+    () =>
+      buildWeeklyScheduleFlowContext({
+        agendaMode,
+        professionals,
+        selectedProfessionalId,
+      }),
+    [agendaMode, professionals, selectedProfessionalId],
+  );
+
+  useEffect(() => {
+    async function loadScheduleSnapshot() {
+      if (agendaMode.kind === 'forbidden' || !selectedProfessionalId) {
+        setCurrentVersion(null);
+        setFutureVersion(null);
+        return;
+      }
+
+      try {
+        setIsScheduleLoading(true);
+        setErrorMessage('');
+        setAccessDeniedMessage('');
+
+        const template = await getScheduleTemplate({
+          professional_id: selectedProfessionalId,
+          effective_date: SCHEDULE_LOOKUP_DATE,
+        });
+        const versionsResponse = await listScheduleTemplateVersions({ template_id: template.id });
+        const timeline = resolveScheduleTimeline(versionsResponse.items, getTodayDate());
+
+        setCurrentVersion(timeline.currentVersion);
+        setFutureVersion(timeline.futureVersion);
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          setCurrentVersion(null);
+          setFutureVersion(null);
+          return;
+        }
+
+        const resolution = resolveAuthenticatedViewError(error, onSessionInvalid, 'No se pudo cargar la agenda semanal guardada.', 'No podés editar esta agenda semanal.');
+
+        if (resolution.kind === 'session-invalid') {
+          return;
+        }
+
+        if (resolution.kind === 'forbidden') {
+          setAccessDeniedMessage(resolution.message);
+          return;
+        }
+
+        setErrorMessage(resolution.message);
+      } finally {
+        setIsScheduleLoading(false);
+      }
+    }
+
+    void loadScheduleSnapshot();
+  }, [agendaMode, onSessionInvalid, selectedProfessionalId]);
+
+  if (agendaMode.kind === 'forbidden') {
+    return (
+      <PageContainer className="stack">
+        <EmptyState eyebrow="Agenda semanal bloqueada" title="Acceso denegado" description={agendaMode.message} />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer className="stack">
+      {(successMessage || errorMessage || accessDeniedMessage) && (
+        <div className="status-bar" aria-live="polite">
+          {successMessage ? <span className="badge success">{successMessage}</span> : null}
+          {errorMessage ? <span className="badge error">{errorMessage}</span> : null}
+          {accessDeniedMessage ? <span className="badge error">Acceso denegado: {accessDeniedMessage}</span> : null}
+        </div>
+      )}
+
+      <div className="inline-note">
+        <strong>Superficie dedicada de agenda semanal</strong>
+        <span>Guardá una nueva versión que impacte desde la fecha elegida sin mezclar template con turnos diarios.</span>
+      </div>
+
+      {isBootstrapping ? (
+        <EmptyState eyebrow="Agenda semanal" title="Cargando contexto profesional" description="Estamos preparando la plantilla semanal antes de editarla." />
+      ) : isScheduleLoading ? (
+        <EmptyState eyebrow="Agenda semanal" title="Cargando versiones guardadas" description="Estamos trayendo la versión activa y la próxima versión desde backend." />
+      ) : (
+        <>
+          {agendaMode.kind === 'operational-shared' && professionals.length === 0 ? (
+            <div className="inline-note inline-note-error">
+              <strong>No hay profesionales activos para editar.</strong>
+              <span>Necesitás al menos un profesional disponible para preparar la agenda semanal.</span>
+            </div>
+          ) : null}
+
+          <Badge tone="info">Persistencia real conectada · preview/conflictos siguen acotados</Badge>
+
+          <WeeklySchedulePage
+            actor={flowContext.actor}
+            professionalOptions={flowContext.professionalOptions}
+            initialSelectedProfessionalId={flowContext.initialSelectedProfessionalId}
+            currentVersion={currentVersion}
+            futureVersion={futureVersion}
+            isSaving={isSaving}
+            onProfessionalChange={(professionalId) => {
+              setSelectedProfessionalId(professionalId);
+              setSuccessMessage('');
+            }}
+            onSave={async (request) => {
+              try {
+                setIsSaving(true);
+                setErrorMessage('');
+                setAccessDeniedMessage('');
+                setSuccessMessage('');
+
+                await createScheduleTemplateVersion({
+                  professional_id: request.professionalId,
+                  effective_from: request.effectiveFrom,
+                  recurrence: request.recurrence,
+                  reason: request.reason || undefined,
+                });
+
+                const template = await getScheduleTemplate({
+                  professional_id: request.professionalId,
+                  effective_date: SCHEDULE_LOOKUP_DATE,
+                });
+                const versionsResponse = await listScheduleTemplateVersions({ template_id: template.id });
+                const timeline = resolveScheduleTimeline(versionsResponse.items, getTodayDate());
+
+                setCurrentVersion(timeline.currentVersion);
+                setFutureVersion(timeline.futureVersion);
+                setSuccessMessage('Versión semanal guardada y recargada desde backend.');
+              } catch (error) {
+                const resolution = resolveAuthenticatedViewError(error, onSessionInvalid, 'No se pudo guardar la agenda semanal.', 'No podés guardar esta agenda semanal.');
+
+                if (resolution.kind === 'session-invalid') {
+                  return;
+                }
+
+                if (resolution.kind === 'forbidden') {
+                  setAccessDeniedMessage(resolution.message);
+                  return;
+                }
+
+                setErrorMessage(resolution.message);
+              } finally {
+                setIsSaving(false);
+              }
+            }}
+          />
+        </>
+      )}
+    </PageContainer>
+  );
+}
+
+function resolveScheduleTimeline(versions: ScheduleTemplateVersion[], today: string) {
+  const currentVersion = versions.find((version) => version.effective_from <= today) ?? null;
+  const futureVersion = versions.find((version) => version.effective_from > today) ?? null;
+
+  return {
+    currentVersion,
+    futureVersion,
+  };
+}
+
+function getTodayDate() {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/web/src/features/schedule/WeeklyTemplateEditor.tsx
+++ b/web/src/features/schedule/WeeklyTemplateEditor.tsx
@@ -1,0 +1,93 @@
+import { SectionCard } from '../../app-shell/AppShell.primitives';
+import type { DayTemplateCardProps, ScheduleWindowRowProps, WeeklyTemplateEditorProps } from './weeklyScheduleModels';
+
+const SLOT_DURATION_OPTIONS = [15, 20, 30, 60] as const;
+
+export function WeeklyTemplateEditor({ draft, onToggleDay, onAddWindow, onRemoveWindow, onWindowChange }: WeeklyTemplateEditorProps) {
+  return (
+    <SectionCard className="stack">
+      <div className="section-header">
+        <span className="hero-kicker">Weekly template editor</span>
+        <h2>Editor semanal</h2>
+        <p>Trabajá día por día. Este bloque define template semanal, no reservas ni cancelaciones puntuales.</p>
+        <p>Primer contrato real: una ventana por día. Cuando backend soporte más, recién ahí abrimos multi-ventana.</p>
+      </div>
+
+      <div className="list">
+        {Object.values(draft.days).map((day) => (
+          <DayTemplateCard
+            key={day.dayKey}
+            day={day}
+            onToggleDay={(nextValue) => onToggleDay(day.dayKey, nextValue)}
+            onAddWindow={() => onAddWindow(day.dayKey)}
+            onRemoveWindow={(windowId) => onRemoveWindow(day.dayKey, windowId)}
+            onWindowChange={(windowId, field, value) => onWindowChange(day.dayKey, windowId, field, value)}
+          />
+        ))}
+      </div>
+    </SectionCard>
+  );
+}
+
+export function DayTemplateCard({ day, onToggleDay, onAddWindow, onRemoveWindow, onWindowChange }: DayTemplateCardProps) {
+  return (
+    <article className="card stack-tight">
+      <div className="status-bar">
+        <div className="field" style={{ margin: 0 }}>
+          <label>
+            <input type="checkbox" checked={day.isEnabled} onChange={(event) => onToggleDay(event.target.checked)} /> Habilitar {day.label}
+          </label>
+        </div>
+        <span className="helper">{day.isEnabled ? 'Ventanas activas en template semanal.' : 'Día sin atención configurada.'}</span>
+      </div>
+
+      {day.isEnabled ? (
+        <>
+          <div className="list">
+            {day.windows.map((window) => (
+              <ScheduleWindowRow
+                key={window.id}
+                dayLabel={day.label}
+                window={window}
+                canRemove={day.windows.length > 1}
+                onRemove={() => onRemoveWindow(window.id)}
+                onChange={(field, value) => onWindowChange(window.id, field, value)}
+              />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </article>
+  );
+}
+
+export function ScheduleWindowRow({ dayLabel, window, canRemove, onRemove, onChange }: ScheduleWindowRowProps) {
+  return (
+    <div className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))' }}>
+      <div className="field">
+        <label htmlFor={`${window.id}-start`}>{dayLabel} · Desde</label>
+        <input id={`${window.id}-start`} type="time" value={window.startTime} onChange={(event) => onChange('startTime', event.target.value)} />
+      </div>
+      <div className="field">
+        <label htmlFor={`${window.id}-end`}>{dayLabel} · Hasta</label>
+        <input id={`${window.id}-end`} type="time" value={window.endTime} onChange={(event) => onChange('endTime', event.target.value)} />
+      </div>
+      <div className="field">
+        <label htmlFor={`${window.id}-duration`}>{dayLabel} · Slot</label>
+        <select id={`${window.id}-duration`} value={window.slotDurationMinutes} onChange={(event) => onChange('slotDurationMinutes', event.target.value)}>
+          {SLOT_DURATION_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option} minutos
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="field">
+        <label>&nbsp;</label>
+        <button type="button" className="button ghost" onClick={onRemove} disabled={!canRemove}>
+          Quitar ventana
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/schedule/agendaAdapter.test.ts
+++ b/web/src/features/schedule/agendaAdapter.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { Consultation, Slot, WeekAgenda } from '../../types/appointments';
+import { buildScheduleBoardModel } from './agendaAdapter';
+
+describe('agendaAdapter', () => {
+	it('builds a board model from slots and consultations', () => {
+		const weekAgenda: WeekAgenda = {
+			professional_id: 'professional-1',
+			week_start: '2026-04-06',
+			templates: [],
+			blocks: [],
+			consultations: [
+				consultation({
+					id: 'consultation-1',
+					slot_id: 'slot-1',
+					status: 'scheduled',
+					scheduled_start: '2026-04-08T10:00:00Z',
+					scheduled_end: '2026-04-08T10:30:00Z',
+				}),
+			],
+			slots: [slot({ id: 'slot-1', start_time: '2026-04-08T10:00:00Z', end_time: '2026-04-08T10:30:00Z', status: 'booked' })],
+		};
+
+		const board = buildScheduleBoardModel(weekAgenda);
+
+		expect(board.weekStart).toBe('2026-04-06');
+		expect(board.timeBands).toEqual(['10:00']);
+		expect(board.days).toHaveLength(5);
+		expect(board.days[2]).toMatchObject({
+			date: '2026-04-08',
+			summary: { available: 0, booked: 1, cancelled: 0, checkedIn: 0, completed: 0, noShow: 0 },
+		});
+		expect(board.days[2]?.appointments[0]).toMatchObject({
+			id: 'consultation-1',
+			slot_id: 'slot-1',
+			status: 'booked',
+			raw_status: 'scheduled',
+			status_label: 'Reservado',
+			is_standalone: false,
+			can_cancel: true,
+		});
+	});
+
+	it('creates synthetic booked slots for standalone consultations and exposes their time bands', () => {
+		const weekAgenda: WeekAgenda = {
+			professional_id: 'professional-1',
+			week_start: '2026-04-06',
+			templates: [],
+			blocks: [],
+			consultations: [
+				consultation({
+					id: 'consultation-standalone',
+					slot_id: null,
+					status: 'checked_in',
+					scheduled_start: '2026-04-07T09:15:00Z',
+					scheduled_end: '2026-04-07T09:35:00Z',
+				}),
+			],
+			slots: [],
+		};
+
+		const board = buildScheduleBoardModel(weekAgenda);
+
+		expect(board.timeBands).toEqual(['09:15']);
+		expect(board.days[1]?.slots[0]).toMatchObject({
+			id: 'consultation-consultation-standalone',
+			status: 'booked',
+			start_time: '2026-04-07T09:15:00Z',
+			end_time: '2026-04-07T09:35:00Z',
+		});
+		expect(board.days[1]?.appointments[0]).toMatchObject({
+			id: 'consultation-standalone',
+			is_standalone: true,
+			can_cancel: false,
+			raw_status: 'checked_in',
+			status_label: 'En recepción',
+		});
+		expect(board.days[1]?.summary.checkedIn).toBe(1);
+	});
+
+	it('keeps cancelled consultations visible in the summary', () => {
+		const weekAgenda: WeekAgenda = {
+			professional_id: 'professional-1',
+			week_start: '2026-04-06',
+			templates: [],
+			blocks: [],
+			consultations: [
+				consultation({
+					id: 'consultation-2',
+					slot_id: 'slot-2',
+					status: 'cancelled',
+					scheduled_start: '2026-04-10T11:00:00Z',
+					scheduled_end: '2026-04-10T11:30:00Z',
+				}),
+			],
+			slots: [slot({ id: 'slot-2', start_time: '2026-04-10T11:00:00Z', end_time: '2026-04-10T11:30:00Z', status: 'available' })],
+		};
+
+		const board = buildScheduleBoardModel(weekAgenda);
+
+		expect(board.timeBands).toEqual(['11:00']);
+		expect(board.days[4]?.summary).toMatchObject({ cancelled: 1, available: 1 });
+		expect(board.days[4]?.appointments[0]).toMatchObject({
+			status: 'cancelled',
+			raw_status: 'cancelled',
+			status_label: 'Cancelado',
+			can_cancel: false,
+		});
+	});
+});
+
+function slot(overrides: Partial<Slot>): Slot {
+	return {
+		id: 'slot-default',
+		professional_id: 'professional-1',
+		start_time: '2026-04-08T10:00:00Z',
+		end_time: '2026-04-08T10:30:00Z',
+		status: 'available',
+		created_at: '2026-04-01T08:00:00Z',
+		updated_at: '2026-04-01T08:00:00Z',
+		...overrides,
+	};
+}
+
+function consultation(overrides: Partial<Consultation>): Consultation {
+	return {
+		id: 'consultation-default',
+		slot_id: 'slot-default',
+		professional_id: 'professional-1',
+		patient_id: 'patient-1',
+		status: 'scheduled',
+		source: 'secretary',
+		scheduled_start: '2026-04-08T10:00:00Z',
+		scheduled_end: '2026-04-08T10:30:00Z',
+		created_at: '2026-04-01T08:00:00Z',
+		updated_at: '2026-04-01T08:00:00Z',
+		...overrides,
+	};
+}

--- a/web/src/features/schedule/agendaAdapter.ts
+++ b/web/src/features/schedule/agendaAdapter.ts
@@ -1,0 +1,177 @@
+import type { Appointment, Consultation, Slot, WeekAgenda } from '../../types/appointments';
+import { formatWeekdayLabel, formatTimeBand, getOperationalWeekDays } from './helpers';
+
+export type ScheduleBoardAppointment = Appointment & {
+	raw_status: Consultation['status'];
+	status_label: string;
+	is_standalone: boolean;
+	can_cancel: boolean;
+	source: Consultation['source'];
+	scheduled_start: string;
+	scheduled_end: string;
+};
+
+export type ScheduleBoardDay = {
+	date: string;
+	weekdayLabel: string;
+	slots: Slot[];
+	appointments: ScheduleBoardAppointment[];
+	summary: {
+		available: number;
+		booked: number;
+		cancelled: number;
+		checkedIn: number;
+		completed: number;
+		noShow: number;
+	};
+};
+
+export type ScheduleBoardModel = {
+	weekStart: string;
+	days: ScheduleBoardDay[];
+	timeBands: string[];
+};
+
+export function buildScheduleBoardModel(weekAgenda: WeekAgenda): ScheduleBoardModel {
+	const weekDays = getOperationalWeekDays(weekAgenda.week_start);
+	const slotsByDate = groupSlotsByDate(weekAgenda.slots);
+	const appointmentsByDate = groupAppointmentsByDate(weekAgenda.consultations);
+	const timeBands = buildTimeBands(weekAgenda);
+
+	const days = weekDays.map((day) => {
+		const dayAppointments = [...(appointmentsByDate.get(day.date) ?? [])].sort(compareAppointmentsByStart);
+		const standaloneSlots = dayAppointments
+			.filter((appointment) => appointment.is_standalone)
+			.map(createStandaloneSlot)
+			.filter((slot): slot is Slot => slot !== null);
+		const daySlots = [...(slotsByDate.get(day.date) ?? []), ...standaloneSlots].sort(compareSlotsByStartTime);
+
+		return {
+			date: day.date,
+			weekdayLabel: day.weekdayLabel,
+			slots: daySlots,
+			appointments: dayAppointments,
+			summary: buildDaySummary(daySlots, dayAppointments),
+		};
+	});
+
+	return {
+		weekStart: weekDays[0]?.date ?? weekAgenda.week_start,
+		days,
+		timeBands,
+	};
+}
+
+function groupSlotsByDate(slots: Slot[]) {
+	const byDate = new Map<string, Slot[]>();
+
+	for (const slot of slots) {
+		const date = slot.start_time.slice(0, 10);
+		const current = byDate.get(date) ?? [];
+		current.push(slot);
+		byDate.set(date, current);
+	}
+
+	return byDate;
+}
+
+function groupAppointmentsByDate(consultations: Consultation[]) {
+	const byDate = new Map<string, ScheduleBoardAppointment[]>();
+
+	for (const consultation of consultations) {
+		const date = consultation.scheduled_start.slice(0, 10);
+		const current = byDate.get(date) ?? [];
+		current.push(adaptConsultationToAppointment(consultation));
+		byDate.set(date, current);
+	}
+
+	return byDate;
+}
+
+function adaptConsultationToAppointment(consultation: Consultation): ScheduleBoardAppointment {
+	const isStandalone = !consultation.slot_id;
+	const legacyStatus = consultation.status === 'cancelled' ? 'cancelled' : 'booked';
+
+	return {
+		id: consultation.id,
+		slot_id: consultation.slot_id ?? standaloneSlotID(consultation.id),
+		professional_id: consultation.professional_id,
+		patient_id: consultation.patient_id,
+		status: legacyStatus,
+		created_at: consultation.created_at,
+		updated_at: consultation.updated_at,
+		cancelled_at: consultation.cancelled_at ?? null,
+		raw_status: consultation.status,
+		status_label: consultationStatusLabel(consultation.status),
+		is_standalone: isStandalone,
+		can_cancel: !isStandalone && consultation.status !== 'cancelled' && consultation.status !== 'completed' && consultation.status !== 'no_show',
+		source: consultation.source,
+		scheduled_start: consultation.scheduled_start,
+		scheduled_end: consultation.scheduled_end,
+	};
+}
+
+function createStandaloneSlot(appointment: ScheduleBoardAppointment): Slot | null {
+	if (!appointment.is_standalone) {
+		return null;
+	}
+
+	return {
+		id: appointment.slot_id,
+		professional_id: appointment.professional_id,
+		start_time: appointment.scheduled_start,
+		end_time: appointment.scheduled_end,
+		status: 'booked',
+		created_at: appointment.created_at,
+		updated_at: appointment.updated_at,
+	};
+}
+
+function buildTimeBands(weekAgenda: WeekAgenda) {
+	const slotBands = weekAgenda.slots.map((slot) => formatTimeBand(slot.start_time));
+	const consultationBands = weekAgenda.consultations.map((consultation) => formatTimeBand(consultation.scheduled_start));
+
+	return [...new Set([...slotBands, ...consultationBands])].sort();
+}
+
+function buildDaySummary(slots: Slot[], appointments: ScheduleBoardAppointment[]) {
+	return {
+		available: slots.filter((slot) => slot.status === 'available').length,
+		booked: appointments.filter((appointment) => appointment.raw_status === 'scheduled').length,
+		cancelled: appointments.filter((appointment) => appointment.raw_status === 'cancelled').length,
+		checkedIn: appointments.filter((appointment) => appointment.raw_status === 'checked_in').length,
+		completed: appointments.filter((appointment) => appointment.raw_status === 'completed').length,
+		noShow: appointments.filter((appointment) => appointment.raw_status === 'no_show').length,
+	};
+}
+
+function consultationStatusLabel(status: Consultation['status']) {
+	switch (status) {
+		case 'scheduled':
+			return 'Reservado';
+		case 'checked_in':
+			return 'En recepción';
+		case 'completed':
+			return 'Atendido';
+		case 'cancelled':
+			return 'Cancelado';
+		case 'no_show':
+			return 'Ausente';
+	}
+}
+
+function standaloneSlotID(consultationID: string) {
+	return `consultation-${consultationID}`;
+}
+
+function compareSlotsByStartTime(left: Slot, right: Slot) {
+	return new Date(left.start_time).getTime() - new Date(right.start_time).getTime();
+}
+
+function compareAppointmentsByStart(left: ScheduleBoardAppointment, right: ScheduleBoardAppointment) {
+	return new Date(left.scheduled_start).getTime() - new Date(right.scheduled_start).getTime();
+}
+
+export function buildBoardCellLabel(date: string, startTime: string, endTime: string) {
+	return `${formatWeekdayLabel(date)} · ${startTime} - ${endTime} UTC`;
+}

--- a/web/src/features/schedule/weeklyScheduleFlowAdapter.ts
+++ b/web/src/features/schedule/weeklyScheduleFlowAdapter.ts
@@ -1,0 +1,56 @@
+import type { AgendaMode } from '../../auth/actorCapabilities';
+import type { Professional } from '../../types/directory';
+import type { ProfessionalScheduleOption, WeeklyScheduleActorContext } from './weeklyScheduleModels';
+
+type BuildWeeklyScheduleFlowContextInput = {
+  agendaMode: AgendaMode;
+  professionals: Professional[];
+  selectedProfessionalId: string;
+};
+
+type WeeklyScheduleFlowContext = {
+  actor: WeeklyScheduleActorContext;
+  professionalOptions: ProfessionalScheduleOption[];
+  initialSelectedProfessionalId?: string;
+};
+
+export function buildWeeklyScheduleFlowContext({
+  agendaMode,
+  professionals,
+  selectedProfessionalId,
+}: BuildWeeklyScheduleFlowContextInput): WeeklyScheduleFlowContext {
+  const professionalOptions = professionals.map((professional) => ({
+    id: professional.id,
+    label: formatProfessionalName(professional),
+    subtitle: professional.specialty,
+  }));
+
+  if (agendaMode.kind === 'doctor-own') {
+    const selectedProfessional = professionals.find((professional) => professional.id === agendaMode.professionalId);
+
+    return {
+      actor: {
+        kind: 'doctor',
+        actorLabel: selectedProfessional ? formatProfessionalName(selectedProfessional) : 'Agenda propia',
+        professionalId: agendaMode.professionalId,
+        professionalName: selectedProfessional ? formatProfessionalName(selectedProfessional) : 'Mi agenda profesional',
+      },
+      professionalOptions,
+      initialSelectedProfessionalId: agendaMode.professionalId,
+    };
+  }
+
+  return {
+    actor: {
+      kind: 'secretary',
+      actorLabel: 'Secretaría central',
+      workspaceLabel: 'Agenda operativa multi-profesional',
+    },
+    professionalOptions,
+    initialSelectedProfessionalId: selectedProfessionalId || professionalOptions[0]?.id,
+  };
+}
+
+function formatProfessionalName(professional: Professional) {
+  return `${professional.first_name} ${professional.last_name}`;
+}

--- a/web/src/features/schedule/weeklyScheduleModels.ts
+++ b/web/src/features/schedule/weeklyScheduleModels.ts
@@ -1,0 +1,169 @@
+import type { ScheduleRecurrence, ScheduleTemplateVersion, ScheduleTemplateWindow } from '../../types/appointments';
+
+export const WEEKLY_SCHEDULE_DAY_ORDER = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const;
+
+export type WeeklyScheduleDayKey = (typeof WEEKLY_SCHEDULE_DAY_ORDER)[number];
+
+export type WeeklyScheduleWindowDraft = {
+  id: string;
+  startTime: string;
+  endTime: string;
+  slotDurationMinutes: ScheduleTemplateWindow['slot_duration_minutes'];
+};
+
+export type WeeklyScheduleDayDraft = {
+  dayKey: WeeklyScheduleDayKey;
+  label: string;
+  shortLabel: string;
+  isEnabled: boolean;
+  windows: WeeklyScheduleWindowDraft[];
+};
+
+export type WeeklyScheduleDraft = {
+  effectiveFrom: string;
+  reason: string;
+  days: Record<WeeklyScheduleDayKey, WeeklyScheduleDayDraft>;
+};
+
+export type WeeklySchedulePreviewDay = {
+  dayKey: WeeklyScheduleDayKey;
+  label: string;
+  shortLabel: string;
+  isEnabled: boolean;
+  windowCount: number;
+  slotCount: number;
+  windows: string[];
+};
+
+export type WeeklyScheduleConflict = {
+  id: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  patientLabel?: string;
+  summary: string;
+  severity: 'warning' | 'critical';
+};
+
+export type ProfessionalScheduleOption = {
+  id: string;
+  label: string;
+  subtitle?: string;
+};
+
+export type WeeklyScheduleActorContext =
+  | {
+      kind: 'secretary';
+      actorLabel: string;
+      workspaceLabel?: string;
+    }
+  | {
+      kind: 'doctor';
+      actorLabel: string;
+      professionalId: string;
+      professionalName: string;
+    };
+
+export type WeeklyScheduleSaveRequest = {
+  professionalId: string;
+  effectiveFrom: string;
+  reason: string;
+  recurrence: ScheduleRecurrence;
+  previewDays: WeeklySchedulePreviewDay[];
+  visibleConflicts: WeeklyScheduleConflict[];
+};
+
+export type WeeklySchedulePageProps = {
+  actor: WeeklyScheduleActorContext;
+  professionalOptions?: ProfessionalScheduleOption[];
+  initialSelectedProfessionalId?: string;
+  currentVersion?: ScheduleTemplateVersion | null;
+  futureVersion?: ScheduleTemplateVersion | null;
+  knownConflicts?: WeeklyScheduleConflict[];
+  isSaving?: boolean;
+  onCancel?: () => void;
+  onProfessionalChange?: (professionalId: string) => void;
+  onSave?: (request: WeeklyScheduleSaveRequest) => void;
+};
+
+export type VersionSummaryCard = {
+  title: string;
+  eyebrow: string;
+  versionLabel: string;
+  effectiveFromLabel: string;
+  scheduleLabel: string;
+  reasonLabel: string;
+};
+
+export type ProfessionalScheduleContextProps = {
+  actor: WeeklyScheduleActorContext;
+  professionalOptions: ProfessionalScheduleOption[];
+  selectedProfessionalId: string;
+  currentVersion?: ScheduleTemplateVersion | null;
+  futureVersion?: ScheduleTemplateVersion | null;
+  onProfessionalChange: (professionalId: string) => void;
+};
+
+export type WeeklyTemplateEditorProps = {
+  draft: WeeklyScheduleDraft;
+  onToggleDay: (dayKey: WeeklyScheduleDayKey, nextValue: boolean) => void;
+  onAddWindow: (dayKey: WeeklyScheduleDayKey) => void;
+  onRemoveWindow: (dayKey: WeeklyScheduleDayKey, windowId: string) => void;
+  onWindowChange: (
+    dayKey: WeeklyScheduleDayKey,
+    windowId: string,
+    field: keyof Pick<WeeklyScheduleWindowDraft, 'startTime' | 'endTime' | 'slotDurationMinutes'>,
+    value: string,
+  ) => void;
+};
+
+export type DayTemplateCardProps = {
+  day: WeeklyScheduleDayDraft;
+  onToggleDay: (nextValue: boolean) => void;
+  onAddWindow: () => void;
+  onRemoveWindow: (windowId: string) => void;
+  onWindowChange: (
+    windowId: string,
+    field: keyof Pick<WeeklyScheduleWindowDraft, 'startTime' | 'endTime' | 'slotDurationMinutes'>,
+    value: string,
+  ) => void;
+};
+
+export type ScheduleWindowRowProps = {
+  dayLabel: string;
+  window: WeeklyScheduleWindowDraft;
+  canRemove: boolean;
+  onRemove: () => void;
+  onChange: (field: keyof Pick<WeeklyScheduleWindowDraft, 'startTime' | 'endTime' | 'slotDurationMinutes'>, value: string) => void;
+};
+
+export type EffectiveFromPanelProps = {
+  effectiveFrom: string;
+  reason: string;
+  onEffectiveFromChange: (value: string) => void;
+  onReasonChange: (value: string) => void;
+};
+
+export type WeeklySchedulePreviewProps = {
+  previewDays: WeeklySchedulePreviewDay[];
+};
+
+export type ScheduleConflictPanelProps = {
+  conflicts: WeeklyScheduleConflict[];
+  effectiveFrom: string;
+};
+
+export type WeeklyScheduleActionsProps = {
+  canSave: boolean;
+  isSaving?: boolean;
+  onSave: () => void;
+  onCancel?: () => void;
+};

--- a/web/src/features/schedule/weeklyScheduleState.test.ts
+++ b/web/src/features/schedule/weeklyScheduleState.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import type { ScheduleTemplateVersion } from '../../types/appointments';
+import type { WeeklyScheduleConflict } from './weeklyScheduleModels';
+import {
+  buildWeeklySchedulePreview,
+  createWeeklyScheduleDraftFromVersion,
+  createWeeklyScheduleSaveRequest,
+  filterVisibleScheduleConflicts,
+  isWeeklyScheduleReadyToSave,
+} from './weeklyScheduleState';
+
+describe('weeklyScheduleState', () => {
+  it('maps an existing template version into editable day cards and preview slot counts', () => {
+    const draft = createWeeklyScheduleDraftFromVersion(activeVersion());
+    const preview = buildWeeklySchedulePreview(draft);
+
+    expect(draft.days.monday.isEnabled).toBe(true);
+    expect(draft.days.tuesday.isEnabled).toBe(false);
+    expect(draft.days.wednesday.windows).toHaveLength(1);
+    expect(preview.find((day) => day.dayKey === 'monday')).toMatchObject({
+      windowCount: 1,
+      slotCount: 6,
+    });
+    expect(preview.find((day) => day.dayKey === 'wednesday')).toMatchObject({
+      windowCount: 1,
+      slotCount: 4,
+    });
+  });
+
+  it('requires effective_from before save and filters visible conflicts from that date onward', () => {
+    const baseDraft = createWeeklyScheduleDraftFromVersion(activeVersion());
+    const conflicts: WeeklyScheduleConflict[] = [
+      {
+        id: 'conflict-before',
+        date: '2026-04-28',
+        startTime: '09:00',
+        endTime: '09:30',
+        patientLabel: 'Juan Pérez',
+        summary: 'Consulta ya reservada',
+        severity: 'warning',
+      },
+      {
+        id: 'conflict-after',
+        date: '2026-05-06',
+        startTime: '10:00',
+        endTime: '10:30',
+        patientLabel: 'María Gómez',
+        summary: 'El nuevo horario deja sin cobertura el turno reservado',
+        severity: 'critical',
+      },
+    ];
+
+    expect(isWeeklyScheduleReadyToSave({ ...baseDraft, effectiveFrom: '' })).toBe(false);
+
+    const draft = { ...baseDraft, effectiveFrom: '2026-05-01', reason: 'Nuevo esquema de consultorio' };
+    const visibleConflicts = filterVisibleScheduleConflicts(conflicts, draft.effectiveFrom);
+    const request = createWeeklyScheduleSaveRequest({
+      professionalId: 'professional-1',
+      draft,
+      conflicts,
+    });
+
+    expect(visibleConflicts.map((conflict) => conflict.id)).toEqual(['conflict-after']);
+    expect(isWeeklyScheduleReadyToSave(draft)).toBe(true);
+    expect(request).toMatchObject({
+      professionalId: 'professional-1',
+      effectiveFrom: '2026-05-01',
+      reason: 'Nuevo esquema de consultorio',
+    });
+    expect(request.recurrence.monday).toMatchObject({
+      start_time: '09:00',
+      end_time: '12:00',
+      slot_duration_minutes: 30,
+    });
+    expect(request.recurrence.tuesday).toBeUndefined();
+    expect(request.visibleConflicts.map((conflict) => conflict.id)).toEqual(['conflict-after']);
+  });
+});
+
+function activeVersion(): ScheduleTemplateVersion {
+  return {
+    id: 'version-1',
+    template_id: 'template-1',
+    version_number: 3,
+    effective_from: '2026-04-01',
+    recurrence: {
+      monday: {
+        start_time: '09:00',
+        end_time: '12:00',
+        slot_duration_minutes: 30,
+      },
+      wednesday: {
+        start_time: '14:00',
+        end_time: '16:00',
+        slot_duration_minutes: 30,
+      },
+    },
+    created_at: '2026-03-25T10:00:00Z',
+    created_by: 'secretary-1',
+    reason: 'Base operativa vigente',
+  };
+}

--- a/web/src/features/schedule/weeklyScheduleState.ts
+++ b/web/src/features/schedule/weeklyScheduleState.ts
@@ -1,0 +1,268 @@
+import type { ScheduleRecurrence, ScheduleTemplateVersion } from '../../types/appointments';
+import type {
+  VersionSummaryCard,
+  WeeklyScheduleConflict,
+  WeeklyScheduleDayDraft,
+  WeeklyScheduleDayKey,
+  WeeklyScheduleDraft,
+  WeeklySchedulePreviewDay,
+  WeeklyScheduleSaveRequest,
+  WeeklyScheduleWindowDraft,
+} from './weeklyScheduleModels';
+import { WEEKLY_SCHEDULE_DAY_ORDER } from './weeklyScheduleModels';
+
+const DAY_LABELS: Record<WeeklyScheduleDayKey, { label: string; shortLabel: string }> = {
+  monday: { label: 'Lunes', shortLabel: 'Lun' },
+  tuesday: { label: 'Martes', shortLabel: 'Mar' },
+  wednesday: { label: 'Miércoles', shortLabel: 'Mié' },
+  thursday: { label: 'Jueves', shortLabel: 'Jue' },
+  friday: { label: 'Viernes', shortLabel: 'Vie' },
+  saturday: { label: 'Sábado', shortLabel: 'Sáb' },
+  sunday: { label: 'Domingo', shortLabel: 'Dom' },
+};
+
+export function createWeeklyScheduleDraftFromVersion(version?: ScheduleTemplateVersion | null): WeeklyScheduleDraft {
+  const days = WEEKLY_SCHEDULE_DAY_ORDER.reduce<Record<WeeklyScheduleDayKey, WeeklyScheduleDayDraft>>((accumulator, dayKey) => {
+    const recurrenceWindow = version?.recurrence[dayKey];
+
+    accumulator[dayKey] = {
+      dayKey,
+      label: DAY_LABELS[dayKey].label,
+      shortLabel: DAY_LABELS[dayKey].shortLabel,
+      isEnabled: Boolean(recurrenceWindow),
+      windows: recurrenceWindow ? [adaptWindow(dayKey, recurrenceWindow, 1)] : [],
+    };
+
+    return accumulator;
+  }, {} as Record<WeeklyScheduleDayKey, WeeklyScheduleDayDraft>);
+
+  return {
+    effectiveFrom: version?.effective_from ?? '',
+    reason: version?.reason ?? '',
+    days,
+  };
+}
+
+export function cloneDraftForNewVersion(version?: ScheduleTemplateVersion | null) {
+  const draft = createWeeklyScheduleDraftFromVersion(version);
+
+  return {
+    ...draft,
+    effectiveFrom: '',
+    reason: '',
+  };
+}
+
+export function toggleDraftDay(draft: WeeklyScheduleDraft, dayKey: WeeklyScheduleDayKey, nextValue: boolean): WeeklyScheduleDraft {
+  const nextWindows = nextValue
+    ? draft.days[dayKey].windows.length > 0
+      ? draft.days[dayKey].windows
+      : [createDefaultWindow(dayKey, 1)]
+    : [];
+
+  return {
+    ...draft,
+    days: {
+      ...draft.days,
+      [dayKey]: {
+        ...draft.days[dayKey],
+        isEnabled: nextValue,
+        windows: nextWindows,
+      },
+    },
+  };
+}
+
+export function addWindowToDraftDay(draft: WeeklyScheduleDraft, dayKey: WeeklyScheduleDayKey): WeeklyScheduleDraft {
+  const day = draft.days[dayKey];
+  const nextOrdinal = day.windows.length + 1;
+
+  return {
+    ...draft,
+    days: {
+      ...draft.days,
+      [dayKey]: {
+        ...day,
+        isEnabled: true,
+        windows: [...day.windows, createDefaultWindow(dayKey, nextOrdinal)],
+      },
+    },
+  };
+}
+
+export function removeWindowFromDraftDay(draft: WeeklyScheduleDraft, dayKey: WeeklyScheduleDayKey, windowId: string): WeeklyScheduleDraft {
+  const day = draft.days[dayKey];
+  const nextWindows = day.windows.filter((window) => window.id !== windowId);
+
+  return {
+    ...draft,
+    days: {
+      ...draft.days,
+      [dayKey]: {
+        ...day,
+        isEnabled: nextWindows.length > 0 ? day.isEnabled : false,
+        windows: nextWindows,
+      },
+    },
+  };
+}
+
+export function updateDraftWindow(
+  draft: WeeklyScheduleDraft,
+  dayKey: WeeklyScheduleDayKey,
+  windowId: string,
+  field: keyof Pick<WeeklyScheduleWindowDraft, 'startTime' | 'endTime' | 'slotDurationMinutes'>,
+  value: string,
+): WeeklyScheduleDraft {
+  const day = draft.days[dayKey];
+
+  return {
+    ...draft,
+    days: {
+      ...draft.days,
+      [dayKey]: {
+        ...day,
+        windows: day.windows.map((window) =>
+          window.id === windowId
+            ? {
+                ...window,
+                [field]: field === 'slotDurationMinutes' ? Number(value) : value,
+              }
+            : window,
+        ),
+      },
+    },
+  };
+}
+
+export function buildWeeklySchedulePreview(draft: WeeklyScheduleDraft): WeeklySchedulePreviewDay[] {
+  return WEEKLY_SCHEDULE_DAY_ORDER.map((dayKey) => {
+    const day = draft.days[dayKey];
+    const validWindows = day.windows.filter(isWindowValid);
+
+    return {
+      dayKey,
+      label: day.label,
+      shortLabel: day.shortLabel,
+      isEnabled: day.isEnabled,
+      windowCount: validWindows.length,
+      slotCount: validWindows.reduce((total, window) => total + calculateWindowSlots(window), 0),
+      windows: validWindows.map((window) => `${window.startTime}–${window.endTime} · ${window.slotDurationMinutes} min`),
+    };
+  });
+}
+
+export function filterVisibleScheduleConflicts(conflicts: WeeklyScheduleConflict[], effectiveFrom: string) {
+  if (!effectiveFrom) {
+    return conflicts;
+  }
+
+  return conflicts.filter((conflict) => conflict.date >= effectiveFrom);
+}
+
+export function isWeeklyScheduleReadyToSave(draft: WeeklyScheduleDraft) {
+  if (!draft.effectiveFrom) {
+    return false;
+  }
+
+  const activeDays = WEEKLY_SCHEDULE_DAY_ORDER.map((dayKey) => draft.days[dayKey]).filter((day) => day.isEnabled);
+
+  if (activeDays.length === 0) {
+    return false;
+  }
+
+  return activeDays.every((day) => day.windows.length > 0 && day.windows.every(isWindowValid));
+}
+
+export function buildVersionSummaryCard(
+  version: ScheduleTemplateVersion | null | undefined,
+  type: 'current' | 'future',
+): VersionSummaryCard | null {
+  if (!version) {
+    return null;
+  }
+
+  const preview = buildWeeklySchedulePreview(createWeeklyScheduleDraftFromVersion(version));
+  const enabledDays = preview.filter((day) => day.windowCount > 0);
+
+  return {
+    title: type === 'current' ? 'Agenda activa' : 'Versión futura cargada',
+    eyebrow: type === 'current' ? 'Vigente ahora' : 'Cambio pendiente',
+    versionLabel: `Versión ${version.version_number}`,
+    effectiveFromLabel: version.effective_from,
+    scheduleLabel: enabledDays.length > 0 ? enabledDays.map((day) => day.shortLabel ?? day.label).join(' · ') : 'Sin días configurados',
+    reasonLabel: version.reason?.trim() || 'Sin motivo registrado',
+  };
+}
+
+export function createWeeklyScheduleSaveRequest(args: {
+  professionalId: string;
+  draft: WeeklyScheduleDraft;
+  conflicts: WeeklyScheduleConflict[];
+}): WeeklyScheduleSaveRequest {
+  return {
+    professionalId: args.professionalId,
+    effectiveFrom: args.draft.effectiveFrom,
+    reason: args.draft.reason.trim(),
+    recurrence: buildRecurrence(args.draft),
+    previewDays: buildWeeklySchedulePreview(args.draft),
+    visibleConflicts: filterVisibleScheduleConflicts(args.conflicts, args.draft.effectiveFrom),
+  };
+}
+
+function buildRecurrence(draft: WeeklyScheduleDraft): ScheduleRecurrence {
+  return WEEKLY_SCHEDULE_DAY_ORDER.reduce<ScheduleRecurrence>((recurrence, dayKey) => {
+    const day = draft.days[dayKey];
+    const firstWindow = day.windows.find(isWindowValid);
+
+    if (!day.isEnabled || !firstWindow) {
+      return recurrence;
+    }
+
+    recurrence[dayKey] = {
+      start_time: firstWindow.startTime,
+      end_time: firstWindow.endTime,
+      slot_duration_minutes: firstWindow.slotDurationMinutes,
+    };
+
+    return recurrence;
+  }, {});
+}
+
+function calculateWindowSlots(window: WeeklyScheduleWindowDraft) {
+  const startMinutes = parseTime(window.startTime);
+  const endMinutes = parseTime(window.endTime);
+
+  if (endMinutes <= startMinutes) {
+    return 0;
+  }
+
+  return Math.floor((endMinutes - startMinutes) / window.slotDurationMinutes);
+}
+
+function isWindowValid(window: WeeklyScheduleWindowDraft) {
+  return Boolean(window.startTime && window.endTime) && calculateWindowSlots(window) > 0;
+}
+
+function parseTime(value: string) {
+  const [hours, minutes] = value.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+function adaptWindow(dayKey: WeeklyScheduleDayKey, window: NonNullable<ScheduleTemplateVersion['recurrence'][WeeklyScheduleDayKey]>, ordinal: number) {
+  return {
+    id: `${dayKey}-${ordinal}`,
+    startTime: window.start_time,
+    endTime: window.end_time,
+    slotDurationMinutes: window.slot_duration_minutes,
+  };
+}
+
+function createDefaultWindow(dayKey: WeeklyScheduleDayKey, ordinal: number): WeeklyScheduleWindowDraft {
+  return {
+    id: `${dayKey}-${ordinal}`,
+    startTime: '09:00',
+    endTime: '12:00',
+    slotDurationMinutes: 30,
+  };
+}

--- a/web/src/types/appointments.ts
+++ b/web/src/types/appointments.ts
@@ -23,6 +23,105 @@ export type Appointment = {
   cancelled_at?: string | null;
 };
 
+export type ScheduleTemplateWindow = {
+	start_time: string;
+	end_time: string;
+	slot_duration_minutes: 15 | 20 | 30 | 60;
+};
+
+export type ScheduleRecurrence = Partial<{
+	monday: ScheduleTemplateWindow;
+	tuesday: ScheduleTemplateWindow;
+	wednesday: ScheduleTemplateWindow;
+	thursday: ScheduleTemplateWindow;
+	friday: ScheduleTemplateWindow;
+	saturday: ScheduleTemplateWindow;
+	sunday: ScheduleTemplateWindow;
+}>;
+
+export type ScheduleTemplateVersion = {
+	id: string;
+	template_id: string;
+	version_number: number;
+	effective_from: string;
+	recurrence: ScheduleRecurrence;
+	created_at: string;
+	created_by?: string | null;
+	reason?: string | null;
+};
+
+export type ScheduleTemplate = {
+	id: string;
+	professional_id: string;
+	created_at: string;
+	updated_at: string;
+	versions?: ScheduleTemplateVersion[];
+};
+
+export type GetScheduleTemplateFilters = {
+	professional_id?: string;
+	effective_date: string;
+};
+
+export type ListScheduleTemplateVersionFilters = {
+	template_id: string;
+};
+
+export type CreateScheduleTemplateVersionPayload = {
+	professional_id: string;
+	effective_from: string;
+	recurrence: ScheduleRecurrence;
+	reason?: string;
+	created_by?: string | null;
+};
+
+export type ScheduleBlockScope = 'single' | 'range' | 'template';
+
+export type ScheduleBlock = {
+	id: string;
+	professional_id: string;
+	scope: ScheduleBlockScope;
+	block_date?: string | null;
+	start_date?: string | null;
+	end_date?: string | null;
+	day_of_week?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | null;
+	start_time: string;
+	end_time: string;
+	template_id?: string | null;
+	created_at: string;
+	updated_at: string;
+};
+
+export type ConsultationStatus = 'scheduled' | 'checked_in' | 'completed' | 'cancelled' | 'no_show';
+
+export type ConsultationSource = 'online' | 'secretary' | 'doctor';
+
+export type Consultation = {
+	id: string;
+	slot_id?: string | null;
+	professional_id: string;
+	patient_id: string;
+	status: ConsultationStatus;
+	source: ConsultationSource;
+	scheduled_start: string;
+	scheduled_end: string;
+	notes?: string | null;
+	check_in_time?: string | null;
+	reception_notes?: string | null;
+	created_at: string;
+	updated_at: string;
+	cancelled_at?: string | null;
+};
+
+export type WeekAgenda = {
+	professional_id: string;
+	week_start: string;
+	templates: ScheduleTemplate[];
+	blocks: ScheduleBlock[];
+	consultations: Consultation[];
+	slots: Slot[];
+};
+
 export type CreateAppointmentPayload = {
   slot_id: string;
   patient_id: string;


### PR DESCRIPTION
Closes #35
Closes #36

## Summary
- add consultations-based weekly agenda support in appointments-service, including schedule templates, blocks, consultations, and weekly agenda composition
- add an explicit weekly schedule UI surface with persisted template load/save and actor-aware flows for secretary and doctor
- migrate agenda board reading to the weekly agenda contract while keeping legacy appointment operations as temporary compatibility

## Changes
| File area | Change |
|------|--------|
| `services/appointments-service/**` | add consultations-based weekly scheduling model, migrations, API behavior, and tests |
| `web/src/features/schedule/**` | add weekly schedule workspace, editor, adapters, and agenda integration |
| `web/src/api/appointments.ts` | add schedule template load/save client methods and weekly agenda reads |
| `web/src/auth/actorCapabilities.ts` | expose explicit weekly schedule surface per actor |

## Test Plan
- [x] `npm test -- src/api/appointments.test.ts src/features/schedule/WeeklyScheduleWorkspace.test.tsx src/features/schedule/WeeklySchedulePage.test.tsx`
- [x] `npm test -- src/App.test.tsx src/auth/actorCapabilities.test.ts src/features/schedule/ScheduleDemo.test.tsx src/features/schedule/WeeklySchedulePage.test.tsx src/features/schedule/WeeklyScheduleWorkspace.test.tsx`
- [x] `npm run typecheck`

## Notes
- weekly schedule save/load is real
- preview/conflict handling remains intentionally limited for now
- same-date replacement for `effective_from` is intentionally left for follow-up issue #38