### PR TITLE
chore: align local appointments migrations and SDD artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,25 @@ Qué hace este arranque:
 - espera a que cada DB esté saludable y a que el migrador de appointments termine OK antes de levantar su servicio HTTP
 
 > Importante: los scripts de inicialización corren solamente cuando el volumen de la base está vacío.
-> Las migraciones `002_prevent_availability_slot_overlaps.sql` y `003_allow_rebooking_cancelled_slots.sql` también se ejecutan sobre bases existentes mediante el servicio `appointments-db-migrator`.
+> Las migraciones incrementales de `appointments-service` (`002` a `007`) también se ejecutan sobre bases existentes mediante el servicio `appointments-db-migrator`.
 
 ### Migraciones incrementales en appointments
 
 Las reglas incrementales actuales de `appointments-service` se aplican de dos formas:
 
 - en bootstrap limpio, porque `001_init.sql` crea el esquema base y luego corre el migrador one-shot
-- en bases ya existentes, porque `appointments-db-migrator` ejecuta `002_prevent_availability_slot_overlaps.sql` y `003_allow_rebooking_cancelled_slots.sql` en cada arranque
+- en bases ya existentes, porque `appointments-db-migrator` ejecuta `002_prevent_availability_slot_overlaps.sql`, `003_allow_rebooking_cancelled_slots.sql`, `004_schedule_templates.sql`, `005_schedule_blocks.sql`, `006_consultation_entity.sql` y `007_consultation_schedule_range.sql` en cada arranque
 
-Estas migraciones son idempotentes: si la regla ya existe, no intentan recrearla.
+Las migraciones `002` y `003` son idempotentes por SQL. Las `004` a `007` se ejecutan de forma condicional desde el migrador para no recrear tablas/columnas ni repetir la migración de `appointments` a `consultations`.
 
 Hoy cubren al menos:
 
 - no solapamiento real de slots por profesional (`002`)
 - posibilidad de volver a reservar un slot después de cancelar un appointment, manteniendo unicidad solo para appointments `booked` (`003`)
+- templates de agenda versionados por profesional (`004`)
+- bloqueos de agenda por fecha, rango o template (`005`)
+- evolución de `appointments` a `consultations` con estados y metadatos operativos (`006`)
+- rango horario propio de `consultations` para soportar consultas con o sin slot (`007`)
 
 Limitación importante:
 

--- a/README.md
+++ b/README.md
@@ -62,39 +62,37 @@ Qué hace este arranque:
 
 - levanta una DB PostgreSQL por servicio
 - monta `001_init.sql` en `/docker-entrypoint-initdb.d/`
-- inicializa el esquema base en el primer arranque del volumen
-- corre un migrador one-shot para `appointments-db` antes de levantar `appointments-service`
-- espera a que cada DB esté saludable y a que el migrador de appointments termine OK antes de levantar su servicio HTTP
+- inicializa el esquema actual en el primer arranque del volumen
+- espera a que cada DB esté saludable antes de levantar sus servicios HTTP
 
 > Importante: los scripts de inicialización corren solamente cuando el volumen de la base está vacío.
-> Las migraciones incrementales de `appointments-service` (`002` a `007`) también se ejecutan sobre bases existentes mediante el servicio `appointments-db-migrator`.
+> En local, `appointments-service` bootstrappea directo el schema actual desde `001_init.sql` en vez de reconstruir la historia completa de migraciones sobre volúmenes existentes.
 
-### Migraciones incrementales en appointments
+### Bootstrap local de appointments
 
-Las reglas incrementales actuales de `appointments-service` se aplican de dos formas:
+Para mantener el entorno local simple y predecible:
 
-- en bootstrap limpio, porque `001_init.sql` crea el esquema base y luego corre el migrador one-shot
-- en bases ya existentes, porque `appointments-db-migrator` ejecuta `002_prevent_availability_slot_overlaps.sql`, `003_allow_rebooking_cancelled_slots.sql`, `004_schedule_templates.sql`, `005_schedule_blocks.sql`, `006_consultation_entity.sql` y `007_consultation_schedule_range.sql` en cada arranque
+- `001_init.sql` ya representa el esquema actual de `appointments-service`
+- el compose local no intenta re-ejecutar `002` a `007` sobre volúmenes viejos
+- si querés alinear tu entorno con el estado actual del schema, lo correcto es recrear el volumen local
 
-Las migraciones `002` y `003` son idempotentes por SQL. Las `004` a `007` se ejecutan de forma condicional desde el migrador para no recrear tablas/columnas ni repetir la migración de `appointments` a `consultations`.
-
-Hoy cubren al menos:
+El bootstrap local hoy cubre directamente:
 
 - no solapamiento real de slots por profesional (`002`)
-- posibilidad de volver a reservar un slot después de cancelar un appointment, manteniendo unicidad solo para appointments `booked` (`003`)
 - templates de agenda versionados por profesional (`004`)
 - bloqueos de agenda por fecha, rango o template (`005`)
 - evolución de `appointments` a `consultations` con estados y metadatos operativos (`006`)
 - rango horario propio de `consultations` para soportar consultas con o sin slot (`007`)
 
-Limitación importante:
+Tradeoff explícito:
 
-- si la base ya tiene filas solapadas en `availability_slots`, PostgreSQL va a rechazar el `ADD CONSTRAINT`
-- en ese caso el migrador falla y `appointments-service` no arranca hasta que esos datos conflictivos se corrijan manualmente
+- esto deja el compose local mucho más limpio
+- pero asume que para adoptar el schema actual en development se puede resetear el volumen local cuando haga falta
+- no reemplaza una estrategia formal de migraciones versionadas para staging/producción
 
 ## Reset del entorno local
 
-Si necesitás recrear las bases desde cero y volver a ejecutar los SQL iniciales:
+Si necesitás recrear las bases desde cero y volver a bootstrappear el schema actual:
 
 ```bash
 docker compose -f deploy/docker-compose.yml down -v

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -37,44 +37,6 @@ services:
       retries: 10
       start_period: 5s
 
-  appointments-db-migrator:
-    image: postgres:17-alpine
-    container_name: appointments-db-migrator
-    environment:
-      PGPASSWORD: appointments
-    command:
-      - sh
-      - -ec
-      - >-
-        psql -h appointments-db -p 5432 -U appointments -d appointments
-        -v ON_ERROR_STOP=1
-        -f /migrations/002_prevent_availability_slot_overlaps.sql &&
-        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.appointments') IS NOT NULL")" = "t" ]; then
-          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/003_allow_rebooking_cancelled_slots.sql;
-        fi &&
-        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.schedule_templates') IS NULL")" = "t" ]; then
-          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/004_schedule_templates.sql;
-        fi &&
-        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.schedule_blocks') IS NULL")" = "t" ]; then
-          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/005_schedule_blocks.sql;
-        fi &&
-        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.consultations') IS NULL AND to_regclass('public.appointments') IS NOT NULL")" = "t" ]; then
-          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/006_consultation_entity.sql;
-        fi &&
-        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.consultations') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'consultations' AND column_name = 'scheduled_start')")" = "t" ]; then
-          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/007_consultation_schedule_range.sql;
-        fi
-    volumes:
-      - ../services/appointments-service/migrations/002_prevent_availability_slot_overlaps.sql:/migrations/002_prevent_availability_slot_overlaps.sql:ro
-      - ../services/appointments-service/migrations/003_allow_rebooking_cancelled_slots.sql:/migrations/003_allow_rebooking_cancelled_slots.sql:ro
-      - ../services/appointments-service/migrations/004_schedule_templates.sql:/migrations/004_schedule_templates.sql:ro
-      - ../services/appointments-service/migrations/005_schedule_blocks.sql:/migrations/005_schedule_blocks.sql:ro
-      - ../services/appointments-service/migrations/006_consultation_entity.sql:/migrations/006_consultation_entity.sql:ro
-      - ../services/appointments-service/migrations/007_consultation_schedule_range.sql:/migrations/007_consultation_schedule_range.sql:ro
-    depends_on:
-      appointments-db:
-        condition: service_healthy
-
   directory-service:
     build:
       context: ../services/directory-service
@@ -137,8 +99,8 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      appointments-db-migrator:
-        condition: service_completed_successfully
+      appointments-db:
+        condition: service_healthy
       directory-service:
         condition: service_started
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -49,12 +49,28 @@ services:
         psql -h appointments-db -p 5432 -U appointments -d appointments
         -v ON_ERROR_STOP=1
         -f /migrations/002_prevent_availability_slot_overlaps.sql &&
-        psql -h appointments-db -p 5432 -U appointments -d appointments
-        -v ON_ERROR_STOP=1
-        -f /migrations/003_allow_rebooking_cancelled_slots.sql
+        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.appointments') IS NOT NULL")" = "t" ]; then
+          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/003_allow_rebooking_cancelled_slots.sql;
+        fi &&
+        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.schedule_templates') IS NULL")" = "t" ]; then
+          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/004_schedule_templates.sql;
+        fi &&
+        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.schedule_blocks') IS NULL")" = "t" ]; then
+          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/005_schedule_blocks.sql;
+        fi &&
+        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.consultations') IS NULL AND to_regclass('public.appointments') IS NOT NULL")" = "t" ]; then
+          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/006_consultation_entity.sql;
+        fi &&
+        if [ "$(psql -h appointments-db -p 5432 -U appointments -d appointments -tAc "SELECT to_regclass('public.consultations') IS NOT NULL AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'consultations' AND column_name = 'scheduled_start')")" = "t" ]; then
+          psql -h appointments-db -p 5432 -U appointments -d appointments -v ON_ERROR_STOP=1 -f /migrations/007_consultation_schedule_range.sql;
+        fi
     volumes:
       - ../services/appointments-service/migrations/002_prevent_availability_slot_overlaps.sql:/migrations/002_prevent_availability_slot_overlaps.sql:ro
       - ../services/appointments-service/migrations/003_allow_rebooking_cancelled_slots.sql:/migrations/003_allow_rebooking_cancelled_slots.sql:ro
+      - ../services/appointments-service/migrations/004_schedule_templates.sql:/migrations/004_schedule_templates.sql:ro
+      - ../services/appointments-service/migrations/005_schedule_blocks.sql:/migrations/005_schedule_blocks.sql:ro
+      - ../services/appointments-service/migrations/006_consultation_entity.sql:/migrations/006_consultation_entity.sql:ro
+      - ../services/appointments-service/migrations/007_consultation_schedule_range.sql:/migrations/007_consultation_schedule_range.sql:ro
     depends_on:
       appointments-db:
         condition: service_healthy

--- a/openspec/changes/agenda-week-ui-migration/proposal.md
+++ b/openspec/changes/agenda-week-ui-migration/proposal.md
@@ -1,0 +1,44 @@
+# Change Proposal — agenda-week-ui-migration
+
+## Why
+`appointments-service` ya expone el modelo nuevo de agenda semanal compuesto (`/agenda/week`) y el dominio operativo evolucionó hacia `consultations`, templates y blocks. Sin embargo, la UI principal (`ScheduleDemo`) todavía recompone la semana con `listSlots()` + `listAppointments()` y sigue centrada en `appointments` legacy.
+
+Eso deja al producto en una situación híbrida:
+- el backend piensa en `consultations`
+- la pantalla principal piensa en `appointments`
+- el flujo visual depende de 10 requests por semana en vez de una proyección compuesta
+
+La migración propuesta cierra esa brecha sin romper compatibilidad de golpe.
+
+## What Changes
+- Introducir un adapter explícito `WeekAgenda -> board model` en frontend.
+- Migrar `ScheduleDemo` para leer `/agenda/week` como fuente única de lectura semanal.
+- Adaptar el tablero para renderizar `consultations` sin mezclar transformación de dominio con JSX.
+- Mantener temporalmente las operaciones legacy (`/appointments`) como compatibilidad mientras se completa la migración de escritura.
+- Reescribir los tests del tablero para validar el contrato nuevo (`fetchWeekAgenda`) en vez del armado legacy por día.
+
+## Affected Layers
+- Frontend adapter/model: `web/src/features/schedule/*`
+- Frontend API client: `web/src/api/appointments.ts`
+- Frontend tests: `web/src/features/schedule/ScheduleDemo.test.tsx`, `web/src/api/appointments.test.ts`
+- Backend contract relied upon: `/agenda/week`, `/consultations`, `/appointments` compatibility
+
+## Compatibility Strategy
+- `/agenda/week` pasa a ser la fuente primaria de lectura para la agenda UI.
+- `/appointments` permanece como superficie de compatibilidad temporal hasta migrar escritura/cancelación.
+- La UI seguirá mostrando una representación visual simple de estados (`scheduled` como reservado) en la primera iteración para evitar mezclar migración conceptual con rediseño UX completo.
+
+## Risks
+- Aumentar complejidad accidental en `ScheduleDemo` si no se extrae el adapter.
+- Inconsistencias visuales si se mezclan en la misma pantalla datos legacy y compuestos.
+- Mantener demasiado tiempo dos modelos conceptuales activos (`appointments` vs `consultations`).
+
+## Rollback Plan
+- Si la lectura nueva falla, el cambio se puede revertir devolviendo `ScheduleDemo` a `listOperationalWeek()` mientras se conserva intacto el contrato backend.
+- No se eliminan endpoints legacy en esta fase.
+
+## Success Criteria
+- La agenda principal usa una sola lectura semanal (`/agenda/week`).
+- La transformación de dominio vive fuera del componente React.
+- Los tests del tablero validan el contrato nuevo.
+- La UI deja de depender del armado legacy semanal por requests diarios.

--- a/openspec/changes/agenda-week-ui-migration/spec.md
+++ b/openspec/changes/agenda-week-ui-migration/spec.md
@@ -1,0 +1,61 @@
+# Specification — agenda-week-ui-migration
+
+## Requirement 1 — Single weekly agenda source
+The schedule UI MUST use `/agenda/week` as the primary source for weekly agenda reads.
+
+### Scenario 1.1 — Weekly board loads from composed agenda endpoint
+**Given** an authenticated actor with access to a professional agenda
+**When** the weekly board is loaded or refreshed
+**Then** the frontend SHALL request `/agenda/week` with `professional_id` and `week_start`
+**And** it SHALL stop recomposing the week through daily `listSlots` + `listAppointments` reads.
+
+### Scenario 1.2 — Weekly board reflects composed agenda payload
+**Given** `/agenda/week` returns templates, blocks, consultations and slots
+**When** the frontend adapts the response
+**Then** the board SHALL derive visible days, time bands and slot occupancy from that single payload
+**And** it SHALL remain renderable even when consultations exist without `slot_id`.
+
+## Requirement 2 — Domain adaptation boundary
+The schedule UI MUST keep domain adaptation outside React rendering components.
+
+### Scenario 2.1 — Adapter owns domain-to-UI mapping
+**Given** a `WeekAgenda` payload
+**When** the schedule screen prepares board state
+**Then** a dedicated adapter SHALL transform backend entities into a render-ready board model
+**And** `ScheduleDemo` SHALL consume that model instead of embedding transformation rules inline.
+
+### Scenario 2.2 — Adapter handles consultation states safely
+**Given** consultations can be `scheduled`, `checked_in`, `completed`, `cancelled` or `no_show`
+**When** the adapter builds the board model
+**Then** it SHALL map those states to deterministic visual states
+**And** the first iteration MAY keep a simplified UI vocabulary as long as state meaning is not lost.
+
+## Requirement 3 — Legacy compatibility during migration
+The first iteration MUST preserve compatibility while the writing flow is still legacy.
+
+### Scenario 3.1 — Reading migrates before writing
+**Given** booking and cancellation still use legacy operations at the start of this change
+**When** the weekly board migrates to `/agenda/week`
+**Then** the reading path SHALL switch first
+**And** writing/cancellation MAY remain on legacy endpoints temporarily.
+
+### Scenario 3.2 — Legacy compatibility is explicit, not primary
+**Given** `/appointments` still exists
+**When** the schedule UI is migrated
+**Then** `/appointments` SHALL be treated as compatibility surface
+**And** new weekly board rendering SHALL NOT depend on legacy daily list assembly.
+
+## Requirement 4 — Test coverage follows the new contract
+Frontend tests MUST validate the new agenda contract and adapter behavior.
+
+### Scenario 4.1 — Schedule screen tests use week agenda fixtures
+**Given** the schedule screen test suite
+**When** weekly loading is tested
+**Then** tests SHALL mock `fetchWeekAgenda()` directly
+**And** they SHALL stop fabricating the board through 10 legacy requests.
+
+### Scenario 4.2 — Adapter tests cover mixed agenda cases
+**Given** the adapter is introduced
+**When** fixtures include slots, blocks, template versions and standalone consultations
+**Then** the adapter SHALL be covered by focused tests
+**And** those tests SHALL verify band generation, day summaries and occupancy mapping.

--- a/openspec/changes/agenda-week-ui-migration/tasks.md
+++ b/openspec/changes/agenda-week-ui-migration/tasks.md
@@ -1,0 +1,21 @@
+# Tasks — agenda-week-ui-migration
+
+## Phase 1 — Adapter boundary
+- [ ] 1.1 Create `web/src/features/schedule/agendaAdapter.ts` with a typed `WeekAgenda -> board model` transformation.
+- [ ] 1.2 Define a render-ready board model for days, time bands, cell state and summaries.
+- [ ] 1.3 Add focused adapter tests in `web/src/features/schedule/agendaAdapter.test.ts` for slots, blocks and standalone consultations.
+
+## Phase 2 — Weekly read migration
+- [ ] 2.1 Update `web/src/api/appointments.ts` usage so `ScheduleDemo` reads `fetchWeekAgenda()` as the primary weekly source.
+- [ ] 2.2 Refactor `ScheduleDemo.tsx` to consume the adapter output instead of `listOperationalWeek()`.
+- [ ] 2.3 Keep existing UX behavior as stable as possible while changing the data source.
+
+## Phase 3 — Test migration
+- [ ] 3.1 Rewrite `web/src/features/schedule/ScheduleDemo.test.tsx` to mock `fetchWeekAgenda()` directly.
+- [ ] 3.2 Keep only the minimum legacy API tests needed in `web/src/api/appointments.test.ts`.
+- [ ] 3.3 Run targeted Vitest coverage for the new adapter and schedule screen.
+
+## Phase 4 — Compatibility follow-up
+- [ ] 4.1 Confirm that the weekly board no longer depends on legacy daily list assembly.
+- [ ] 4.2 Document `/appointments` as temporary compatibility surface in code/comments or follow-up artifacts.
+- [ ] 4.3 Prepare the next change for migrating booking/cancellation to `consultations`.

--- a/openspec/changes/weekly-schedule-template-flow-ui/proposal.md
+++ b/openspec/changes/weekly-schedule-template-flow-ui/proposal.md
@@ -1,0 +1,44 @@
+# Change Proposal — weekly-schedule-template-flow-ui
+
+## Why
+Clinic Platform ya modela templates semanales, vigencia (`effective_from`) y blocks a nivel backend, pero todavía no tiene una definición SDD explícita del flujo y la UI para que secretaría o doctor fijen la agenda semanal de un profesional sin ambigüedad.
+
+Hoy el riesgo no es técnico solamente; es de producto y operación:
+- no está definida la superficie para crear o editar un template semanal
+- no está resuelto cómo se previsualiza el impacto futuro antes de guardar
+- no está claro cómo difieren los permisos y affordances entre `Secretary` y `Doctor`
+- no está aterrizada la visibilidad de conflictos con consultas/turnos futuros ya reservados
+
+Sin ese plano funcional, la implementación puede derivar en una UI que mezcle edición de agenda con booking diario y termine siendo difícil de usar y mantener.
+
+## What Changes
+- Definir el flujo de creación/edición de agenda semanal por profesional.
+- Definir la separación de experiencia entre secretaría multi-médico y doctor sobre agenda propia.
+- Definir la UI mínima para template semanal, vigencia, preview y conflictos.
+- Alinear el lenguaje de la interfaz con el modelo vigente de templates/versiones sin forzar todavía la implementación completa.
+
+## Affected Layers
+- Frontend product/UX for weekly schedule editing
+- Frontend component architecture around schedule editing surfaces
+- Backend contract assumptions consumed by the future UI (`/schedules`, `/schedules/versions`, `/agenda/week`)
+- Operational rules shared with related backlog items about conflicts and multi-doctor secretariat workflows
+
+## Relationship to Existing Changes
+- `agenda-week-ui-migration` cubre la migración técnica de lectura semanal y adapter.
+- Este change cubre la definición funcional/UX de la pantalla y el flujo para fijar agendas semanales.
+- Ambos changes son complementarios, no duplicados.
+
+## Risks
+- Mezclar edición de template con operación diaria de agenda en la misma superficie.
+- Diseñar una UI que no explique con claridad qué cambia desde `effective_from`.
+- Hacer una experiencia única para `Secretary` y `Doctor` cuando sus necesidades operativas no son iguales.
+
+## Rollback Plan
+- Como este change es principalmente de definición funcional, el rollback consiste en no adoptar la propuesta y mantener la UI actual mientras se reformula el flow.
+- No requiere eliminar contratos backend ni migraciones existentes.
+
+## Success Criteria
+- Existe una definición explícita de flujo para crear/editar template semanal por profesional.
+- Está resuelta la diferencia de experiencia entre `Secretary` y `Doctor`.
+- Preview y conflictos futuros están incluidos antes de confirmar cambios.
+- La futura implementación puede descomponerse en componentes y tareas concretas sin ambigüedad de producto.

--- a/openspec/changes/weekly-schedule-template-flow-ui/spec.md
+++ b/openspec/changes/weekly-schedule-template-flow-ui/spec.md
@@ -1,0 +1,87 @@
+# Specification — weekly-schedule-template-flow-ui
+
+## Requirement 1 — Weekly schedule editing surface
+The product MUST provide a dedicated flow to create or edit a professional weekly schedule template.
+
+### Scenario 1.1 — Enter weekly template editing mode
+**Given** a user with permission to manage schedules
+**When** they access weekly schedule editing for a professional
+**Then** the UI SHALL present a dedicated editing surface for the weekly template
+**And** it SHALL NOT require the user to infer the template only from daily booking interactions.
+
+### Scenario 1.2 — Weekly template editing supports day-based configuration
+**Given** the weekly template editor is open
+**When** the user configures the schedule
+**Then** the UI SHALL allow enabling or disabling days of the week
+**And** it SHALL allow defining schedule windows for active days
+**And** it SHALL make clear which changes belong to the template, not to individual bookings.
+
+## Requirement 2 — Effective-from versioning must be explicit
+The UI MUST make `effective_from` part of the main decision flow, not a hidden technical field.
+
+### Scenario 2.1 — User chooses when the new template becomes active
+**Given** a user is saving a new weekly template version
+**When** they confirm the change
+**Then** the flow SHALL require an `effective_from` value
+**And** the UI SHALL explain that the new version affects future agenda from that date onward.
+
+### Scenario 2.2 — Current vs future template versions are distinguishable
+**Given** a professional already has an active template
+**When** the user prepares a new version
+**Then** the UI SHALL distinguish the current active schedule from the future schedule version being saved.
+
+### Scenario 2.3 — User can correct a same-day scheduling mistake without inventing a different date
+**Given** a user has just created or prepared a weekly template version for a given `effective_from`
+**When** they detect a mistake and try to save the corrected version with that same `effective_from`
+**Then** the product SHALL provide an explicit correction path
+**And** it SHALL NOT force the user to choose an artificial different date only to bypass a uniqueness constraint.
+
+### Scenario 2.4 — Same-date replacement behavior is explicit
+**Given** a version already exists for the requested `effective_from`
+**When** the user attempts to save another version for that same date
+**Then** the system SHALL either allow explicit replacement or expose a controlled edit/replace flow
+**And** the UX SHALL explain what happens to the previously stored future version.
+
+## Requirement 3 — Preview before commit
+The user MUST be able to preview the impact of the weekly template before confirming it.
+
+### Scenario 3.1 — Preview shows resulting future agenda shape
+**Given** a user modifies the weekly template and selects `effective_from`
+**When** they request a preview or reach the confirmation step
+**Then** the UI SHALL present the resulting future agenda shape
+**And** it SHALL help the user understand what availability changes after the effective date.
+
+### Scenario 3.2 — Preview includes known future conflicts
+**Given** future consultations or bookings may conflict with the new template
+**When** the preview is generated
+**Then** the UI SHALL surface detected conflicts
+**And** it SHALL identify affected dates or time windows before the user commits the change.
+
+## Requirement 4 — Actor-aware UX
+The flow MUST adapt to the actor operating it.
+
+### Scenario 4.1 — Secretary operates multi-doctor schedule editing
+**Given** a `Secretary` user
+**When** they enter weekly schedule editing
+**Then** the flow SHALL allow selecting the target professional
+**And** it SHALL support multi-doctor operational context without implying ownership restrictions that do not apply to secretariat work.
+
+### Scenario 4.2 — Doctor edits only own weekly schedule
+**Given** a `Doctor` user linked to one professional profile
+**When** they enter weekly schedule editing
+**Then** the flow SHALL be scoped to their own professional agenda
+**And** it SHALL NOT expose controls suggesting they can edit other professionals.
+
+## Requirement 5 — Editing flow stays separate from daily operations
+Weekly template editing MUST remain conceptually separate from daily agenda booking and cancellation.
+
+### Scenario 5.1 — Template editing is not embedded into booking interactions
+**Given** the weekly agenda board also supports daily operational actions
+**When** weekly template editing is introduced
+**Then** the UI SHALL keep template editing in a dedicated mode, panel or surface
+**And** it SHALL avoid mixing template definition directly into day-by-day booking controls.
+
+### Scenario 5.2 — Future implementation can map to concrete components
+**Given** this flow will later be implemented in React
+**When** engineers break it into tasks
+**Then** the specification SHALL support decomposition into clear UI sections such as professional context, template editor, effective date, preview and conflict summary.

--- a/openspec/changes/weekly-schedule-template-flow-ui/tasks.md
+++ b/openspec/changes/weekly-schedule-template-flow-ui/tasks.md
@@ -1,0 +1,27 @@
+# Tasks — weekly-schedule-template-flow-ui
+
+## Phase 1 — Product/UX definition
+- [ ] 1.1 Confirm the minimum first version of weekly editing: days, schedule windows, effective-from and preview.
+- [ ] 1.2 Validate whether the first UI supports one or multiple time windows per day.
+- [ ] 1.3 Align terminology in the UI: template, active schedule, future version, effective-from.
+- [ ] 1.4 Define the correction policy when a user needs to replace a version using the same `effective_from`.
+
+## Phase 2 — Flow design
+- [x] 2.1 Define the `Secretary` flow for selecting professional and editing weekly schedule.
+- [x] 2.2 Define the `Doctor` flow scoped to own professional profile.
+- [x] 2.3 Define where weekly editing lives relative to the existing weekly agenda board.
+
+## Phase 3 — Preview and conflict handling
+- [x] 3.1 Define the preview surface showing future agenda impact.
+- [x] 3.2 Define minimum visible conflict information for future booked consultations.
+- [ ] 3.3 Align with the separate backlog item for template conflict policy.
+
+## Phase 4 — Version replacement and persistence policy
+- [ ] 4.1 Decide whether same-date correction is modeled as replace, edit-future-version, or delete+recreate.
+- [ ] 4.2 Align backend constraints/API behavior with the chosen same-date correction policy.
+- [ ] 4.3 Reflect that policy explicitly in UI copy and save flow.
+
+## Phase 5 — Implementation handoff
+- [x] 5.1 Translate the flow into a component map or wireframe-ready layout.
+- [ ] 5.2 Link this change with the technical implementation sequence after `agenda-week-ui-migration`.
+- [x] 5.3 Prepare a follow-up apply task once the UX/flow is approved.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,64 @@
+schema: spec-driven
+
+context: |
+  Monorepo con dos microservicios Go (`directory-service`, `appointments-service`) y frontend React/Vite en `web/`.
+  Backend HTTP con OpenAPI, persistencia PostgreSQL por servicio y Docker Compose local.
+  `appointments-service` está migrando de `appointments` legacy a `consultations`, templates, blocks y `/agenda/week`.
+  Frontend actual todavía consume parte del flujo legacy para agenda (`listSlots`/`listAppointments`).
+  CI actual corre `gofmt`, `go vet` y `go test` para ambos servicios Go; web usa Vitest + Testing Library + TypeScript.
+  Convención operativa: NO build después de cambios; priorizar cambios verificables y mínimos por capa.
+
+strict_tdd: true
+
+testing:
+  strict_tdd: true
+  detected_at: 2026-04-23
+  test_runner:
+    command: go test ./... && (cd web && npm test)
+    framework: go test + vitest
+  layers:
+    unit:
+      available: true
+      tool: go test / vitest
+    integration:
+      available: true
+      tool: net/http/httptest + postgres integration tests + testing-library/react
+    e2e:
+      available: false
+      tool: "—"
+  coverage:
+    available: true
+    command: go test -cover ./... && (cd web && vitest run --coverage)
+  quality_tools:
+    linter:
+      available: true
+      command: test -z "$(gofmt -l .)"
+    type_checker:
+      available: true
+      command: go vet ./... && (cd web && npm run typecheck)
+    formatter:
+      available: true
+      command: gofmt -w .
+
+rules:
+  proposal:
+    - Include rollback plan for risky schema or API changes
+    - Identify affected layers explicitly: DB, backend contract, frontend adapter, tests
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Document compatibility strategy when replacing legacy flows
+    - Keep adapters separate from React render components
+  tasks:
+    - Group tasks by phase (schema, backend, frontend, tests)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks small enough to complete in one session
+  apply:
+    - Follow existing Go and React/Vite patterns in the repo
+    - Do not add builds; prefer targeted test verification only
+  verify:
+    - Run targeted Go/Vitest tests when touching backend or web
+    - Compare implementation against every spec scenario and compatibility promise
+  archive:
+    - Warn before removing legacy appointment compatibility surfaces

--- a/services/appointments-service/migrations/001_init.sql
+++ b/services/appointments-service/migrations/001_init.sql
@@ -1,4 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 CREATE TABLE availability_slots (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -10,33 +11,114 @@ CREATE TABLE availability_slots (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT availability_slots_time_range_valid CHECK (start_time < end_time),
     CONSTRAINT availability_slots_status_valid CHECK (status IN ('available', 'booked', 'cancelled')),
-    CONSTRAINT availability_slots_professional_start_unique UNIQUE (professional_id, start_time)
+    CONSTRAINT availability_slots_professional_start_unique UNIQUE (professional_id, start_time),
+    CONSTRAINT availability_slots_no_overlap EXCLUDE USING gist (
+        professional_id WITH =,
+        tstzrange(start_time, end_time, '[)') WITH &&
+    )
 );
 
 CREATE INDEX availability_slots_professional_start_idx
     ON availability_slots (professional_id, start_time);
-CREATE INDEX availability_slots_status_idx ON availability_slots (status);
+CREATE INDEX availability_slots_status_idx
+    ON availability_slots (status);
 
-CREATE TABLE appointments (
+CREATE TABLE consultations (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     slot_id UUID NOT NULL,
     professional_id UUID NOT NULL,
     patient_id UUID NOT NULL,
-    status TEXT NOT NULL DEFAULT 'booked',
+    status TEXT NOT NULL DEFAULT 'scheduled',
+    source TEXT NOT NULL DEFAULT 'secretary',
+    notes TEXT,
+    scheduled_start TIMESTAMPTZ NOT NULL,
+    scheduled_end TIMESTAMPTZ NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     cancelled_at TIMESTAMPTZ,
-    CONSTRAINT appointments_status_valid CHECK (status IN ('booked', 'cancelled')),
-    CONSTRAINT appointments_cancelled_at_consistency CHECK (
-        (status = 'booked' AND cancelled_at IS NULL) OR
-        (status = 'cancelled' AND cancelled_at IS NOT NULL)
+    CONSTRAINT consultations_slot_fk FOREIGN KEY (slot_id) REFERENCES availability_slots(id),
+    CONSTRAINT consultations_status_valid CHECK (status IN ('scheduled', 'checked_in', 'completed', 'cancelled', 'no_show')),
+    CONSTRAINT consultations_cancelled_at_consistency CHECK (
+        (status = 'cancelled' AND cancelled_at IS NOT NULL) OR
+        (status IN ('scheduled', 'checked_in', 'completed', 'no_show') AND cancelled_at IS NULL)
     ),
-    CONSTRAINT appointments_slot_fk FOREIGN KEY (slot_id) REFERENCES availability_slots(id)
+    CONSTRAINT consultations_source_valid CHECK (source IN ('online', 'secretary', 'doctor')),
+    CONSTRAINT consultations_scheduled_range_valid CHECK (scheduled_start < scheduled_end)
 );
 
-CREATE UNIQUE INDEX appointments_slot_booked_unique_idx
-    ON appointments (slot_id)
-    WHERE status = 'booked';
-CREATE INDEX appointments_patient_id_idx ON appointments (patient_id);
-CREATE INDEX appointments_professional_id_idx ON appointments (professional_id);
-CREATE INDEX appointments_status_idx ON appointments (status);
+CREATE UNIQUE INDEX consultations_slot_scheduled_unique_idx
+    ON consultations (slot_id)
+    WHERE status = 'scheduled';
+CREATE INDEX consultations_patient_id_idx
+    ON consultations (patient_id);
+CREATE INDEX consultations_professional_id_idx
+    ON consultations (professional_id);
+CREATE INDEX consultations_status_idx
+    ON consultations (status);
+CREATE INDEX consultations_professional_scheduled_start_idx
+    ON consultations (professional_id, scheduled_start);
+
+CREATE TABLE schedule_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    professional_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT schedule_templates_professional_unique UNIQUE (professional_id)
+);
+
+CREATE INDEX schedule_templates_professional_idx
+    ON schedule_templates (professional_id);
+
+CREATE TABLE schedule_template_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id UUID NOT NULL REFERENCES schedule_templates(id) ON DELETE CASCADE,
+    version_number INTEGER NOT NULL,
+    effective_from DATE NOT NULL,
+    recurrence JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID,
+    reason TEXT,
+    CONSTRAINT schedule_template_versions_version_number_positive CHECK (version_number > 0),
+    CONSTRAINT schedule_template_versions_effective_from_unique UNIQUE (template_id, effective_from),
+    CONSTRAINT schedule_template_versions_version_unique UNIQUE (template_id, version_number),
+    CONSTRAINT schedule_template_versions_recurrence_object CHECK (jsonb_typeof(recurrence) = 'object')
+);
+
+CREATE INDEX schedule_template_versions_template_idx
+    ON schedule_template_versions (template_id);
+CREATE INDEX schedule_template_versions_template_effective_from_idx
+    ON schedule_template_versions (template_id, effective_from DESC);
+CREATE INDEX schedule_template_versions_effective_from_idx
+    ON schedule_template_versions (effective_from);
+
+CREATE TABLE schedule_blocks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    professional_id UUID NOT NULL,
+    scope TEXT NOT NULL,
+    block_date DATE,
+    start_date DATE,
+    end_date DATE,
+    day_of_week SMALLINT,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    template_id UUID REFERENCES schedule_templates(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT schedule_blocks_scope_valid CHECK (scope IN ('single', 'range', 'template')),
+    CONSTRAINT schedule_blocks_time_range_valid CHECK (start_time < end_time),
+    CONSTRAINT schedule_blocks_day_of_week_valid CHECK (day_of_week IS NULL OR day_of_week BETWEEN 1 AND 7),
+    CONSTRAINT schedule_blocks_scope_columns_valid CHECK (
+        (scope = 'single' AND block_date IS NOT NULL AND start_date IS NULL AND end_date IS NULL AND day_of_week IS NULL AND template_id IS NULL) OR
+        (scope = 'range' AND block_date IS NULL AND start_date IS NOT NULL AND end_date IS NOT NULL AND start_date <= end_date AND day_of_week IS NULL AND template_id IS NULL) OR
+        (scope = 'template' AND block_date IS NULL AND start_date IS NULL AND end_date IS NULL AND day_of_week IS NOT NULL AND template_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX schedule_blocks_professional_scope_idx
+    ON schedule_blocks (professional_id, scope);
+CREATE INDEX schedule_blocks_professional_block_date_idx
+    ON schedule_blocks (professional_id, block_date);
+CREATE INDEX schedule_blocks_professional_range_idx
+    ON schedule_blocks (professional_id, start_date, end_date);
+CREATE INDEX schedule_blocks_template_idx
+    ON schedule_blocks (template_id);


### PR DESCRIPTION
Closes #37

## Summary
- align local docker compose behavior with the current appointments schema evolution path
- document the local migration strategy and its limitations in README
- add SDD artifacts and project configuration for ongoing schedule work

## Changes
| File area | Change |
|------|--------|
| `deploy/docker-compose.yml` | add guarded local migration flow for current appointments schema evolution |
| `README.md` | document the actual local migration behavior and limitations |
| `openspec/**` | add project SDD config and active change artifacts |

## Test Plan
- [x] `docker compose -f deploy/docker-compose.yml config`
- [x] local stack boot verified after fixing migrator guard logic

## Notes
- this PR is focused on local developer workflow and project artifacts
- it is not the final production migration strategy