### PR TITLE
feat(patient): add DNI booking surface

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -95,8 +95,10 @@ services:
         psql -h appointments-db -p 5432 -U appointments -d appointments
         -v ON_ERROR_STOP=1
         -f /migrations/008_reconcile_local_schema.sql
+        -f /migrations/009_patient_request_flow.sql
     volumes:
       - ../services/appointments-service/migrations/008_reconcile_local_schema.sql:/migrations/008_reconcile_local_schema.sql:ro
+      - ../services/appointments-service/migrations/009_patient_request_flow.sql:/migrations/009_patient_request_flow.sql:ro
     depends_on:
       appointments-db:
         condition: service_healthy

--- a/services/appointments-service/internal/appointments/consultation_models.go
+++ b/services/appointments-service/internal/appointments/consultation_models.go
@@ -6,6 +6,7 @@ type ConsultationStatus string
 
 const (
 	ConsultationStatusScheduled ConsultationStatus = "scheduled"
+	ConsultationStatusRequested ConsultationStatus = "requested"
 	ConsultationStatusCheckedIn ConsultationStatus = "checked_in"
 	ConsultationStatusCompleted ConsultationStatus = "completed"
 	ConsultationStatusCancelled ConsultationStatus = "cancelled"
@@ -15,6 +16,7 @@ const (
 func (status ConsultationStatus) IsValid() bool {
 	switch status {
 	case ConsultationStatusScheduled,
+		ConsultationStatusRequested,
 		ConsultationStatusCheckedIn,
 		ConsultationStatusCompleted,
 		ConsultationStatusCancelled,
@@ -48,13 +50,15 @@ const (
 	ConsultationSourceOnline    ConsultationSource = "online"
 	ConsultationSourceSecretary ConsultationSource = "secretary"
 	ConsultationSourceDoctor    ConsultationSource = "doctor"
+	ConsultationSourcePatient   ConsultationSource = "patient"
 )
 
 func (source ConsultationSource) IsValid() bool {
 	switch source {
 	case ConsultationSourceOnline,
 		ConsultationSourceSecretary,
-		ConsultationSourceDoctor:
+		ConsultationSourceDoctor,
+		ConsultationSourcePatient:
 		return true
 	default:
 		return false

--- a/services/appointments-service/internal/appointments/consultation_models_test.go
+++ b/services/appointments-service/internal/appointments/consultation_models_test.go
@@ -92,6 +92,7 @@ func TestConsultationStatusIsValid(t *testing.T) {
 		want   bool
 	}{
 		{name: "scheduled is valid", status: ConsultationStatusScheduled, want: true},
+		{name: "requested is valid", status: ConsultationStatusRequested, want: true},
 		{name: "checked_in is valid", status: ConsultationStatusCheckedIn, want: true},
 		{name: "completed is valid", status: ConsultationStatusCompleted, want: true},
 		{name: "cancelled is valid", status: ConsultationStatusCancelled, want: true},
@@ -122,7 +123,7 @@ func TestConsultationSourceIsValid(t *testing.T) {
 		{name: "online is valid", source: ConsultationSourceOnline, want: true},
 		{name: "secretary is valid", source: ConsultationSourceSecretary, want: true},
 		{name: "doctor is valid", source: ConsultationSourceDoctor, want: true},
-		{name: "patient is invalid", source: ConsultationSource("patient"), want: false},
+		{name: "patient is valid", source: ConsultationSourcePatient, want: true},
 		{name: "empty is invalid", source: ConsultationSource(""), want: false},
 	}
 

--- a/services/appointments-service/internal/appointments/consultation_repository_test.go
+++ b/services/appointments-service/internal/appointments/consultation_repository_test.go
@@ -138,6 +138,56 @@ func TestCreateConsultationAllowsNilSlotIDWithStandaloneScheduleRange(t *testing
 	}
 }
 
+func TestCreateConsultationAllowsRequestedPatientSource(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledStart := time.Date(2026, time.April, 16, 10, 0, 0, 0, time.UTC)
+	scheduledEnd := time.Date(2026, time.April, 16, 10, 1, 0, 0, time.UTC)
+	notes := "Prefiero turno por la tarde"
+
+	repo := NewRepository(newScriptedDB(t, []scriptedQueryResult{{
+		row: newConsultationRow(
+			"550e8400-e29b-41d4-a716-446655440214",
+			nil,
+			"550e8400-e29b-41d4-a716-446655440211",
+			"550e8400-e29b-41d4-a716-446655440212",
+			ConsultationStatusRequested,
+			ConsultationSourcePatient,
+			&notes,
+			scheduledStart,
+			scheduledEnd,
+			nil,
+			nil,
+			now,
+			now,
+			nil,
+		),
+	}}))
+
+	consultation, err := repo.CreateConsultation(context.Background(), CreateConsultationParams{
+		ProfessionalID: "550e8400-e29b-41d4-a716-446655440211",
+		PatientID:      "550e8400-e29b-41d4-a716-446655440212",
+		Status:         ConsultationStatusRequested,
+		Source:         ConsultationSourcePatient,
+		ScheduledStart: &scheduledStart,
+		ScheduledEnd:   &scheduledEnd,
+		Notes:          &notes,
+	})
+	if err != nil {
+		t.Fatalf("CreateConsultation error = %v", err)
+	}
+	if consultation.Status != ConsultationStatusRequested {
+		t.Fatalf("status = %q, want %q", consultation.Status, ConsultationStatusRequested)
+	}
+	if consultation.Source != ConsultationSourcePatient {
+		t.Fatalf("source = %q, want %q", consultation.Source, ConsultationSourcePatient)
+	}
+	if consultation.SlotID != nil {
+		t.Fatalf("slot_id = %v, want nil", consultation.SlotID)
+	}
+}
+
 func TestGetConsultationReturnsConsultation(t *testing.T) {
 	t.Parallel()
 

--- a/services/appointments-service/internal/appointments/repository.go
+++ b/services/appointments-service/internal/appointments/repository.go
@@ -82,6 +82,7 @@ type CreateConsultationParams struct {
 	SlotID         *string            `json:"slot_id,omitempty"`
 	ProfessionalID string             `json:"professional_id"`
 	PatientID      string             `json:"patient_id"`
+	Status         ConsultationStatus `json:"status,omitempty"`
 	Source         ConsultationSource `json:"source"`
 	ScheduledStart *time.Time         `json:"scheduled_start,omitempty"`
 	ScheduledEnd   *time.Time         `json:"scheduled_end,omitempty"`
@@ -456,28 +457,29 @@ func (r *Repository) CreateConsultation(ctx context.Context, params CreateConsul
 	}
 
 	query := `
-		INSERT INTO consultations (slot_id, professional_id, patient_id, source, scheduled_start, scheduled_end, notes)
-		SELECT NULL, $1, $2, $3, $4, $5, $6
+		INSERT INTO consultations (slot_id, professional_id, patient_id, status, source, scheduled_start, scheduled_end, notes)
+		SELECT NULL, $1, $2, $3, $4, $5, $6, $7
 		WHERE NOT EXISTS (
 			SELECT 1
 			FROM consultations
 			WHERE professional_id = $1
+			  AND $3 IN ('scheduled', 'checked_in')
 			  AND status IN ('scheduled', 'checked_in')
-			  AND scheduled_start < $5
-			  AND scheduled_end > $4
+			  AND scheduled_start < $6
+			  AND scheduled_end > $5
 		)
 		RETURNING id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
 	`
-	args := []any{validated.professionalID, validated.patientID, validated.source, validated.scheduledStart, validated.scheduledEnd, validated.notes}
+	args := []any{validated.professionalID, validated.patientID, validated.status, validated.source, validated.scheduledStart, validated.scheduledEnd, validated.notes}
 	if validated.slotID != nil {
 		query = `
-			INSERT INTO consultations (slot_id, professional_id, patient_id, source, scheduled_start, scheduled_end, notes)
-			SELECT $1, $2, $3, $4, start_time, end_time, $5
+			INSERT INTO consultations (slot_id, professional_id, patient_id, status, source, scheduled_start, scheduled_end, notes)
+			SELECT $1, $2, $3, $4, $5, start_time, end_time, $6
 			FROM availability_slots
 			WHERE id = $1 AND professional_id = $2
 			RETURNING id, slot_id, professional_id, patient_id, status, source, notes, scheduled_start, scheduled_end, check_in_time, reception_notes, created_at, updated_at, cancelled_at
 		`
-		args = []any{validated.slotID, validated.professionalID, validated.patientID, validated.source, validated.notes}
+		args = []any{validated.slotID, validated.professionalID, validated.patientID, validated.status, validated.source, validated.notes}
 	}
 
 	consultation, err := scanConsultation(r.db.QueryRowContext(ctx, query, args...))
@@ -1486,6 +1488,7 @@ type validatedCreateConsultationParams struct {
 	professionalID string
 	patientID      string
 	source         ConsultationSource
+	status         ConsultationStatus
 	scheduledStart time.Time
 	scheduledEnd   time.Time
 	notes          *string
@@ -1506,6 +1509,13 @@ func validateCreateConsultationParams(params CreateConsultationParams) (validate
 	if _, err := uuid.Parse(patientID); err != nil {
 		return validatedCreateConsultationParams{}, ErrValidation
 	}
+	status := params.Status
+	if status == "" {
+		status = ConsultationStatusScheduled
+	}
+	if !status.IsValid() {
+		return validatedCreateConsultationParams{}, ErrValidation
+	}
 	if !params.Source.IsValid() {
 		return validatedCreateConsultationParams{}, ErrValidation
 	}
@@ -1514,6 +1524,7 @@ func validateCreateConsultationParams(params CreateConsultationParams) (validate
 		professionalID: professionalID,
 		patientID:      patientID,
 		source:         params.Source,
+		status:         status,
 	}
 
 	if params.SlotID != nil {

--- a/services/appointments-service/internal/directory/client.go
+++ b/services/appointments-service/internal/directory/client.go
@@ -15,6 +15,7 @@ import (
 var (
 	ErrUnavailable  = errors.New("directory service unavailable")
 	ErrUnauthorized = errors.New("directory unauthorized")
+	ErrNotFound     = errors.New("directory resource not found")
 )
 
 type User struct {
@@ -25,6 +26,12 @@ type User struct {
 	Active         bool       `json:"active"`
 	CreatedAt      *time.Time `json:"created_at,omitempty"`
 	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
+}
+
+type Patient struct {
+	ID       string `json:"id"`
+	Document string `json:"document"`
+	Active   bool   `json:"active"`
 }
 
 type Client struct {
@@ -57,6 +64,38 @@ func (c *Client) ProfessionalExists(ctx context.Context, professionalID string) 
 
 func (c *Client) PatientExists(ctx context.Context, patientID string) (bool, error) {
 	return c.lookup(ctx, path.Join("patients", patientID))
+}
+
+func (c *Client) PatientByDocument(ctx context.Context, document string) (Patient, error) {
+	endpoint := *c.baseURL
+	endpoint.Path = path.Join(c.baseURL.Path, "internal", "patients", "by-document")
+	query := endpoint.Query()
+	query.Set("document", strings.TrimSpace(document))
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return Patient{}, fmt.Errorf("create directory request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return Patient{}, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var patient Patient
+		if err := json.NewDecoder(resp.Body).Decode(&patient); err != nil {
+			return Patient{}, fmt.Errorf("decode patient: %w", err)
+		}
+		return patient, nil
+	case http.StatusNotFound:
+		return Patient{}, ErrNotFound
+	default:
+		return Patient{}, fmt.Errorf("%w: status %d", ErrUnavailable, resp.StatusCode)
+	}
 }
 
 func (c *Client) CurrentUser(ctx context.Context, bearer string) (User, error) {

--- a/services/appointments-service/internal/http/server.go
+++ b/services/appointments-service/internal/http/server.go
@@ -67,6 +67,22 @@ type createConsultationRequest struct {
 	Notes          *string                         `json:"notes,omitempty"`
 }
 
+type createPatientRequestRequest struct {
+	Document       string     `json:"document"`
+	ProfessionalID string     `json:"professional_id"`
+	Notes          *string    `json:"notes,omitempty"`
+	Contact        *string    `json:"contact,omitempty"`
+	ScheduledStart *time.Time `json:"scheduled_start,omitempty"`
+	ScheduledEnd   *time.Time `json:"scheduled_end,omitempty"`
+}
+
+type publicAvailabilitySlot struct {
+	ID             string    `json:"id,omitempty"`
+	ProfessionalID string    `json:"professional_id"`
+	StartTime      time.Time `json:"start_time"`
+	EndTime        time.Time `json:"end_time"`
+}
+
 type createBlockRequest struct {
 	ProfessionalID string  `json:"professional_id"`
 	Scope          string  `json:"scope"`
@@ -103,6 +119,7 @@ type directoryLookup interface {
 	CurrentUser(ctx context.Context, bearer string) (directory.User, error)
 	ProfessionalExists(ctx context.Context, professionalID string) (bool, error)
 	PatientExists(ctx context.Context, patientID string) (bool, error)
+	PatientByDocument(ctx context.Context, document string) (directory.Patient, error)
 }
 
 type ActorContext struct {
@@ -138,9 +155,29 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/blocks", s.blocks)
 	s.mux.HandleFunc("/blocks/", s.blockByID)
 	s.mux.HandleFunc("/consultations", s.consultations)
+	s.mux.HandleFunc("/patient-requests", s.patientRequests)
+	s.mux.HandleFunc("/public/availability", s.publicAvailability)
 	s.mux.HandleFunc("/agenda/week", s.agendaWeek)
 	s.mux.HandleFunc("/appointments", s.appointments)
 	s.mux.HandleFunc("/appointments/", s.appointmentByIDAction)
+}
+
+func (s *Server) publicAvailability(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	s.getPublicAvailability(w, r)
+}
+
+func (s *Server) patientRequests(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	s.createPatientRequest(w, r)
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
@@ -825,6 +862,201 @@ func (s *Server) createConsultation(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, consultation)
 }
 
+func (s *Server) createPatientRequest(w http.ResponseWriter, r *http.Request) {
+	var request createPatientRequestRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	params, err := validateCreatePatientRequest(request)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid patient request")
+		return
+	}
+
+	patient, err := s.dir.PatientByDocument(r.Context(), params.Document)
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "patient not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+
+	professionalExists, err := s.dir.ProfessionalExists(r.Context(), params.ProfessionalID)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "directory service unavailable")
+		return
+	}
+	if !professionalExists {
+		writeError(w, http.StatusBadRequest, "professional not found")
+		return
+	}
+
+	status := appointments.ConsultationStatusRequested
+	scheduledStart := params.ScheduledStart
+	scheduledEnd := params.ScheduledEnd
+	if scheduledStart != nil && scheduledEnd != nil {
+		status = appointments.ConsultationStatusScheduled
+	} else {
+		now := time.Now().UTC()
+		requestEnd := now.Add(time.Minute)
+		scheduledStart = &now
+		scheduledEnd = &requestEnd
+	}
+	consultation, err := s.repo.CreateConsultation(r.Context(), appointments.CreateConsultationParams{
+		ProfessionalID: params.ProfessionalID,
+		PatientID:      patient.ID,
+		Status:         status,
+		Source:         appointments.ConsultationSourcePatient,
+		ScheduledStart: scheduledStart,
+		ScheduledEnd:   scheduledEnd,
+		Notes:          params.Notes,
+	})
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid patient request")
+		return
+	}
+	if errors.Is(err, appointments.ErrConflict) {
+		writeError(w, http.StatusConflict, "patient request conflicts with existing schedule")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create patient request")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, consultation)
+}
+
+func (s *Server) getPublicAvailability(w http.ResponseWriter, r *http.Request) {
+	professionalID := strings.TrimSpace(r.URL.Query().Get("professional_id"))
+	weekStart, err := validateAgendaWeekFilters(professionalID, r.URL.Query().Get("week_start"))
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid availability filters")
+		return
+	}
+
+	blocks, err := s.repo.ListScheduleBlocks(r.Context(), appointments.ScheduleBlockFilters{ProfessionalID: professionalID})
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid availability filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load availability")
+		return
+	}
+
+	consultations, err := s.repo.ListConsultations(r.Context(), appointments.ConsultationFilters{
+		ProfessionalID: professionalID,
+		WeekStart:      weekStart.Format("2006-01-02"),
+	})
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid availability filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load availability")
+		return
+	}
+
+	templates, err := s.loadWeekAgendaTemplates(r.Context(), professionalID, weekStart)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid availability filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load availability")
+		return
+	}
+
+	agenda, err := appointments.ComposeWeekAgenda(professionalID, weekStart, templates, blocks, consultations)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid availability filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load availability")
+		return
+	}
+
+	persistedSlots, err := s.loadPublicAvailabilityPersistedSlots(r.Context(), professionalID, weekStart)
+	if errors.Is(err, appointments.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "invalid availability filters")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load availability")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"items": filterPublicAvailability(mergePersistedPublicSlotIDs(agenda.Slots, persistedSlots), agenda.Consultations)})
+}
+
+func (s *Server) loadPublicAvailabilityPersistedSlots(ctx context.Context, professionalID string, weekStart time.Time) ([]appointments.AvailabilitySlot, error) {
+	slots := make([]appointments.AvailabilitySlot, 0)
+	for dayOffset := 0; dayOffset < 7; dayOffset++ {
+		date := weekStart.AddDate(0, 0, dayOffset).Format("2006-01-02")
+		items, err := s.repo.ListSlots(ctx, appointments.SlotFilters{ProfessionalID: professionalID, Status: "available", Date: date})
+		if err != nil {
+			return nil, err
+		}
+		slots = append(slots, items...)
+	}
+	return slots, nil
+}
+
+func mergePersistedPublicSlotIDs(generated []appointments.AvailabilitySlot, persisted []appointments.AvailabilitySlot) []appointments.AvailabilitySlot {
+	idsByRange := make(map[string]string, len(persisted))
+	for _, slot := range persisted {
+		idsByRange[slotRangeKey(slot)] = slot.ID
+	}
+
+	merged := make([]appointments.AvailabilitySlot, 0, len(generated))
+	for _, slot := range generated {
+		if id := idsByRange[slotRangeKey(slot)]; id != "" {
+			slot.ID = id
+		}
+		merged = append(merged, slot)
+	}
+	return merged
+}
+
+func slotRangeKey(slot appointments.AvailabilitySlot) string {
+	return slot.ProfessionalID + "|" + slot.StartTime.UTC().Format(time.RFC3339Nano) + "|" + slot.EndTime.UTC().Format(time.RFC3339Nano)
+}
+
+func filterPublicAvailability(slots []appointments.AvailabilitySlot, consultations []appointments.Consultation) []publicAvailabilitySlot {
+	items := make([]publicAvailabilitySlot, 0, len(slots))
+	for _, slot := range slots {
+		if publicSlotOverlapsConsultation(slot, consultations) {
+			continue
+		}
+		items = append(items, publicAvailabilitySlot{
+			ID:             slot.ID,
+			ProfessionalID: slot.ProfessionalID,
+			StartTime:      slot.StartTime,
+			EndTime:        slot.EndTime,
+		})
+	}
+
+	return items
+}
+
+func publicSlotOverlapsConsultation(slot appointments.AvailabilitySlot, consultations []appointments.Consultation) bool {
+	for _, consultation := range consultations {
+		if consultation.Status != appointments.ConsultationStatusScheduled && consultation.Status != appointments.ConsultationStatusCheckedIn {
+			continue
+		}
+		if slot.StartTime.Before(consultation.ScheduledEnd) && consultation.ScheduledStart.Before(slot.EndTime) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) getConsultation(w http.ResponseWriter, r *http.Request) {
 	actor, ok := s.requireAgendaActor(w, r)
 	if !ok {
@@ -1165,6 +1397,53 @@ func validateCreateConsultationRequest(params appointments.CreateConsultationPar
 	}
 
 	return params, nil
+}
+
+func validateCreatePatientRequest(request createPatientRequestRequest) (createPatientRequestRequest, error) {
+	document := strings.TrimSpace(request.Document)
+	professionalID := strings.TrimSpace(request.ProfessionalID)
+	if document == "" {
+		return createPatientRequestRequest{}, appointments.ErrValidation
+	}
+	if _, err := uuid.Parse(professionalID); err != nil {
+		return createPatientRequestRequest{}, appointments.ErrValidation
+	}
+
+	var notes *string
+	if request.Notes != nil || request.Contact != nil {
+		parts := make([]string, 0, 2)
+		if request.Notes != nil {
+			if value := strings.TrimSpace(*request.Notes); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		if request.Contact != nil {
+			if value := strings.TrimSpace(*request.Contact); value != "" {
+				parts = append(parts, "Contacto: "+value)
+			}
+		}
+		if len(parts) > 0 {
+			joined := strings.Join(parts, ". ")
+			notes = &joined
+		}
+	}
+
+	if (request.ScheduledStart == nil) != (request.ScheduledEnd == nil) {
+		return createPatientRequestRequest{}, appointments.ErrValidation
+	}
+	var scheduledStart *time.Time
+	var scheduledEnd *time.Time
+	if request.ScheduledStart != nil && request.ScheduledEnd != nil {
+		start := request.ScheduledStart.UTC()
+		end := request.ScheduledEnd.UTC()
+		if !start.Before(end) {
+			return createPatientRequestRequest{}, appointments.ErrValidation
+		}
+		scheduledStart = &start
+		scheduledEnd = &end
+	}
+
+	return createPatientRequestRequest{Document: document, ProfessionalID: professionalID, Notes: notes, ScheduledStart: scheduledStart, ScheduledEnd: scheduledEnd}, nil
 }
 
 func validateCreateBlockRequest(params appointments.CreateScheduleBlockParams) error {

--- a/services/appointments-service/internal/http/server_test.go
+++ b/services/appointments-service/internal/http/server_test.go
@@ -1402,6 +1402,138 @@ func TestCreateConsultationPostScenarios(t *testing.T) {
 	}
 }
 
+func TestPatientRequestPostScenarios(t *testing.T) {
+	const (
+		validPatientID      = "550e8400-e29b-41d4-a716-446655440503"
+		validProfessionalID = "550e8400-e29b-41d4-a716-446655440504"
+	)
+
+	createdAt := time.Date(2026, time.April, 16, 9, 0, 0, 0, time.UTC)
+	requestedStart := createdAt
+	requestedEnd := createdAt.Add(time.Minute)
+	notes := "Prefiero turno por la tarde. Contacto: 11-5555"
+	createdRequest := appointments.Consultation{
+		ID:             "550e8400-e29b-41d4-a716-446655440501",
+		ProfessionalID: validProfessionalID,
+		PatientID:      validPatientID,
+		Status:         appointments.ConsultationStatusRequested,
+		Source:         appointments.ConsultationSourcePatient,
+		ScheduledStart: requestedStart,
+		ScheduledEnd:   requestedEnd,
+		Notes:          &notes,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+
+	tests := []struct {
+		name                 string
+		body                 string
+		directory            stubDirectoryLookup
+		repoErr              error
+		wantStatus           int
+		wantError            string
+		wantDocumentLookups  int
+		wantProfessionalHits int
+		wantRepoCalls        int
+	}{
+		{
+			name:                 "invalid document returns bad request",
+			body:                 `{"document":" ","professional_id":"` + validProfessionalID + `"}`,
+			wantStatus:           http.StatusBadRequest,
+			wantError:            "invalid patient request",
+			wantDocumentLookups:  0,
+			wantProfessionalHits: 0,
+			wantRepoCalls:        0,
+		},
+		{
+			name: "patient document not found returns not found without leaking profile data",
+			body: `{"document":"12345678","professional_id":"` + validProfessionalID + `"}`,
+			directory: stubDirectoryLookup{
+				patientDocumentErr: directory.ErrNotFound,
+			},
+			wantStatus:           http.StatusNotFound,
+			wantError:            "patient not found",
+			wantDocumentLookups:  1,
+			wantProfessionalHits: 0,
+			wantRepoCalls:        0,
+		},
+		{
+			name: "success creates public requested patient consultation",
+			body: `{"document":" 12345678 ","professional_id":"` + validProfessionalID + `","notes":"Prefiero turno por la tarde","contact":"11-5555"}`,
+			directory: stubDirectoryLookup{
+				professionalExists: true,
+				patientByDocument:  directory.Patient{ID: validPatientID, Document: "12345678", Active: true},
+			},
+			wantStatus:           http.StatusCreated,
+			wantDocumentLookups:  1,
+			wantProfessionalHits: 1,
+			wantRepoCalls:        1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.directory
+			repo := &stubAppointmentsRepository{
+				createConsultationFn: func(_ context.Context, params appointments.CreateConsultationParams) (appointments.Consultation, error) {
+					if params.PatientID != validPatientID {
+						t.Fatalf("patient_id = %q, want %q", params.PatientID, validPatientID)
+					}
+					if params.ProfessionalID != validProfessionalID {
+						t.Fatalf("professional_id = %q, want %q", params.ProfessionalID, validProfessionalID)
+					}
+					if params.Source != appointments.ConsultationSourcePatient {
+						t.Fatalf("source = %q, want %q", params.Source, appointments.ConsultationSourcePatient)
+					}
+					if params.Status != appointments.ConsultationStatusRequested {
+						t.Fatalf("status = %q, want %q", params.Status, appointments.ConsultationStatusRequested)
+					}
+					if params.SlotID != nil {
+						t.Fatalf("slot_id = %v, want nil", params.SlotID)
+					}
+					if params.Notes == nil || *params.Notes != notes {
+						t.Fatalf("notes = %v, want %q", params.Notes, notes)
+					}
+					return createdRequest, tt.repoErr
+				},
+			}
+			server := NewServer(testAppointmentsConfig(), repo, &dir)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/patient-requests", bytes.NewBufferString(tt.body)))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if dir.patientDocumentCalls != tt.wantDocumentLookups {
+				t.Fatalf("PatientByDocument calls = %d, want %d", dir.patientDocumentCalls, tt.wantDocumentLookups)
+			}
+			if dir.professionalCalls != tt.wantProfessionalHits {
+				t.Fatalf("ProfessionalExists calls = %d, want %d", dir.professionalCalls, tt.wantProfessionalHits)
+			}
+			if repo.createConsultationCalls != tt.wantRepoCalls {
+				t.Fatalf("CreateConsultation calls = %d, want %d", repo.createConsultationCalls, tt.wantRepoCalls)
+			}
+
+			if tt.wantError != "" {
+				assertErrorResponse(t, recorder.Body, tt.wantError)
+				return
+			}
+
+			var response appointments.Consultation
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.PatientID != validPatientID || response.Status != appointments.ConsultationStatusRequested || response.Source != appointments.ConsultationSourcePatient {
+				t.Fatalf("response = %+v, want requested patient consultation", response)
+			}
+			if strings.Contains(recorder.Body.String(), "12345678") {
+				t.Fatalf("response leaked patient document: %s", recorder.Body.String())
+			}
+		})
+	}
+}
+
 func TestGetConsultationScenarios(t *testing.T) {
 	const (
 		validConsultationID = "550e8400-e29b-41d4-a716-446655440411"
@@ -1852,6 +1984,190 @@ func TestGetAgendaWeekReturnsEmptyScheduleWhenNoTemplateExists(t *testing.T) {
 	}
 }
 
+func TestGetPublicAvailabilityReturnsOnlySafeAvailableSlots(t *testing.T) {
+	t.Parallel()
+
+	const professionalID = "550e8400-e29b-41d4-a716-446655440030"
+	templateID := "550e8400-e29b-41d4-a716-446655440031"
+	weekStart := time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC)
+	version := appointments.ScheduleTemplateVersion{
+		ID:            "550e8400-e29b-41d4-a716-446655440032",
+		TemplateID:    templateID,
+		VersionNumber: 1,
+		EffectiveFrom: weekStart,
+		Recurrence:    json.RawMessage(`{"monday":{"start_time":"09:00","end_time":"10:00","slot_duration_minutes":30}}`),
+		CreatedAt:     weekStart.Add(-24 * time.Hour),
+	}
+	occupiedStart := weekStart.Add(9 * time.Hour)
+	occupiedEnd := occupiedStart.Add(30 * time.Minute)
+	privateNote := "private note"
+
+	repo := &stubAppointmentsRepository{
+		getActiveTemplateFn: func(_ context.Context, gotProfessionalID, effectiveDate string) (appointments.ScheduleTemplateVersion, error) {
+			if gotProfessionalID != professionalID {
+				t.Fatalf("professionalID = %q, want %q", gotProfessionalID, professionalID)
+			}
+			if effectiveDate != "2026-04-12" {
+				t.Fatalf("effectiveDate = %q, want %q", effectiveDate, "2026-04-12")
+			}
+			return version, nil
+		},
+		getTemplateFn: func(_ context.Context, gotTemplateID string) (appointments.ScheduleTemplate, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("templateID = %q, want %q", gotTemplateID, templateID)
+			}
+			return appointments.ScheduleTemplate{ID: templateID, ProfessionalID: professionalID, CreatedAt: weekStart.Add(-48 * time.Hour), UpdatedAt: weekStart.Add(-24 * time.Hour)}, nil
+		},
+		listTemplateVersionsFn: func(_ context.Context, gotTemplateID string) ([]appointments.ScheduleTemplateVersion, error) {
+			if gotTemplateID != templateID {
+				t.Fatalf("templateID = %q, want %q", gotTemplateID, templateID)
+			}
+			return []appointments.ScheduleTemplateVersion{version}, nil
+		},
+		listScheduleBlocksFn: func(_ context.Context, filters appointments.ScheduleBlockFilters) ([]appointments.ScheduleBlock, error) {
+			if filters.ProfessionalID != professionalID {
+				t.Fatalf("filters.ProfessionalID = %q, want %q", filters.ProfessionalID, professionalID)
+			}
+			return nil, nil
+		},
+		listConsultationsFn: func(_ context.Context, filters appointments.ConsultationFilters) ([]appointments.Consultation, error) {
+			if filters.ProfessionalID != professionalID || filters.WeekStart != "2026-04-06" {
+				t.Fatalf("filters = %+v, want professional %q week 2026-04-06", filters, professionalID)
+			}
+			return []appointments.Consultation{
+				{
+					ID:             "550e8400-e29b-41d4-a716-446655440033",
+					ProfessionalID: professionalID,
+					PatientID:      "550e8400-e29b-41d4-a716-446655440034",
+					Status:         appointments.ConsultationStatusScheduled,
+					Source:         appointments.ConsultationSourceSecretary,
+					ScheduledStart: occupiedStart,
+					ScheduledEnd:   occupiedEnd,
+					Notes:          &privateNote,
+				},
+				{
+					ID:             "550e8400-e29b-41d4-a716-446655440036",
+					ProfessionalID: professionalID,
+					PatientID:      "550e8400-e29b-41d4-a716-446655440037",
+					Status:         appointments.ConsultationStatusRequested,
+					Source:         appointments.ConsultationSourcePatient,
+					ScheduledStart: weekStart.Add(9*time.Hour + 30*time.Minute),
+					ScheduledEnd:   weekStart.Add(9*time.Hour + 31*time.Minute),
+				},
+			}, nil
+		},
+		listSlotsFn: func(_ context.Context, filters appointments.SlotFilters) ([]appointments.AvailabilitySlot, error) {
+			if filters.ProfessionalID != professionalID || filters.Status != "available" {
+				t.Fatalf("slot filters = %+v, want professional %q available", filters, professionalID)
+			}
+			if filters.Date == "2026-04-06" {
+				return []appointments.AvailabilitySlot{{
+					ID:             "550e8400-e29b-41d4-a716-446655440035",
+					ProfessionalID: professionalID,
+					StartTime:      weekStart.Add(9*time.Hour + 30*time.Minute),
+					EndTime:        weekStart.Add(10 * time.Hour),
+					Status:         "available",
+				}}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	server := NewServer(testAppointmentsConfig(), repo, &stubDirectoryLookup{})
+	recorder := httptest.NewRecorder()
+
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/public/availability?professional_id="+professionalID+"&week_start=2026-04-06", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	var response struct {
+		Items []struct {
+			ID             string `json:"id,omitempty"`
+			ProfessionalID string `json:"professional_id"`
+			StartTime      string `json:"start_time"`
+			EndTime        string `json:"end_time"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("items len = %d, want 1: %+v", len(response.Items), response.Items)
+	}
+	if response.Items[0].ID != "550e8400-e29b-41d4-a716-446655440035" || response.Items[0].ProfessionalID != professionalID || response.Items[0].StartTime != "2026-04-06T09:30:00Z" || response.Items[0].EndTime != "2026-04-06T10:00:00Z" {
+		t.Fatalf("item = %+v, want only the free 09:30 slot", response.Items[0])
+	}
+	body := recorder.Body.String()
+	for _, forbidden := range []string{"consultations", "patient_id", "notes", "private note", "blocks", "templates", "status"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("public availability leaked %q in body: %s", forbidden, body)
+		}
+	}
+}
+
+func TestPatientRequestDirectBookingCreatesScheduledConsultation(t *testing.T) {
+	const (
+		validPatientID      = "550e8400-e29b-41d4-a716-446655440513"
+		validProfessionalID = "550e8400-e29b-41d4-a716-446655440514"
+	)
+	scheduledStart := time.Date(2026, time.April, 20, 14, 0, 0, 0, time.UTC)
+	scheduledEnd := scheduledStart.Add(30 * time.Minute)
+	created := appointments.Consultation{
+		ID:             "550e8400-e29b-41d4-a716-446655440515",
+		ProfessionalID: validProfessionalID,
+		PatientID:      validPatientID,
+		Status:         appointments.ConsultationStatusScheduled,
+		Source:         appointments.ConsultationSourcePatient,
+		ScheduledStart: scheduledStart,
+		ScheduledEnd:   scheduledEnd,
+	}
+	dir := stubDirectoryLookup{
+		professionalExists: true,
+		patientByDocument:  directory.Patient{ID: validPatientID, Document: "12345678", Active: true},
+	}
+	repo := &stubAppointmentsRepository{
+		createConsultationFn: func(_ context.Context, params appointments.CreateConsultationParams) (appointments.Consultation, error) {
+			if params.PatientID != validPatientID || params.ProfessionalID != validProfessionalID {
+				t.Fatalf("params patient/professional = %q/%q", params.PatientID, params.ProfessionalID)
+			}
+			if params.Status != appointments.ConsultationStatusScheduled {
+				t.Fatalf("status = %q, want %q", params.Status, appointments.ConsultationStatusScheduled)
+			}
+			if params.Source != appointments.ConsultationSourcePatient {
+				t.Fatalf("source = %q, want %q", params.Source, appointments.ConsultationSourcePatient)
+			}
+			if params.ScheduledStart == nil || !params.ScheduledStart.Equal(scheduledStart) {
+				t.Fatalf("scheduled_start = %v, want %v", params.ScheduledStart, scheduledStart)
+			}
+			if params.ScheduledEnd == nil || !params.ScheduledEnd.Equal(scheduledEnd) {
+				t.Fatalf("scheduled_end = %v, want %v", params.ScheduledEnd, scheduledEnd)
+			}
+			return created, nil
+		},
+	}
+
+	server := NewServer(testAppointmentsConfig(), repo, &dir)
+	recorder := httptest.NewRecorder()
+	body := `{"document":"12345678","professional_id":"` + validProfessionalID + `","scheduled_start":"2026-04-20T14:00:00Z","scheduled_end":"2026-04-20T14:30:00Z"}`
+
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/patient-requests", bytes.NewBufferString(body)))
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusCreated)
+	}
+	if repo.createConsultationCalls != 1 {
+		t.Fatalf("CreateConsultation calls = %d, want 1", repo.createConsultationCalls)
+	}
+	var response appointments.Consultation
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Status != appointments.ConsultationStatusScheduled || response.Source != appointments.ConsultationSourcePatient {
+		t.Fatalf("response = %+v, want scheduled patient consultation", response)
+	}
+}
+
 func TestListSlotsReturnsBadRequestOnInvalidFilters(t *testing.T) {
 	repo := &stubAppointmentsRepository{
 		listSlotsFn: func(context.Context, appointments.SlotFilters) ([]appointments.AvailabilitySlot, error) {
@@ -2169,15 +2485,18 @@ type stubAppointmentsRepository struct {
 }
 
 type stubDirectoryLookup struct {
-	currentUser        directory.User
-	currentUserErr     error
-	professionalExists bool
-	professionalErr    error
-	patientExists      bool
-	patientErr         error
-	currentUserCalls   int
-	professionalCalls  int
-	patientCalls       int
+	currentUser          directory.User
+	currentUserErr       error
+	professionalExists   bool
+	professionalErr      error
+	patientExists        bool
+	patientErr           error
+	patientByDocument    directory.Patient
+	patientDocumentErr   error
+	currentUserCalls     int
+	professionalCalls    int
+	patientCalls         int
+	patientDocumentCalls int
 }
 
 func (s *stubDirectoryLookup) CurrentUser(context.Context, string) (directory.User, error) {
@@ -2205,6 +2524,14 @@ func (s *stubDirectoryLookup) PatientExists(context.Context, string) (bool, erro
 		return false, s.patientErr
 	}
 	return s.patientExists, nil
+}
+
+func (s *stubDirectoryLookup) PatientByDocument(context.Context, string) (directory.Patient, error) {
+	s.patientDocumentCalls++
+	if s.patientDocumentErr != nil {
+		return directory.Patient{}, s.patientDocumentErr
+	}
+	return s.patientByDocument, nil
 }
 
 func (s *stubAppointmentsRepository) CreateSlotsBulk(ctx context.Context, params appointments.BulkCreateSlotsParams) ([]appointments.AvailabilitySlot, error) {

--- a/services/appointments-service/migrations/001_init.sql
+++ b/services/appointments-service/migrations/001_init.sql
@@ -39,12 +39,12 @@ CREATE TABLE consultations (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     cancelled_at TIMESTAMPTZ,
     CONSTRAINT consultations_slot_fk FOREIGN KEY (slot_id) REFERENCES availability_slots(id),
-    CONSTRAINT consultations_status_valid CHECK (status IN ('scheduled', 'checked_in', 'completed', 'cancelled', 'no_show')),
+    CONSTRAINT consultations_status_valid CHECK (status IN ('scheduled', 'requested', 'checked_in', 'completed', 'cancelled', 'no_show')),
     CONSTRAINT consultations_cancelled_at_consistency CHECK (
         (status = 'cancelled' AND cancelled_at IS NOT NULL) OR
-        (status IN ('scheduled', 'checked_in', 'completed', 'no_show') AND cancelled_at IS NULL)
+        (status IN ('scheduled', 'requested', 'checked_in', 'completed', 'no_show') AND cancelled_at IS NULL)
     ),
-    CONSTRAINT consultations_source_valid CHECK (source IN ('online', 'secretary', 'doctor')),
+    CONSTRAINT consultations_source_valid CHECK (source IN ('online', 'secretary', 'doctor', 'patient')),
     CONSTRAINT consultations_scheduled_range_valid CHECK (scheduled_start < scheduled_end)
 );
 

--- a/services/appointments-service/migrations/009_patient_request_flow.sql
+++ b/services/appointments-service/migrations/009_patient_request_flow.sql
@@ -1,0 +1,14 @@
+-- Patient request flow: allow patient-origin, request-first consultations.
+
+ALTER TABLE consultations
+    DROP CONSTRAINT IF EXISTS consultations_status_valid,
+    DROP CONSTRAINT IF EXISTS consultations_source_valid,
+    DROP CONSTRAINT IF EXISTS consultations_cancelled_at_consistency;
+
+ALTER TABLE consultations
+    ADD CONSTRAINT consultations_status_valid CHECK (status IN ('scheduled', 'requested', 'checked_in', 'completed', 'cancelled', 'no_show')),
+    ADD CONSTRAINT consultations_cancelled_at_consistency CHECK (
+        (status = 'cancelled' AND cancelled_at IS NOT NULL) OR
+        (status IN ('scheduled', 'requested', 'checked_in', 'completed', 'no_show') AND cancelled_at IS NULL)
+    ),
+    ADD CONSTRAINT consultations_source_valid CHECK (source IN ('online', 'secretary', 'doctor', 'patient'));

--- a/services/directory-service/internal/directory/repository.go
+++ b/services/directory-service/internal/directory/repository.go
@@ -146,6 +146,35 @@ func (r *Repository) GetPatientByID(ctx context.Context, id string) (Patient, er
 	return patient, err
 }
 
+func (r *Repository) GetPatientByDocument(ctx context.Context, document string) (Patient, error) {
+	validatedDocument, err := validatePatientDocumentLookup(document)
+	if err != nil {
+		return Patient{}, err
+	}
+
+	query := `
+		SELECT id, first_name, last_name, document, birth_date, phone, email, active, created_at, updated_at
+		FROM patients
+		WHERE document = $1
+	`
+
+	patient, err := scanPatient(r.db.QueryRowContext(ctx, query, validatedDocument))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Patient{}, ErrNotFound
+	}
+
+	return patient, err
+}
+
+func validatePatientDocumentLookup(document string) (string, error) {
+	validatedDocument := strings.TrimSpace(document)
+	if validatedDocument == "" {
+		return "", ErrValidation
+	}
+
+	return validatedDocument, nil
+}
+
 func (r *Repository) CreateProfessional(ctx context.Context, params CreateProfessionalParams) (Professional, error) {
 	normalized, err := validateCreateProfessionalParams(params)
 	if err != nil {

--- a/services/directory-service/internal/directory/repository_test.go
+++ b/services/directory-service/internal/directory/repository_test.go
@@ -169,3 +169,31 @@ func TestValidateCreateProfessionalParams(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePatientDocumentLookup(t *testing.T) {
+	tests := []struct {
+		name     string
+		document string
+		want     string
+		wantErr  error
+	}{
+		{name: "trims document", document: "  12345678  ", want: "12345678"},
+		{name: "rejects blank document", document: "   ", wantErr: ErrValidation},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validatePatientDocumentLookup(tt.document)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("document = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/services/directory-service/internal/http/server.go
+++ b/services/directory-service/internal/http/server.go
@@ -30,6 +30,7 @@ type directoryRepository interface {
 	CreatePatient(ctx context.Context, params directory.CreatePatientParams) (directory.Patient, error)
 	ListPatients(ctx context.Context) ([]directory.Patient, error)
 	GetPatientByID(ctx context.Context, id string) (directory.Patient, error)
+	GetPatientByDocument(ctx context.Context, document string) (directory.Patient, error)
 	CreateEncounter(ctx context.Context, params directory.CreateEncounterParams) (directory.Encounter, error)
 	ListPatientEncounters(ctx context.Context, patientID, professionalID string) ([]directory.Encounter, error)
 	CreateProfessional(ctx context.Context, params directory.CreateProfessionalParams) (directory.Professional, error)
@@ -63,6 +64,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/auth/me", s.me)
 	s.mux.HandleFunc("/patients", s.patients)
 	s.mux.HandleFunc("/patients/", s.patientByID)
+	s.mux.HandleFunc("/internal/patients/by-document", s.internalPatientByDocument)
+	s.mux.HandleFunc("/public/professionals", s.publicProfessionals)
 	s.mux.HandleFunc("/professionals", s.professionals)
 	s.mux.HandleFunc("/professionals/", s.professionalByID)
 }
@@ -266,6 +269,44 @@ func (s *Server) professionalByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, professional)
+}
+
+func (s *Server) internalPatientByDocument(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	patient, err := s.repo.GetPatientByDocument(r.Context(), r.URL.Query().Get("document"))
+	if errors.Is(err, directory.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "patient document is required")
+		return
+	}
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "patient not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load patient")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, patient)
+}
+
+func (s *Server) publicProfessionals(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	professionals, err := s.repo.ListProfessionals(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list professionals")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"items": professionals})
 }
 
 func (s *Server) createPatient(w http.ResponseWriter, r *http.Request) {

--- a/services/directory-service/internal/http/server_test.go
+++ b/services/directory-service/internal/http/server_test.go
@@ -646,10 +646,37 @@ func TestHealthReturnsStatusOK(t *testing.T) {
 	}
 }
 
+func TestInternalPatientByDocumentReturnsPatientWithoutAuth(t *testing.T) {
+	repo := &stubDirectoryRepository{
+		getPatientByDocumentFn: func(_ context.Context, document string) (directory.Patient, error) {
+			if document != "12345678" {
+				t.Fatalf("document = %q, want 12345678", document)
+			}
+			return directory.Patient{ID: "patient-1", Document: document, Active: true}, nil
+		},
+	}
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+
+	server.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/internal/patients/by-document?document=12345678", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	var patient directory.Patient
+	if err := json.NewDecoder(recorder.Body).Decode(&patient); err != nil {
+		t.Fatalf("decode patient: %v", err)
+	}
+	if patient.ID != "patient-1" || patient.Document != "12345678" {
+		t.Fatalf("patient = %+v, want patient-1 with document", patient)
+	}
+}
+
 type stubDirectoryRepository struct {
 	createPatientFn         func(context.Context, directory.CreatePatientParams) (directory.Patient, error)
 	listPatientsFn          func(context.Context) ([]directory.Patient, error)
 	getPatientByIDFn        func(context.Context, string) (directory.Patient, error)
+	getPatientByDocumentFn  func(context.Context, string) (directory.Patient, error)
 	createEncounterFn       func(context.Context, directory.CreateEncounterParams) (directory.Encounter, error)
 	listPatientEncountersFn func(context.Context, string, string) ([]directory.Encounter, error)
 	createProfessionalFn    func(context.Context, directory.CreateProfessionalParams) (directory.Professional, error)
@@ -679,6 +706,13 @@ func (s *stubDirectoryRepository) GetPatientByID(ctx context.Context, id string)
 		return directory.Patient{}, errors.New("unexpected GetPatientByID call")
 	}
 	return s.getPatientByIDFn(ctx, id)
+}
+
+func (s *stubDirectoryRepository) GetPatientByDocument(ctx context.Context, document string) (directory.Patient, error) {
+	if s.getPatientByDocumentFn == nil {
+		return directory.Patient{}, errors.New("unexpected GetPatientByDocument call")
+	}
+	return s.getPatientByDocumentFn(ctx, document)
 }
 
 func (s *stubDirectoryRepository) CreateEncounter(ctx context.Context, params directory.CreateEncounterParams) (directory.Encounter, error) {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -52,9 +52,33 @@ vi.mock('./features/directory/DirectoryDemo', () => ({
   DirectoryDemo: ({ directoryMode }: { directoryMode: { kind: string } }) => <div>directory:{directoryMode.kind}</div>,
 }));
 
+vi.mock('./features/patient-request/PatientRequestSurface', () => ({
+  PatientRequestSurface: () => <div>patient-request-surface</div>,
+}));
+
 describe('App actor-aware shell', () => {
   beforeEach(() => {
     useAuthSessionMock.mockReset();
+    window.location.hash = '';
+  });
+
+  it('renders patient request surface before login when the public hash is active', () => {
+    window.location.hash = '#patient-request';
+    useAuthSessionMock.mockReturnValue({
+      status: 'anonymous',
+      accessToken: null,
+      expiresAt: null,
+      user: null,
+      errorMessage: '',
+      isSubmitting: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    render(<App />);
+
+    expect(screen.getByText('patient-request-surface')).toBeInTheDocument();
+    expect(screen.queryByText('login-screen')).not.toBeInTheDocument();
   });
 
   it('shows agenda, weekly schedule and patients for doctors, defaulting to agenda', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,11 +4,13 @@ import { deriveActorCapabilities, resolveShellSurfaceMetadata, type SurfaceId } 
 import { useAuthSession } from './auth/useAuthSession';
 import { LoginScreen } from './features/auth/LoginScreen';
 import { DirectoryDemo } from './features/directory/DirectoryDemo';
+import { PatientRequestSurface } from './features/patient-request/PatientRequestSurface';
 import { PatientsWorkspace } from './features/patients/PatientsWorkspace';
 import { ScheduleDemo } from './features/schedule/ScheduleDemo';
 import { WeeklyScheduleWorkspace } from './features/schedule/WeeklyScheduleWorkspace';
 
 export default function App() {
+  const isPatientRequestRoute = typeof window !== 'undefined' && window.location.hash === '#patient-request';
   const auth = useAuthSession();
   const capabilities = useMemo(
     () => (auth.user ? deriveActorCapabilities(auth.user) : null),
@@ -45,6 +47,10 @@ export default function App() {
   const activeSurfaceDefinition = normalizedActiveSurface && capabilities
     ? { id: normalizedActiveSurface, ...resolveShellSurfaceMetadata(normalizedActiveSurface, capabilities) }
     : visibleSurfaces[0];
+
+  if (isPatientRequestRoute) {
+    return <PatientRequestSurface />;
+  }
 
   if (auth.status === 'loading') {
     return (

--- a/web/src/api/appointments.test.ts
+++ b/web/src/api/appointments.test.ts
@@ -221,4 +221,54 @@ describe('appointments API auth transport', () => {
 			appointments.fetchWeekAgenda({ professional_id: 'professional-1', week_start: '2026-04-06' }),
 		).rejects.toThrow('agenda unavailable');
 	});
+
+	it('creates patient requests without authenticated transport', async () => {
+		requestMock.mockResolvedValue({ id: 'request-1', status: 'requested', source: 'patient' });
+		const appointments = await import('./appointments');
+
+		await appointments.createPatientRequest({
+			document: '12345678',
+			professional_id: 'professional-1',
+			notes: 'Prefiero tarde',
+			contact: '11-5555',
+		});
+
+		expect(requestMock).toHaveBeenCalledWith('/appointments-api', '/patient-requests', {
+			method: 'POST',
+			body: {
+				document: '12345678',
+				professional_id: 'professional-1',
+				notes: 'Prefiero tarde',
+				contact: '11-5555',
+			},
+		});
+	});
+
+	it('loads public availability without authenticated transport', async () => {
+		requestMock.mockResolvedValue({
+			items: [
+				{
+					professional_id: 'professional-1',
+					start_time: '2026-04-20T14:00:00Z',
+					end_time: '2026-04-20T14:30:00Z',
+				},
+			],
+		});
+		const appointments = await import('./appointments');
+
+		await expect(
+			appointments.listPublicAvailability({ professional_id: 'professional-1', week_start: '2026-04-20' }),
+		).resolves.toEqual({
+			items: [
+				{
+					professional_id: 'professional-1',
+					start_time: '2026-04-20T14:00:00Z',
+					end_time: '2026-04-20T14:30:00Z',
+				},
+			],
+		});
+		expect(requestMock).toHaveBeenCalledWith('/appointments-api', '/public/availability', {
+			query: { professional_id: 'professional-1', week_start: '2026-04-20' },
+		});
+	});
 });

--- a/web/src/api/appointments.ts
+++ b/web/src/api/appointments.ts
@@ -6,10 +6,12 @@ import type {
   CreateScheduleTemplateVersionPayload,
   CreateAppointmentPayload,
   CreateConsultationPayload,
+  CreatePatientRequestPayload,
   UpdateConsultationStatusPayload,
   GetScheduleTemplateFilters,
   ListResponse,
   ListScheduleTemplateVersionFilters,
+  PublicAvailabilitySlot,
   ScheduleTemplate,
   ScheduleTemplateVersion,
   Slot,
@@ -33,6 +35,11 @@ type SlotFilters = {
 };
 
 type WeekAgendaFilters = {
+	professional_id: string;
+	week_start: string;
+};
+
+type PublicAvailabilityFilters = {
 	professional_id: string;
 	week_start: string;
 };
@@ -85,6 +92,17 @@ export function createConsultation(payload: CreateConsultationPayload) {
 		body: payload,
 		auth: true,
 	});
+}
+
+export function createPatientRequest(payload: CreatePatientRequestPayload) {
+	return request<Consultation>(APPOINTMENTS_API_BASE, '/patient-requests', {
+		method: 'POST',
+		body: payload,
+	});
+}
+
+export function listPublicAvailability(filters: PublicAvailabilityFilters) {
+	return request<ListResponse<PublicAvailabilitySlot>>(APPOINTMENTS_API_BASE, '/public/availability', { query: filters });
 }
 
 export function updateConsultationStatus(payload: UpdateConsultationStatusPayload) {

--- a/web/src/api/directory.ts
+++ b/web/src/api/directory.ts
@@ -15,6 +15,10 @@ export function listProfessionals() {
 	});
 }
 
+export function listPublicProfessionals() {
+	return request<ListResponse<Professional>>(DIRECTORY_API_BASE, '/public/professionals');
+}
+
 export function listPatients() {
 	return request<ListResponse<Patient>>(DIRECTORY_API_BASE, '/patients', {
 		auth: true,

--- a/web/src/features/patient-request/PatientRequestSurface.test.tsx
+++ b/web/src/features/patient-request/PatientRequestSurface.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PatientRequestSurface } from './PatientRequestSurface';
+
+const { createPatientRequestMock, listPublicAvailabilityMock, listPublicProfessionalsMock } = vi.hoisted(() => ({
+  createPatientRequestMock: vi.fn(),
+  listPublicAvailabilityMock: vi.fn(),
+  listPublicProfessionalsMock: vi.fn(),
+}));
+
+vi.mock('../../api/appointments', () => ({
+  createPatientRequest: createPatientRequestMock,
+  listPublicAvailability: listPublicAvailabilityMock,
+}));
+
+vi.mock('../../api/directory', () => ({
+  listPublicProfessionals: listPublicProfessionalsMock,
+}));
+
+describe('PatientRequestSurface', () => {
+  beforeEach(() => {
+    createPatientRequestMock.mockReset();
+    listPublicAvailabilityMock.mockReset();
+    listPublicProfessionalsMock.mockReset();
+    listPublicProfessionalsMock.mockResolvedValue({
+      items: [
+        {
+          id: 'professional-1',
+          first_name: 'Ana',
+          last_name: 'Lopez',
+          specialty: 'Cardiología',
+          active: true,
+          created_at: '2026-04-16T09:00:00Z',
+          updated_at: '2026-04-16T09:00:00Z',
+        },
+      ],
+    });
+    listPublicAvailabilityMock.mockResolvedValue({
+      items: [
+        {
+          professional_id: 'professional-1',
+          start_time: '2026-04-27T14:00:00Z',
+          end_time: '2026-04-27T14:30:00Z',
+        },
+        {
+          professional_id: 'professional-1',
+          start_time: '2026-04-28T15:00:00Z',
+          end_time: '2026-04-28T15:30:00Z',
+        },
+      ],
+    });
+  });
+
+  it('renders the pre-auth DNI request form without exposing patient profile data', async () => {
+    render(<PatientRequestSurface />);
+
+    expect(screen.getByRole('heading', { name: 'Pedí un turno con tu DNI' })).toBeInTheDocument();
+    expect(screen.getByLabelText('DNI / documento')).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'Ana Lopez — Cardiología' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /lun 27\/04, 14:00/ })).toBeInTheDocument();
+    expect(screen.queryByText(/historia clínica/i)).not.toBeInTheDocument();
+  });
+
+  it('loads availability, selects a slot and submits a scheduled patient booking', async () => {
+    createPatientRequestMock.mockResolvedValue({ id: 'request-1', status: 'scheduled', source: 'patient' });
+    render(<PatientRequestSurface />);
+
+    await screen.findByRole('option', { name: 'Ana Lopez — Cardiología' });
+    await waitFor(() => {
+      expect(listPublicAvailabilityMock).toHaveBeenCalledWith({
+        professional_id: 'professional-1',
+        week_start: '2026-04-27',
+      });
+    });
+    fireEvent.click(await screen.findByRole('button', { name: /lun 27\/04, 14:00/ }));
+    fireEvent.change(screen.getByLabelText('DNI / documento'), { target: { value: '12345678' } });
+    fireEvent.change(screen.getByLabelText('Nota opcional'), { target: { value: 'Prefiero tarde' } });
+    fireEvent.change(screen.getByLabelText('Contacto opcional'), { target: { value: '11-5555' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reservar horario' }));
+
+    await waitFor(() => {
+      expect(createPatientRequestMock).toHaveBeenCalledWith({
+        document: '12345678',
+        professional_id: 'professional-1',
+        notes: 'Prefiero tarde',
+        contact: '11-5555',
+        scheduled_start: '2026-04-27T14:00:00Z',
+        scheduled_end: '2026-04-27T14:30:00Z',
+      });
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('Turno reservado');
+  });
+
+  it('submits a fallback request without selected slot', async () => {
+    createPatientRequestMock.mockResolvedValue({ id: 'request-1', status: 'requested', source: 'patient' });
+    render(<PatientRequestSurface />);
+
+    await screen.findByRole('button', { name: /lun 27\/04, 14:00/ });
+    fireEvent.change(screen.getByLabelText('DNI / documento'), { target: { value: '12345678' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Solicitar sin horario' }));
+
+    await waitFor(() => {
+      expect(createPatientRequestMock).toHaveBeenCalledWith({
+        document: '12345678',
+        professional_id: 'professional-1',
+        notes: undefined,
+        contact: undefined,
+      });
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('Solicitud recibida');
+  });
+
+  it('groups available slots by day without exposing patient data', async () => {
+    render(<PatientRequestSurface />);
+
+    const monday = await screen.findByRole('group', { name: 'lunes 27/04' });
+    expect(within(monday).getByRole('button', { name: /14:00/ })).toBeInTheDocument();
+    const tuesday = screen.getByRole('group', { name: 'martes 28/04' });
+    expect(within(tuesday).getByRole('button', { name: /15:00/ })).toBeInTheDocument();
+    expect(screen.queryByText(/paciente/i)).not.toBeInTheDocument();
+  });
+
+  it('shows an error when the request cannot be created', async () => {
+    createPatientRequestMock.mockRejectedValue(new Error('not found'));
+    render(<PatientRequestSurface />);
+
+    await screen.findByRole('option', { name: 'Ana Lopez — Cardiología' });
+    fireEvent.change(screen.getByLabelText('DNI / documento'), { target: { value: '99999999' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Solicitar sin horario' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No encontramos el DNI');
+  });
+});

--- a/web/src/features/patient-request/PatientRequestSurface.tsx
+++ b/web/src/features/patient-request/PatientRequestSurface.tsx
@@ -1,0 +1,250 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { createPatientRequest, listPublicAvailability } from '../../api/appointments';
+import type { PublicAvailabilitySlot } from '../../types/appointments';
+import { listPublicProfessionals } from '../../api/directory';
+import type { Professional } from '../../types/directory';
+
+type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
+
+const shortWeekday = ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'];
+const longWeekday = ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'];
+
+export function PatientRequestSurface() {
+  const [document, setDocument] = useState('');
+  const [professionalId, setProfessionalId] = useState('');
+  const [weekStart, setWeekStart] = useState(() => currentOperationalWeekStart());
+  const [notes, setNotes] = useState('');
+  const [contact, setContact] = useState('');
+  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const [availability, setAvailability] = useState<PublicAvailabilitySlot[]>([]);
+  const [selectedSlot, setSelectedSlot] = useState<PublicAvailabilitySlot | null>(null);
+  const [loadError, setLoadError] = useState('');
+  const [availabilityError, setAvailabilityError] = useState('');
+  const [submitState, setSubmitState] = useState<SubmitState>('idle');
+  const [submitError, setSubmitError] = useState('');
+
+  useEffect(() => {
+    let alive = true;
+
+    listPublicProfessionals()
+      .then((response) => {
+        if (!alive) {
+          return;
+        }
+        setProfessionals(response.items);
+        setProfessionalId((current) => current || response.items[0]?.id || '');
+      })
+      .catch(() => {
+        if (alive) {
+          setLoadError('No pudimos cargar profesionales. Probá de nuevo en unos minutos.');
+        }
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!professionalId) {
+      setAvailability([]);
+      setSelectedSlot(null);
+      return;
+    }
+
+    let alive = true;
+    setAvailabilityError('');
+    setSelectedSlot(null);
+
+    listPublicAvailability({ professional_id: professionalId, week_start: weekStart })
+      .then((response) => {
+        if (!alive) {
+          return;
+        }
+        setAvailability(response.items);
+      })
+      .catch(() => {
+        if (alive) {
+          setAvailability([]);
+          setAvailabilityError('No pudimos cargar horarios disponibles. Podés solicitar sin horario.');
+        }
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [professionalId, weekStart]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitState('submitting');
+    setSubmitError('');
+
+    try {
+      const selectedRange = selectedSlot
+        ? {
+            scheduled_start: selectedSlot.start_time,
+            scheduled_end: selectedSlot.end_time,
+          }
+        : {};
+
+      const response = await createPatientRequest({
+        document,
+        professional_id: professionalId,
+        notes: notes || undefined,
+        contact: contact || undefined,
+        ...selectedRange,
+      });
+      setSubmitState(response.status === 'scheduled' ? 'success' : 'success');
+    } catch {
+      setSubmitState('error');
+      setSubmitError('No encontramos el DNI o no pudimos registrar la solicitud. Revisá los datos e intentá de nuevo.');
+    }
+  }
+
+  const canSubmit = document.trim() !== '' && professionalId !== '' && submitState !== 'submitting';
+  const groupedAvailability = groupAvailabilityByDay(availability);
+
+  return (
+    <main className="page page-centered">
+      <section className="card stack" aria-labelledby="patient-request-title">
+        <div className="hero-kicker">Solicitud de turno</div>
+        <h1 id="patient-request-title">Pedí un turno con tu DNI</h1>
+        <p>Ingresá tu documento y elegí profesional. Por privacidad, no mostramos tus datos personales en esta pantalla.</p>
+
+        {loadError ? <p role="alert">{loadError}</p> : null}
+
+        <form className="stack" onSubmit={handleSubmit}>
+          <label>
+            DNI / documento
+            <input value={document} onChange={(event) => setDocument(event.target.value)} autoComplete="off" />
+          </label>
+
+          <label>
+            Profesional
+            <select value={professionalId} onChange={(event) => setProfessionalId(event.target.value)}>
+              {professionals.map((professional) => (
+                <option key={professional.id} value={professional.id}>
+                  {professional.first_name} {professional.last_name} — {professional.specialty}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            Semana
+            <input type="date" value={weekStart} onChange={(event) => setWeekStart(toOperationalWeekStart(event.target.value))} />
+          </label>
+
+          <section className="stack" aria-labelledby="availability-title">
+            <h2 id="availability-title">Horarios disponibles</h2>
+            <p>Elegí un horario para reservar directo, o enviá la solicitud sin horario si no te sirve ninguno.</p>
+            {availabilityError ? <p role="alert">{availabilityError}</p> : null}
+            {groupedAvailability.length === 0 && !availabilityError ? <p>No hay horarios disponibles para esta semana.</p> : null}
+            {groupedAvailability.map((group) => (
+              <div key={group.date} role="group" aria-label={group.longLabel} className="stack">
+                <strong>{group.longLabel}</strong>
+                <div className="actions-row">
+                  {group.slots.map((slot) => {
+                    const selected = selectedSlot?.start_time === slot.start_time && selectedSlot?.end_time === slot.end_time;
+                    return (
+                      <button
+                        key={`${slot.start_time}-${slot.end_time}`}
+                        type="button"
+                        aria-pressed={selected}
+                        onClick={() => setSelectedSlot(slot)}
+                      >
+                        {formatSlotButtonLabel(slot)}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </section>
+
+          <label>
+            Nota opcional
+            <textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </label>
+
+          <label>
+            Contacto opcional
+            <input value={contact} onChange={(event) => setContact(event.target.value)} />
+          </label>
+
+          <button type="submit" disabled={!canSubmit}>
+            {submitState === 'submitting' ? 'Enviando...' : selectedSlot ? 'Reservar horario' : 'Solicitar sin horario'}
+          </button>
+        </form>
+
+        {submitState === 'success' ? (
+          <p role="status">
+            {selectedSlot
+              ? 'Turno reservado. Te esperamos en el horario elegido.'
+              : 'Solicitud recibida. El equipo se va a contactar para coordinar el turno.'}
+          </p>
+        ) : null}
+        {submitError ? <p role="alert">{submitError}</p> : null}
+      </section>
+    </main>
+  );
+}
+
+function currentOperationalWeekStart() {
+  const today = new Date();
+  const day = today.getDay() === 0 ? 7 : today.getDay();
+  const monday = new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - day + 1));
+  return formatISODate(monday);
+}
+
+function toOperationalWeekStart(value: string) {
+  if (!value) {
+    return currentOperationalWeekStart();
+  }
+  const selected = parseDateOnly(value);
+  const day = selected.getUTCDay() === 0 ? 7 : selected.getUTCDay();
+  selected.setUTCDate(selected.getUTCDate() - day + 1);
+  return formatISODate(selected);
+}
+
+function groupAvailabilityByDay(slots: PublicAvailabilitySlot[]) {
+  const groups = new Map<string, { date: string; longLabel: string; slots: PublicAvailabilitySlot[] }>();
+  [...slots]
+    .sort((left, right) => left.start_time.localeCompare(right.start_time))
+    .forEach((slot) => {
+      const start = new Date(slot.start_time);
+      const date = formatISODate(start);
+      const current = groups.get(date) ?? { date, longLabel: formatLongDayLabel(start), slots: [] };
+      current.slots.push(slot);
+      groups.set(date, current);
+    });
+  return [...groups.values()];
+}
+
+function formatSlotButtonLabel(slot: PublicAvailabilitySlot) {
+  const start = new Date(slot.start_time);
+  const end = new Date(slot.end_time);
+  return `${shortWeekday[start.getUTCDay()]} ${pad(start.getUTCDate())}/${pad(start.getUTCMonth() + 1)}, ${formatClock(start)}–${formatClock(end)}`;
+}
+
+function formatLongDayLabel(date: Date) {
+  return `${longWeekday[date.getUTCDay()]} ${pad(date.getUTCDate())}/${pad(date.getUTCMonth() + 1)}`;
+}
+
+function formatClock(date: Date) {
+  return `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+}
+
+function parseDateOnly(value: string) {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function formatISODate(date: Date) {
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+}
+
+function pad(value: number) {
+  return value.toString().padStart(2, '0');
+}

--- a/web/src/features/schedule/agendaAdapter.test.ts
+++ b/web/src/features/schedule/agendaAdapter.test.ts
@@ -108,6 +108,36 @@ describe('agendaAdapter', () => {
 		expect(board.days[2]?.summary).toMatchObject({ available: 0, booked: 1 });
 	});
 
+	it('keeps requested patient consultations out of occupied agenda slots', () => {
+		const weekAgenda: WeekAgenda = {
+			professional_id: 'professional-1',
+			week_start: '2026-04-06',
+			templates: [],
+			blocks: [],
+			consultations: [
+				consultation({
+					id: 'consultation-requested',
+					slot_id: null,
+					status: 'requested',
+					source: 'patient',
+					scheduled_start: '2026-04-08T10:00:00Z',
+					scheduled_end: '2026-04-08T10:01:00Z',
+				}),
+			],
+			slots: [slot({ id: '', start_time: '2026-04-08T10:00:00Z', end_time: '2026-04-08T10:30:00Z', status: 'available' })],
+		};
+
+		const board = buildScheduleBoardModel(weekAgenda);
+
+		expect(board.timeBands).toEqual(['10:00']);
+		expect(board.days[2]?.appointments).toHaveLength(0);
+		expect(board.days[2]?.slots[0]).toMatchObject({
+			id: 'template-slot-professional-1-2026-04-08T10:00:00Z-2026-04-08T10:30:00Z',
+			status: 'available',
+		});
+		expect(board.days[2]?.summary).toMatchObject({ available: 1, booked: 0 });
+	});
+
 	it('keeps cancelled consultations visible in the summary', () => {
 		const weekAgenda: WeekAgenda = {
 			professional_id: 'professional-1',

--- a/web/src/features/schedule/agendaAdapter.ts
+++ b/web/src/features/schedule/agendaAdapter.ts
@@ -114,6 +114,10 @@ function groupAppointmentsByDate(consultations: Consultation[]) {
 	const byDate = new Map<string, ScheduleBoardAppointment[]>();
 
 	for (const consultation of consultations) {
+		if (consultation.status === 'requested') {
+			continue;
+		}
+
 		const date = consultation.scheduled_start.slice(0, 10);
 		const current = byDate.get(date) ?? [];
 		current.push(adaptConsultationToAppointment(consultation));
@@ -167,7 +171,9 @@ function createStandaloneSlot(appointment: ScheduleBoardAppointment): Slot | nul
 
 function buildTimeBands(weekAgenda: WeekAgenda) {
 	const slotBands = weekAgenda.slots.map((slot) => formatTimeBand(slot.start_time));
-	const consultationBands = weekAgenda.consultations.map((consultation) => formatTimeBand(consultation.scheduled_start));
+	const consultationBands = weekAgenda.consultations
+		.filter((consultation) => consultation.status !== 'requested')
+		.map((consultation) => formatTimeBand(consultation.scheduled_start));
 
 	return [...new Set([...slotBands, ...consultationBands])].sort();
 }

--- a/web/src/types/appointments.ts
+++ b/web/src/types/appointments.ts
@@ -92,9 +92,9 @@ export type ScheduleBlock = {
 	updated_at: string;
 };
 
-export type ConsultationStatus = 'scheduled' | 'checked_in' | 'completed' | 'cancelled' | 'no_show';
+export type ConsultationStatus = 'scheduled' | 'requested' | 'checked_in' | 'completed' | 'cancelled' | 'no_show';
 
-export type ConsultationSource = 'online' | 'secretary' | 'doctor';
+export type ConsultationSource = 'online' | 'secretary' | 'doctor' | 'patient';
 
 export type Consultation = {
 	id: string;
@@ -122,6 +122,13 @@ export type WeekAgenda = {
 	slots: Slot[];
 };
 
+export type PublicAvailabilitySlot = {
+	id?: string;
+	professional_id: string;
+	start_time: string;
+	end_time: string;
+};
+
 export type CreateAppointmentPayload = {
   slot_id: string;
   patient_id: string;
@@ -136,6 +143,15 @@ export type CreateConsultationPayload = {
 	scheduled_start?: string;
 	scheduled_end?: string;
 	notes?: string;
+};
+
+export type CreatePatientRequestPayload = {
+  document: string;
+  professional_id: string;
+  notes?: string;
+  contact?: string;
+  scheduled_start?: string;
+  scheduled_end?: string;
 };
 
 export type UpdateConsultationStatusPayload = {


### PR DESCRIPTION
Closes #42

## PR Type
- [x] New feature

## Summary
- Adds a public patient request/booking surface keyed by DNI/document.
- Exposes privacy-safe public professional availability and patient request APIs.
- Supports direct scheduled booking when a slot is selected, with fallback request-only flow.

## Changes

| File | Change |
|------|--------|
| `web/src/features/patient-request/PatientRequestSurface.tsx` | Added public patient booking/request UI with professional/week/slot selection |
| `web/src/api/appointments.ts` | Added public availability and patient request API clients |
| `services/appointments-service/internal/http/server.go` | Added public availability and patient request endpoints |
| `services/appointments-service/migrations/009_patient_request_flow.sql` | Added patient request status/source constraint support |
| `services/directory-service/internal/http/server.go` | Added public professionals and internal patient-by-document lookup |
| `deploy/docker-compose.yml` | Applies patient request migration in local Docker migrator |

## Test Plan
- [x] Focused Go tests were run during implementation
- [x] Focused frontend tests were run during implementation
- [x] Manual smoke test: patient books from public surface and consultation appears in agenda
- [x] No build was run

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers