### PR TITLE
feat(clinical): add patient history foundation

### DIFF
--- a/services/directory-service/internal/directory/clinical.go
+++ b/services/directory-service/internal/directory/clinical.go
@@ -12,6 +12,10 @@ import (
 
 var ErrForbidden = errors.New("directory forbidden")
 
+const maxClinicalHistoryTextLength = 4000
+const maxWeightKG = 500
+const maxHeightCM = 300
+
 type CreateEncounterParams struct {
 	PatientID      string `json:"-"`
 	ProfessionalID string `json:"-"`
@@ -39,6 +43,42 @@ type ClinicalNote struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+type ClinicalHistory struct {
+	ID                  string    `json:"id"`
+	PatientID           string    `json:"patient_id"`
+	WeightKG            *float64  `json:"weight_kg"`
+	HeightCM            *float64  `json:"height_cm"`
+	Antecedentes        *string   `json:"antecedentes"`
+	Allergies           *string   `json:"allergies"`
+	HabitualMedication  *string   `json:"habitual_medication"`
+	ChronicConditions   *string   `json:"chronic_conditions"`
+	Habits              *string   `json:"habits"`
+	GeneralObservations *string   `json:"general_observations"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+type UpdateClinicalHistoryParams struct {
+	PatientID           string   `json:"-"`
+	WeightKG            *float64 `json:"weight_kg,omitempty"`
+	HeightCM            *float64 `json:"height_cm,omitempty"`
+	Antecedentes        *string  `json:"antecedentes,omitempty"`
+	Allergies           *string  `json:"allergies,omitempty"`
+	HabitualMedication  *string  `json:"habitual_medication,omitempty"`
+	ChronicConditions   *string  `json:"chronic_conditions,omitempty"`
+	Habits              *string  `json:"habits,omitempty"`
+	GeneralObservations *string  `json:"general_observations,omitempty"`
+
+	SetWeightKG            bool `json:"-"`
+	SetHeightCM            bool `json:"-"`
+	SetAntecedentes        bool `json:"-"`
+	SetAllergies           bool `json:"-"`
+	SetHabitualMedication  bool `json:"-"`
+	SetChronicConditions   bool `json:"-"`
+	SetHabits              bool `json:"-"`
+	SetGeneralObservations bool `json:"-"`
+}
+
 type Encounter struct {
 	ID             string       `json:"id"`
 	ChartID        string       `json:"chart_id"`
@@ -48,6 +88,88 @@ type Encounter struct {
 	CreatedAt      time.Time    `json:"created_at"`
 	UpdatedAt      time.Time    `json:"updated_at"`
 	InitialNote    ClinicalNote `json:"initial_note"`
+}
+
+func (r *Repository) GetClinicalHistory(ctx context.Context, patientID string) (ClinicalHistory, error) {
+	normalizedPatientID, err := validateClinicalHistoryPatientID(patientID)
+	if err != nil {
+		return ClinicalHistory{}, err
+	}
+
+	var patientExists bool
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM patients WHERE id = $1)
+	`, normalizedPatientID).Scan(&patientExists); err != nil {
+		return ClinicalHistory{}, err
+	}
+	if !patientExists {
+		return ClinicalHistory{}, ErrNotFound
+	}
+
+	return scanClinicalHistory(r.db.QueryRowContext(ctx, `
+		INSERT INTO clinical_history (patient_id)
+		VALUES ($1)
+		ON CONFLICT (patient_id) DO UPDATE SET updated_at = clinical_history.updated_at
+		RETURNING id, patient_id, weight_kg, height_cm, antecedentes, allergies, habitual_medication,
+			chronic_conditions, habits, general_observations, created_at, updated_at
+	`, normalizedPatientID))
+}
+
+func (r *Repository) UpdateClinicalHistory(ctx context.Context, params UpdateClinicalHistoryParams) (ClinicalHistory, error) {
+	normalized, err := validateUpdateClinicalHistoryParams(params)
+	if err != nil {
+		return ClinicalHistory{}, err
+	}
+
+	var patientExists bool
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM patients WHERE id = $1)
+	`, normalized.PatientID).Scan(&patientExists); err != nil {
+		return ClinicalHistory{}, err
+	}
+	if !patientExists {
+		return ClinicalHistory{}, ErrNotFound
+	}
+
+	return scanClinicalHistory(r.db.QueryRowContext(ctx, `
+		INSERT INTO clinical_history (
+			patient_id, weight_kg, height_cm, antecedentes, allergies, habitual_medication,
+			chronic_conditions, habits, general_observations
+		)
+		VALUES (
+			$1,
+			CASE WHEN $2 THEN $3::numeric ELSE NULL END,
+			CASE WHEN $4 THEN $5::numeric ELSE NULL END,
+			CASE WHEN $6 THEN $7::text ELSE NULL END,
+			CASE WHEN $8 THEN $9::text ELSE NULL END,
+			CASE WHEN $10 THEN $11::text ELSE NULL END,
+			CASE WHEN $12 THEN $13::text ELSE NULL END,
+			CASE WHEN $14 THEN $15::text ELSE NULL END,
+			CASE WHEN $16 THEN $17::text ELSE NULL END
+		)
+		ON CONFLICT (patient_id) DO UPDATE SET
+			weight_kg = CASE WHEN $2 THEN EXCLUDED.weight_kg ELSE clinical_history.weight_kg END,
+			height_cm = CASE WHEN $4 THEN EXCLUDED.height_cm ELSE clinical_history.height_cm END,
+			antecedentes = CASE WHEN $6 THEN EXCLUDED.antecedentes ELSE clinical_history.antecedentes END,
+			allergies = CASE WHEN $8 THEN EXCLUDED.allergies ELSE clinical_history.allergies END,
+			habitual_medication = CASE WHEN $10 THEN EXCLUDED.habitual_medication ELSE clinical_history.habitual_medication END,
+			chronic_conditions = CASE WHEN $12 THEN EXCLUDED.chronic_conditions ELSE clinical_history.chronic_conditions END,
+			habits = CASE WHEN $14 THEN EXCLUDED.habits ELSE clinical_history.habits END,
+			general_observations = CASE WHEN $16 THEN EXCLUDED.general_observations ELSE clinical_history.general_observations END,
+			updated_at = NOW()
+		RETURNING id, patient_id, weight_kg, height_cm, antecedentes, allergies, habitual_medication,
+			chronic_conditions, habits, general_observations, created_at, updated_at
+	`,
+		normalized.PatientID,
+		normalized.SetWeightKG, normalized.WeightKG,
+		normalized.SetHeightCM, normalized.HeightCM,
+		normalized.SetAntecedentes, normalized.Antecedentes,
+		normalized.SetAllergies, normalized.Allergies,
+		normalized.SetHabitualMedication, normalized.HabitualMedication,
+		normalized.SetChronicConditions, normalized.ChronicConditions,
+		normalized.SetHabits, normalized.Habits,
+		normalized.SetGeneralObservations, normalized.GeneralObservations,
+	))
 }
 
 func (r *Repository) CreateEncounter(ctx context.Context, params CreateEncounterParams) (Encounter, error) {
@@ -202,6 +324,90 @@ func validateCreateEncounterParams(params CreateEncounterParams, now time.Time) 
 	return normalized, occurredAt.UTC(), nil
 }
 
+func validateUpdateClinicalHistoryParams(params UpdateClinicalHistoryParams) (UpdateClinicalHistoryParams, error) {
+	normalizedPatientID, err := validateClinicalHistoryPatientID(params.PatientID)
+	if err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+
+	normalized := UpdateClinicalHistoryParams{
+		PatientID:              normalizedPatientID,
+		WeightKG:               params.WeightKG,
+		HeightCM:               params.HeightCM,
+		SetWeightKG:            params.WeightKG != nil || params.SetWeightKG,
+		SetHeightCM:            params.HeightCM != nil || params.SetHeightCM,
+		SetAntecedentes:        params.Antecedentes != nil || params.SetAntecedentes,
+		SetAllergies:           params.Allergies != nil || params.SetAllergies,
+		SetHabitualMedication:  params.HabitualMedication != nil || params.SetHabitualMedication,
+		SetChronicConditions:   params.ChronicConditions != nil || params.SetChronicConditions,
+		SetHabits:              params.Habits != nil || params.SetHabits,
+		SetGeneralObservations: params.GeneralObservations != nil || params.SetGeneralObservations,
+	}
+
+	if err := validateClinicalMeasurement(normalized.WeightKG, maxWeightKG); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+	if err := validateClinicalMeasurement(normalized.HeightCM, maxHeightCM); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+
+	if normalized.Antecedentes, err = normalizeClinicalHistoryText(params.Antecedentes); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+	if normalized.Allergies, err = normalizeClinicalHistoryText(params.Allergies); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+	if normalized.HabitualMedication, err = normalizeClinicalHistoryText(params.HabitualMedication); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+	if normalized.ChronicConditions, err = normalizeClinicalHistoryText(params.ChronicConditions); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+	if normalized.Habits, err = normalizeClinicalHistoryText(params.Habits); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+	if normalized.GeneralObservations, err = normalizeClinicalHistoryText(params.GeneralObservations); err != nil {
+		return UpdateClinicalHistoryParams{}, err
+	}
+
+	return normalized, nil
+}
+
+func validateClinicalHistoryPatientID(patientID string) (string, error) {
+	normalizedPatientID := strings.TrimSpace(patientID)
+	if _, err := uuid.Parse(normalizedPatientID); err != nil {
+		return "", ErrNotFound
+	}
+
+	return normalizedPatientID, nil
+}
+
+func validateClinicalMeasurement(value *float64, max float64) error {
+	if value == nil {
+		return nil
+	}
+	if *value <= 0 || *value > max {
+		return ErrValidation
+	}
+
+	return nil
+}
+
+func normalizeClinicalHistoryText(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	normalized := strings.TrimSpace(*value)
+	if normalized == "" {
+		return nil, nil
+	}
+	if len([]rune(normalized)) > maxClinicalHistoryTextLength {
+		return nil, ErrValidation
+	}
+
+	return &normalized, nil
+}
+
 func validateEncounterOwnership(patientID, professionalID string) (string, string, error) {
 	normalizedPatientID := strings.TrimSpace(patientID)
 	normalizedProfessionalID := strings.TrimSpace(professionalID)
@@ -311,6 +517,61 @@ func scanEncounterWithNote(scanner encounterScanner) (Encounter, error) {
 	}
 
 	return encounter, nil
+}
+
+type clinicalHistoryScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanClinicalHistory(scanner clinicalHistoryScanner) (ClinicalHistory, error) {
+	var history ClinicalHistory
+	var weightKG, heightCM sql.NullFloat64
+	var antecedentes, allergies, habitualMedication, chronicConditions, habits, generalObservations sql.NullString
+
+	err := scanner.Scan(
+		&history.ID,
+		&history.PatientID,
+		&weightKG,
+		&heightCM,
+		&antecedentes,
+		&allergies,
+		&habitualMedication,
+		&chronicConditions,
+		&habits,
+		&generalObservations,
+		&history.CreatedAt,
+		&history.UpdatedAt,
+	)
+	if err != nil {
+		return ClinicalHistory{}, err
+	}
+
+	history.WeightKG = nullFloatPtr(weightKG)
+	history.HeightCM = nullFloatPtr(heightCM)
+	history.Antecedentes = nullStringPtr(antecedentes)
+	history.Allergies = nullStringPtr(allergies)
+	history.HabitualMedication = nullStringPtr(habitualMedication)
+	history.ChronicConditions = nullStringPtr(chronicConditions)
+	history.Habits = nullStringPtr(habits)
+	history.GeneralObservations = nullStringPtr(generalObservations)
+
+	return history, nil
+}
+
+func nullFloatPtr(value sql.NullFloat64) *float64 {
+	if !value.Valid {
+		return nil
+	}
+
+	return &value.Float64
+}
+
+func nullStringPtr(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+
+	return &value.String
 }
 
 func isNoRows(err error) bool {

--- a/services/directory-service/internal/directory/clinical_postgres_integration_test.go
+++ b/services/directory-service/internal/directory/clinical_postgres_integration_test.go
@@ -2,6 +2,7 @@ package directory
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -62,6 +63,67 @@ func TestRepositoryIntegrationCreateEncounterImplicitlyCreatesChartAndInitialNot
 	}
 	if encounter.InitialNote.Content != persistedNote.Content {
 		t.Fatalf("returned initial note content = %q, want %q", encounter.InitialNote.Content, persistedNote.Content)
+	}
+}
+
+func TestRepositoryIntegrationClinicalHistoryLifecyclePreservesPartialUpdates(t *testing.T) {
+	repo, _ := newPostgresIntegrationRepository(t)
+
+	patient := seedClinicalPatient(t, repo, "history-lifecycle")
+
+	emptyHistory, err := repo.GetClinicalHistory(context.Background(), patient.ID)
+	if err != nil {
+		t.Fatalf("get empty clinical history: %v", err)
+	}
+	if emptyHistory.PatientID != patient.ID {
+		t.Fatalf("empty history patient_id = %q, want %q", emptyHistory.PatientID, patient.ID)
+	}
+	if emptyHistory.WeightKG != nil || emptyHistory.Allergies != nil {
+		t.Fatalf("empty history fields = weight %v allergies %v, want nil", emptyHistory.WeightKG, emptyHistory.Allergies)
+	}
+
+	weight := 72.5
+	allergies := " Penicilina "
+	updated, err := repo.UpdateClinicalHistory(context.Background(), UpdateClinicalHistoryParams{
+		PatientID: patient.ID,
+		WeightKG:  &weight,
+		Allergies: &allergies,
+	})
+	if err != nil {
+		t.Fatalf("update clinical history: %v", err)
+	}
+	if updated.WeightKG == nil || *updated.WeightKG != 72.5 {
+		t.Fatalf("updated weight = %v, want 72.5", updated.WeightKG)
+	}
+	if updated.Allergies == nil || *updated.Allergies != "Penicilina" {
+		t.Fatalf("updated allergies = %v, want Penicilina", updated.Allergies)
+	}
+
+	height := 168.2
+	patched, err := repo.UpdateClinicalHistory(context.Background(), UpdateClinicalHistoryParams{
+		PatientID: patient.ID,
+		HeightCM:  &height,
+	})
+	if err != nil {
+		t.Fatalf("patch clinical history: %v", err)
+	}
+	if patched.WeightKG == nil || *patched.WeightKG != 72.5 {
+		t.Fatalf("patched weight = %v, want preserved 72.5", patched.WeightKG)
+	}
+	if patched.HeightCM == nil || *patched.HeightCM != 168.2 {
+		t.Fatalf("patched height = %v, want 168.2", patched.HeightCM)
+	}
+	if patched.Allergies == nil || *patched.Allergies != "Penicilina" {
+		t.Fatalf("patched allergies = %v, want preserved Penicilina", patched.Allergies)
+	}
+}
+
+func TestRepositoryIntegrationClinicalHistoryMissingPatientReturnsNotFound(t *testing.T) {
+	repo, _ := newPostgresIntegrationRepository(t)
+
+	_, err := repo.GetClinicalHistory(context.Background(), "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("get missing patient error = %v, want %v", err, ErrNotFound)
 	}
 }
 

--- a/services/directory-service/internal/directory/clinical_test.go
+++ b/services/directory-service/internal/directory/clinical_test.go
@@ -2,6 +2,7 @@ package directory
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -87,4 +88,116 @@ func TestValidateCreateEncounterParams(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateUpdateClinicalHistoryParams(t *testing.T) {
+	weight := 72.5
+	height := 168.2
+	blank := "   "
+	allergies := "  Penicilina  "
+	antecedentes := strings.Repeat("a", maxClinicalHistoryTextLength+1)
+
+	tests := []struct {
+		name    string
+		params  UpdateClinicalHistoryParams
+		want    UpdateClinicalHistoryParams
+		wantErr error
+	}{
+		{
+			name: "partial update trims text and nulls blank fields",
+			params: UpdateClinicalHistoryParams{
+				PatientID:           " 0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca ",
+				WeightKG:            &weight,
+				HeightCM:            &height,
+				Allergies:           &allergies,
+				GeneralObservations: &blank,
+			},
+			want: UpdateClinicalHistoryParams{
+				PatientID:           "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca",
+				WeightKG:            &weight,
+				HeightCM:            &height,
+				Allergies:           stringPtr("Penicilina"),
+				GeneralObservations: nil,
+			},
+		},
+		{
+			name: "non positive weight is rejected",
+			params: UpdateClinicalHistoryParams{
+				PatientID: "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca",
+				WeightKG:  float64Ptr(0),
+			},
+			wantErr: ErrValidation,
+		},
+		{
+			name: "overlong text is rejected",
+			params: UpdateClinicalHistoryParams{
+				PatientID:    "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca",
+				Antecedentes: &antecedentes,
+			},
+			wantErr: ErrValidation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateUpdateClinicalHistoryParams(tt.params)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+
+			assertUpdateClinicalHistoryParams(t, got, tt.want)
+		})
+	}
+}
+
+func assertUpdateClinicalHistoryParams(t *testing.T, got, want UpdateClinicalHistoryParams) {
+	t.Helper()
+
+	if got.PatientID != want.PatientID {
+		t.Fatalf("patientID = %q, want %q", got.PatientID, want.PatientID)
+	}
+	assertFloatPtr(t, "weight", got.WeightKG, want.WeightKG)
+	assertFloatPtr(t, "height", got.HeightCM, want.HeightCM)
+	assertStringPtr(t, "allergies", got.Allergies, want.Allergies)
+	assertStringPtr(t, "general observations", got.GeneralObservations, want.GeneralObservations)
+}
+
+func assertFloatPtr(t *testing.T, field string, got, want *float64) {
+	t.Helper()
+
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s = %v, want %v", field, got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("%s = %v, want %v", field, *got, *want)
+	}
+}
+
+func assertStringPtr(t *testing.T, field string, got, want *string) {
+	t.Helper()
+
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s = %v, want %v", field, got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("%s = %q, want %q", field, *got, *want)
+	}
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/services/directory-service/internal/directory/repository_postgres_integration_helpers_test.go
+++ b/services/directory-service/internal/directory/repository_postgres_integration_helpers_test.go
@@ -96,7 +96,7 @@ func resetDirectorySchema(t *testing.T, db *sql.DB) {
 func applyDirectoryMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
 
-	for _, migration := range []string{"001_init.sql", "002_access_auth.sql", "003_clinical_core.sql"} {
+	for _, migration := range []string{"001_init.sql", "002_access_auth.sql", "003_clinical_core.sql", "004_clinical_history_foundation.sql"} {
 		contents := readDirectoryMigrationFile(t, migration)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/services/directory-service/internal/http/server.go
+++ b/services/directory-service/internal/http/server.go
@@ -33,6 +33,8 @@ type directoryRepository interface {
 	GetPatientByDocument(ctx context.Context, document string) (directory.Patient, error)
 	CreateEncounter(ctx context.Context, params directory.CreateEncounterParams) (directory.Encounter, error)
 	ListPatientEncounters(ctx context.Context, patientID, professionalID string) ([]directory.Encounter, error)
+	GetClinicalHistory(ctx context.Context, patientID string) (directory.ClinicalHistory, error)
+	UpdateClinicalHistory(ctx context.Context, params directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error)
 	CreateProfessional(ctx context.Context, params directory.CreateProfessionalParams) (directory.Professional, error)
 	ListProfessionals(ctx context.Context) ([]directory.Professional, error)
 	GetProfessionalByID(ctx context.Context, id string) (directory.Professional, error)
@@ -201,6 +203,10 @@ func (s *Server) patientByID(w http.ResponseWriter, r *http.Request) {
 		s.patientEncounters(w, r, parts[0])
 		return
 	}
+	if len(parts) == 2 && parts[1] == "clinical-history" {
+		s.patientClinicalHistory(w, r, parts[0])
+		return
+	}
 
 	http.NotFound(w, r)
 }
@@ -232,6 +238,17 @@ func (s *Server) patientEncounters(w http.ResponseWriter, r *http.Request, patie
 		s.createEncounter(w, r, patientID)
 	default:
 		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
+	}
+}
+
+func (s *Server) patientClinicalHistory(w http.ResponseWriter, r *http.Request, patientID string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getClinicalHistory(w, r, patientID)
+	case http.MethodPatch:
+		s.updateClinicalHistory(w, r, patientID)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPatch)
 	}
 }
 
@@ -416,6 +433,67 @@ func (s *Server) listPatientEncounters(w http.ResponseWriter, r *http.Request, p
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"items": encounters})
+}
+
+func (s *Server) getClinicalHistory(w http.ResponseWriter, r *http.Request, patientID string) {
+	if _, err := s.currentDoctorUser(r); errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	history, err := s.repo.GetClinicalHistory(r.Context(), patientID)
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "patient not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load clinical history")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, history)
+}
+
+func (s *Server) updateClinicalHistory(w http.ResponseWriter, r *http.Request, patientID string) {
+	if _, err := s.currentDoctorUser(r); errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	var request directory.UpdateClinicalHistoryParams
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	request.PatientID = patientID
+
+	history, err := s.repo.UpdateClinicalHistory(r.Context(), request)
+	if errors.Is(err, directory.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "failed to update clinical history")
+		return
+	}
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "patient not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update clinical history")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, history)
 }
 
 func (s *Server) createProfessional(w http.ResponseWriter, r *http.Request) {

--- a/services/directory-service/internal/http/server_test.go
+++ b/services/directory-service/internal/http/server_test.go
@@ -281,6 +281,130 @@ func TestListPatientEncountersReturnsItemsForCurrentProfessional(t *testing.T) {
 	}
 }
 
+func TestGetClinicalHistoryReturnsEmptyHistoryForDoctor(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	now := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		getClinicalHistoryFn: func(_ context.Context, gotPatientID string) (directory.ClinicalHistory, error) {
+			if gotPatientID != patientID {
+				t.Fatalf("patientID = %q, want %q", gotPatientID, patientID)
+			}
+			return directory.ClinicalHistory{ID: "history-1", PatientID: patientID, CreatedAt: now, UpdatedAt: now}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/patients/"+patientID+"/clinical-history", nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var history directory.ClinicalHistory
+	if err := json.NewDecoder(recorder.Body).Decode(&history); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if history.PatientID != patientID {
+		t.Fatalf("patient_id = %q, want %q", history.PatientID, patientID)
+	}
+	if history.WeightKG != nil || history.Allergies != nil {
+		t.Fatalf("empty history clinical fields = weight %v allergies %v, want nil fields", history.WeightKG, history.Allergies)
+	}
+}
+
+func TestPatchClinicalHistoryUpdatesProvidedFieldsForDoctor(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	allergies := "Penicilina"
+	now := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		updateClinicalHistoryFn: func(_ context.Context, params directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error) {
+			if params.PatientID != patientID {
+				t.Fatalf("patientID = %q, want %q", params.PatientID, patientID)
+			}
+			if params.Allergies == nil || *params.Allergies != " Penicilina " {
+				t.Fatalf("allergies = %v, want raw payload", params.Allergies)
+			}
+			return directory.ClinicalHistory{ID: "history-1", PatientID: patientID, Allergies: &allergies, CreatedAt: now, UpdatedAt: now}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPatch, "/patients/"+patientID+"/clinical-history", bytes.NewBufferString(`{"allergies":" Penicilina "}`))
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var history directory.ClinicalHistory
+	if err := json.NewDecoder(recorder.Body).Decode(&history); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if history.Allergies == nil || *history.Allergies != "Penicilina" {
+		t.Fatalf("allergies = %v, want Penicilina", history.Allergies)
+	}
+}
+
+func TestClinicalHistoryReturnsForbiddenForSecretary(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "secretary@clinic.local", Role: "secretary", ProfessionalID: &professionalID, Active: true}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/patients/0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca/clinical-history", nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestClinicalHistoryReturnsNotFoundForMissingPatient(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		getClinicalHistoryFn: func(context.Context, string) (directory.ClinicalHistory, error) {
+			return directory.ClinicalHistory{}, directory.ErrNotFound
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/patients/0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca/clinical-history", nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
 func TestLoginReturnsAccessToken(t *testing.T) {
 	repo := &stubDirectoryRepository{
 		authenticateUserFn: func(_ context.Context, email, password string) (directory.User, error) {
@@ -679,6 +803,8 @@ type stubDirectoryRepository struct {
 	getPatientByDocumentFn  func(context.Context, string) (directory.Patient, error)
 	createEncounterFn       func(context.Context, directory.CreateEncounterParams) (directory.Encounter, error)
 	listPatientEncountersFn func(context.Context, string, string) ([]directory.Encounter, error)
+	getClinicalHistoryFn    func(context.Context, string) (directory.ClinicalHistory, error)
+	updateClinicalHistoryFn func(context.Context, directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error)
 	createProfessionalFn    func(context.Context, directory.CreateProfessionalParams) (directory.Professional, error)
 	listProfessionalsFn     func(context.Context) ([]directory.Professional, error)
 	getProfessionalByIDFn   func(context.Context, string) (directory.Professional, error)
@@ -727,6 +853,20 @@ func (s *stubDirectoryRepository) ListPatientEncounters(ctx context.Context, pat
 		return nil, errors.New("unexpected ListPatientEncounters call")
 	}
 	return s.listPatientEncountersFn(ctx, patientID, professionalID)
+}
+
+func (s *stubDirectoryRepository) GetClinicalHistory(ctx context.Context, patientID string) (directory.ClinicalHistory, error) {
+	if s.getClinicalHistoryFn == nil {
+		return directory.ClinicalHistory{}, errors.New("unexpected GetClinicalHistory call")
+	}
+	return s.getClinicalHistoryFn(ctx, patientID)
+}
+
+func (s *stubDirectoryRepository) UpdateClinicalHistory(ctx context.Context, params directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error) {
+	if s.updateClinicalHistoryFn == nil {
+		return directory.ClinicalHistory{}, errors.New("unexpected UpdateClinicalHistory call")
+	}
+	return s.updateClinicalHistoryFn(ctx, params)
 }
 
 func (s *stubDirectoryRepository) CreateProfessional(ctx context.Context, params directory.CreateProfessionalParams) (directory.Professional, error) {

--- a/services/directory-service/migrations/004_clinical_history_foundation.sql
+++ b/services/directory-service/migrations/004_clinical_history_foundation.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS clinical_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    patient_id UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    weight_kg NUMERIC(5,2) CHECK (weight_kg IS NULL OR (weight_kg > 0 AND weight_kg <= 500)),
+    height_cm NUMERIC(5,2) CHECK (height_cm IS NULL OR (height_cm > 0 AND height_cm <= 300)),
+    antecedentes TEXT CHECK (antecedentes IS NULL OR char_length(antecedentes) <= 4000),
+    allergies TEXT CHECK (allergies IS NULL OR char_length(allergies) <= 4000),
+    habitual_medication TEXT CHECK (habitual_medication IS NULL OR char_length(habitual_medication) <= 4000),
+    chronic_conditions TEXT CHECK (chronic_conditions IS NULL OR char_length(chronic_conditions) <= 4000),
+    habits TEXT CHECK (habits IS NULL OR char_length(habits) <= 4000),
+    general_observations TEXT CHECK (general_observations IS NULL OR char_length(general_observations) <= 4000),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT clinical_history_patient_unique UNIQUE (patient_id)
+);
+
+CREATE INDEX IF NOT EXISTS clinical_history_patient_id_idx ON clinical_history (patient_id);

--- a/services/directory-service/openapi/openapi.yaml
+++ b/services/directory-service/openapi/openapi.yaml
@@ -209,6 +209,58 @@ paths:
         '500':
           $ref: '#/components/responses/CreateEncounterInternalServerError'
 
+  /patients/{id}/clinical-history:
+    get:
+      summary: Get patient clinical history
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+      responses:
+        '200':
+          description: Clinical history loaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClinicalHistory'
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/PatientNotFound'
+        '500':
+          $ref: '#/components/responses/ClinicalHistoryInternalServerError'
+    patch:
+      summary: Update patient clinical history
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateClinicalHistoryRequest'
+      responses:
+        '200':
+          description: Clinical history updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClinicalHistory'
+        '400':
+          $ref: '#/components/responses/UpdateClinicalHistoryBadRequest'
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/PatientNotFound'
+        '500':
+          $ref: '#/components/responses/ClinicalHistoryInternalServerError'
+
   /professionals:
     get:
       summary: List professionals
@@ -492,6 +544,32 @@ components:
             failed_to_list_encounters:
               value:
                 error: failed to list encounters
+    UpdateClinicalHistoryBadRequest:
+      description: Invalid JSON body or clinical history validation failure.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            invalid_json_body:
+              value:
+                error: invalid json body
+            failed_to_update_clinical_history:
+              value:
+                error: failed to update clinical history
+    ClinicalHistoryInternalServerError:
+      description: Unexpected failure while loading or updating clinical history.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            failed_to_load_clinical_history:
+              value:
+                error: failed to load clinical history
+            failed_to_update_clinical_history:
+              value:
+                error: failed to update clinical history
   schemas:
     ErrorResponse:
       type: object
@@ -776,6 +854,112 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Encounter'
+
+    ClinicalHistory:
+      type: object
+      required:
+        - id
+        - patient_id
+        - weight_kg
+        - height_cm
+        - antecedentes
+        - allergies
+        - habitual_medication
+        - chronic_conditions
+        - habits
+        - general_observations
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        patient_id:
+          type: string
+          format: uuid
+        weight_kg:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 500
+          nullable: true
+        height_cm:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 300
+          nullable: true
+        antecedentes:
+          type: string
+          maxLength: 4000
+          nullable: true
+        allergies:
+          type: string
+          maxLength: 4000
+          nullable: true
+        habitual_medication:
+          type: string
+          maxLength: 4000
+          nullable: true
+        chronic_conditions:
+          type: string
+          maxLength: 4000
+          nullable: true
+        habits:
+          type: string
+          maxLength: 4000
+          nullable: true
+        general_observations:
+          type: string
+          maxLength: 4000
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    UpdateClinicalHistoryRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        weight_kg:
+          type: number
+          format: double
+          exclusiveMinimum: true
+          minimum: 0
+          maximum: 500
+        height_cm:
+          type: number
+          format: double
+          exclusiveMinimum: true
+          minimum: 0
+          maximum: 300
+        antecedentes:
+          type: string
+          maxLength: 4000
+          nullable: true
+        allergies:
+          type: string
+          maxLength: 4000
+          nullable: true
+        habitual_medication:
+          type: string
+          maxLength: 4000
+          nullable: true
+        chronic_conditions:
+          type: string
+          maxLength: 4000
+          nullable: true
+        habits:
+          type: string
+          maxLength: 4000
+          nullable: true
+        general_observations:
+          type: string
+          maxLength: 4000
+          nullable: true
 
     CreateProfessionalRequest:
       type: object


### PR DESCRIPTION
Closes #46

## PR Type
- [x] New feature

## Summary
- Adds patient-scoped editable clinical history in directory-service.
- Adds GET/PATCH clinical history endpoints with doctor-only access.
- Covers migration, repository validation/upsert behavior, HTTP handling, OpenAPI, and focused Go tests.

## Changes

| File | Change |
|------|--------|
| `services/directory-service/migrations/004_clinical_history_foundation.sql` | Adds patient-scoped clinical_history table |
| `services/directory-service/internal/directory/clinical.go` | Adds clinical history model, validation, get/upsert repository behavior |
| `services/directory-service/internal/http/server.go` | Adds patient clinical-history route handlers |
| `services/directory-service/openapi/openapi.yaml` | Documents clinical history contract |
| `services/directory-service/internal/**/*test.go` | Adds focused unit, HTTP, and Postgres integration coverage |

## Test Plan
- [x] Targeted clinical-history tests passed during SDD apply
- [x] `go test ./internal/directory ./internal/http` passed during SDD apply
- [x] No build was run

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers