### PR TITLE
feat(clinical): add standalone patient notes

### DIFF
--- a/services/directory-service/internal/directory/clinical.go
+++ b/services/directory-service/internal/directory/clinical.go
@@ -43,6 +43,24 @@ type ClinicalNote struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+type PatientClinicalNote struct {
+	ID             string    `json:"id"`
+	PatientID      string    `json:"patient_id"`
+	ProfessionalID string    `json:"professional_id"`
+	Content        string    `json:"content"`
+	ConsultationID *string   `json:"consultation_id"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type PatientClinicalNoteParams struct {
+	PatientID       string  `json:"-"`
+	ProfessionalID  string  `json:"-"`
+	Content         string  `json:"content"`
+	ConsultationID  *string `json:"consultation_id,omitempty"`
+	SetConsultation bool    `json:"-"`
+}
+
 type ClinicalHistory struct {
 	ID                  string    `json:"id"`
 	PatientID           string    `json:"patient_id"`
@@ -170,6 +188,130 @@ func (r *Repository) UpdateClinicalHistory(ctx context.Context, params UpdateCli
 		normalized.SetHabits, normalized.Habits,
 		normalized.SetGeneralObservations, normalized.GeneralObservations,
 	))
+}
+
+func (r *Repository) CreatePatientClinicalNote(ctx context.Context, params PatientClinicalNoteParams) (PatientClinicalNote, error) {
+	normalized, err := validatePatientClinicalNoteParams(params)
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+	if err := r.ensureClinicalPatientExists(ctx, normalized.PatientID); err != nil {
+		return PatientClinicalNote{}, err
+	}
+
+	return scanPatientClinicalNote(r.db.QueryRowContext(ctx, `
+		INSERT INTO clinical_notes (patient_id, professional_id, kind, content, consultation_id)
+		VALUES ($1, $2, 'standalone', $3, $4)
+		RETURNING id, patient_id, professional_id, content, consultation_id, created_at, updated_at
+	`, normalized.PatientID, normalized.ProfessionalID, normalized.Content, normalized.ConsultationID))
+}
+
+func (r *Repository) ListPatientClinicalNotes(ctx context.Context, patientID string) ([]PatientClinicalNote, error) {
+	normalizedPatientID, err := validateClinicalHistoryPatientID(patientID)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.ensureClinicalPatientExists(ctx, normalizedPatientID); err != nil {
+		return nil, err
+	}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, patient_id, professional_id, content, consultation_id, created_at, updated_at
+		FROM clinical_notes
+		WHERE patient_id = $1 AND kind = 'standalone'
+		ORDER BY created_at DESC, id DESC
+	`, normalizedPatientID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	notes := make([]PatientClinicalNote, 0)
+	for rows.Next() {
+		note, err := scanPatientClinicalNote(rows)
+		if err != nil {
+			return nil, err
+		}
+		notes = append(notes, note)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return notes, nil
+}
+
+func (r *Repository) GetPatientClinicalNote(ctx context.Context, patientID, noteID string) (PatientClinicalNote, error) {
+	normalizedPatientID, normalizedNoteID, err := validatePatientClinicalNoteIdentity(patientID, noteID)
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+
+	note, err := scanPatientClinicalNote(r.db.QueryRowContext(ctx, `
+		SELECT id, patient_id, professional_id, content, consultation_id, created_at, updated_at
+		FROM clinical_notes
+		WHERE id = $1 AND patient_id = $2 AND kind = 'standalone'
+	`, normalizedNoteID, normalizedPatientID))
+	if isNoRows(err) {
+		return PatientClinicalNote{}, ErrNotFound
+	}
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+
+	return note, nil
+}
+
+func (r *Repository) UpdatePatientClinicalNote(ctx context.Context, noteID string, params PatientClinicalNoteParams) (PatientClinicalNote, error) {
+	normalizedNoteID, err := validatePatientClinicalNoteID(noteID)
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+	normalized, err := validatePatientClinicalNoteParams(params)
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+
+	note, err := scanPatientClinicalNote(r.db.QueryRowContext(ctx, `
+		UPDATE clinical_notes
+		SET content = $3,
+			consultation_id = CASE WHEN $4 THEN $5::uuid ELSE consultation_id END,
+			updated_at = NOW()
+		WHERE id = $1 AND patient_id = $2 AND kind = 'standalone'
+		RETURNING id, patient_id, professional_id, content, consultation_id, created_at, updated_at
+	`, normalizedNoteID, normalized.PatientID, normalized.Content, normalized.SetConsultation, normalized.ConsultationID))
+	if isNoRows(err) {
+		return PatientClinicalNote{}, ErrNotFound
+	}
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+
+	return note, nil
+}
+
+func (r *Repository) DeletePatientClinicalNote(ctx context.Context, patientID, noteID string) error {
+	normalizedPatientID, normalizedNoteID, err := validatePatientClinicalNoteIdentity(patientID, noteID)
+	if err != nil {
+		return err
+	}
+
+	result, err := r.db.ExecContext(ctx, `
+		DELETE FROM clinical_notes
+		WHERE id = $1 AND patient_id = $2 AND kind = 'standalone'
+	`, normalizedNoteID, normalizedPatientID)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
 }
 
 func (r *Repository) CreateEncounter(ctx context.Context, params CreateEncounterParams) (Encounter, error) {
@@ -373,6 +515,68 @@ func validateUpdateClinicalHistoryParams(params UpdateClinicalHistoryParams) (Up
 	return normalized, nil
 }
 
+func validatePatientClinicalNoteParams(params PatientClinicalNoteParams) (PatientClinicalNoteParams, error) {
+	normalizedPatientID, normalizedProfessionalID, err := validateEncounterOwnership(params.PatientID, params.ProfessionalID)
+	if err != nil {
+		return PatientClinicalNoteParams{}, err
+	}
+
+	normalized := PatientClinicalNoteParams{
+		PatientID:       normalizedPatientID,
+		ProfessionalID:  normalizedProfessionalID,
+		Content:         strings.TrimSpace(params.Content),
+		SetConsultation: params.SetConsultation || params.ConsultationID != nil,
+	}
+	if normalized.Content == "" {
+		return PatientClinicalNoteParams{}, ErrValidation
+	}
+
+	consultationID, err := normalizeOptionalUUID(params.ConsultationID)
+	if err != nil {
+		return PatientClinicalNoteParams{}, err
+	}
+	normalized.ConsultationID = consultationID
+
+	return normalized, nil
+}
+
+func validatePatientClinicalNoteIdentity(patientID, noteID string) (string, string, error) {
+	normalizedPatientID, err := validateClinicalHistoryPatientID(patientID)
+	if err != nil {
+		return "", "", err
+	}
+	normalizedNoteID, err := validatePatientClinicalNoteID(noteID)
+	if err != nil {
+		return "", "", err
+	}
+
+	return normalizedPatientID, normalizedNoteID, nil
+}
+
+func validatePatientClinicalNoteID(noteID string) (string, error) {
+	normalizedNoteID := strings.TrimSpace(noteID)
+	if _, err := uuid.Parse(normalizedNoteID); err != nil {
+		return "", ErrNotFound
+	}
+
+	return normalizedNoteID, nil
+}
+
+func normalizeOptionalUUID(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	normalized := strings.TrimSpace(*value)
+	if normalized == "" {
+		return nil, nil
+	}
+	if _, err := uuid.Parse(normalized); err != nil {
+		return nil, ErrValidation
+	}
+
+	return &normalized, nil
+}
+
 func validateClinicalHistoryPatientID(patientID string) (string, error) {
 	normalizedPatientID := strings.TrimSpace(patientID)
 	if _, err := uuid.Parse(normalizedPatientID); err != nil {
@@ -380,6 +584,20 @@ func validateClinicalHistoryPatientID(patientID string) (string, error) {
 	}
 
 	return normalizedPatientID, nil
+}
+
+func (r *Repository) ensureClinicalPatientExists(ctx context.Context, patientID string) error {
+	var patientExists bool
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM patients WHERE id = $1)
+	`, patientID).Scan(&patientExists); err != nil {
+		return err
+	}
+	if !patientExists {
+		return ErrNotFound
+	}
+
+	return nil
 }
 
 func validateClinicalMeasurement(value *float64, max float64) error {
@@ -487,6 +705,28 @@ func scanClinicalNote(scanner clinicalNoteScanner) (ClinicalNote, error) {
 	if err != nil {
 		return ClinicalNote{}, err
 	}
+
+	return note, nil
+}
+
+func scanPatientClinicalNote(scanner clinicalNoteScanner) (PatientClinicalNote, error) {
+	var note PatientClinicalNote
+	var consultationID sql.NullString
+
+	err := scanner.Scan(
+		&note.ID,
+		&note.PatientID,
+		&note.ProfessionalID,
+		&note.Content,
+		&consultationID,
+		&note.CreatedAt,
+		&note.UpdatedAt,
+	)
+	if err != nil {
+		return PatientClinicalNote{}, err
+	}
+
+	note.ConsultationID = nullStringPtr(consultationID)
 
 	return note, nil
 }

--- a/services/directory-service/internal/directory/clinical_postgres_integration_test.go
+++ b/services/directory-service/internal/directory/clinical_postgres_integration_test.go
@@ -127,6 +127,127 @@ func TestRepositoryIntegrationClinicalHistoryMissingPatientReturnsNotFound(t *te
 	}
 }
 
+func TestRepositoryIntegrationPatientClinicalNotesLifecycle(t *testing.T) {
+	repo, db := newPostgresIntegrationRepository(t)
+
+	patient := seedClinicalPatient(t, repo, "patient-notes")
+	professional := seedClinicalProfessional(t, repo, "patient-notes")
+	consultationID := "2ba4fc4a-6a4b-4e82-9af8-86a80f7f6f5a"
+
+	standalone, err := repo.CreatePatientClinicalNote(context.Background(), PatientClinicalNoteParams{
+		PatientID:      patient.ID,
+		ProfessionalID: professional.ID,
+		Content:        " Nota autónoma ",
+	})
+	if err != nil {
+		t.Fatalf("create standalone note: %v", err)
+	}
+	if standalone.PatientID != patient.ID {
+		t.Fatalf("standalone patient_id = %q, want %q", standalone.PatientID, patient.ID)
+	}
+	if standalone.Content != "Nota autónoma" {
+		t.Fatalf("standalone content = %q, want Nota autónoma", standalone.Content)
+	}
+	if standalone.ConsultationID != nil {
+		t.Fatalf("standalone consultation_id = %v, want nil", standalone.ConsultationID)
+	}
+
+	linked, err := repo.CreatePatientClinicalNote(context.Background(), PatientClinicalNoteParams{
+		PatientID:       patient.ID,
+		ProfessionalID:  professional.ID,
+		Content:         "Nota vinculada.",
+		ConsultationID:  &consultationID,
+		SetConsultation: true,
+	})
+	if err != nil {
+		t.Fatalf("create linked note: %v", err)
+	}
+	if linked.ConsultationID == nil || *linked.ConsultationID != consultationID {
+		t.Fatalf("linked consultation_id = %v, want %s", linked.ConsultationID, consultationID)
+	}
+
+	notes, err := repo.ListPatientClinicalNotes(context.Background(), patient.ID)
+	if err != nil {
+		t.Fatalf("list patient notes: %v", err)
+	}
+	if len(notes) != 2 {
+		t.Fatalf("notes listed = %d, want 2", len(notes))
+	}
+	if notes[0].ID != linked.ID || notes[1].ID != standalone.ID {
+		t.Fatalf("notes order = [%s %s], want newest linked then standalone", notes[0].ID, notes[1].ID)
+	}
+
+	cleared, err := repo.UpdatePatientClinicalNote(context.Background(), linked.ID, PatientClinicalNoteParams{
+		PatientID:       patient.ID,
+		ProfessionalID:  professional.ID,
+		Content:         "Nota actualizada.",
+		SetConsultation: true,
+	})
+	if err != nil {
+		t.Fatalf("update linked note: %v", err)
+	}
+	if cleared.Content != "Nota actualizada." {
+		t.Fatalf("updated content = %q, want Nota actualizada.", cleared.Content)
+	}
+	if cleared.ConsultationID != nil {
+		t.Fatalf("updated consultation_id = %v, want nil", cleared.ConsultationID)
+	}
+
+	if got := countClinicalHistory(t, db); got != 0 {
+		t.Fatalf("clinical history rows = %d, want 0", got)
+	}
+
+	if err := repo.DeletePatientClinicalNote(context.Background(), patient.ID, linked.ID); err != nil {
+		t.Fatalf("delete linked note: %v", err)
+	}
+	notes, err = repo.ListPatientClinicalNotes(context.Background(), patient.ID)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(notes) != 1 || notes[0].ID != standalone.ID {
+		t.Fatalf("notes after delete = %+v, want only standalone note %s", notes, standalone.ID)
+	}
+}
+
+func TestRepositoryIntegrationPatientClinicalNotesPreserveEncounterCompatibility(t *testing.T) {
+	repo, _ := newPostgresIntegrationRepository(t)
+
+	patient := seedClinicalPatient(t, repo, "notes-compat")
+	professional := seedClinicalProfessional(t, repo, "notes-compat")
+
+	encounter, err := repo.CreateEncounter(context.Background(), CreateEncounterParams{
+		PatientID:      patient.ID,
+		ProfessionalID: professional.ID,
+		OccurredAt:     time.Date(2026, 4, 7, 14, 30, 0, 0, time.UTC).Format(time.RFC3339),
+		Note:           "Nota inicial de encuentro.",
+	})
+	if err != nil {
+		t.Fatalf("create encounter: %v", err)
+	}
+	_, err = repo.CreatePatientClinicalNote(context.Background(), PatientClinicalNoteParams{
+		PatientID:      patient.ID,
+		ProfessionalID: professional.ID,
+		Content:        "Nota autónoma fuera del encuentro.",
+	})
+	if err != nil {
+		t.Fatalf("create standalone note: %v", err)
+	}
+
+	encounters, err := repo.ListPatientEncounters(context.Background(), patient.ID, professional.ID)
+	if err != nil {
+		t.Fatalf("list patient encounters: %v", err)
+	}
+	if len(encounters) != 1 {
+		t.Fatalf("encounters listed = %d, want 1", len(encounters))
+	}
+	if encounters[0].ID != encounter.ID {
+		t.Fatalf("encounter id = %q, want %q", encounters[0].ID, encounter.ID)
+	}
+	if encounters[0].InitialNote.Kind != "initial" || encounters[0].InitialNote.Content != "Nota inicial de encuentro." {
+		t.Fatalf("initial note = %+v, want original encounter initial note", encounters[0].InitialNote)
+	}
+}
+
 func TestRepositoryIntegrationListPatientEncountersScopesByPatientAndProfessional(t *testing.T) {
 	repo, db := newPostgresIntegrationRepository(t)
 

--- a/services/directory-service/internal/directory/clinical_test.go
+++ b/services/directory-service/internal/directory/clinical_test.go
@@ -154,6 +154,120 @@ func TestValidateUpdateClinicalHistoryParams(t *testing.T) {
 	}
 }
 
+func TestValidatePatientClinicalNoteParams(t *testing.T) {
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	consultationID := "2ba4fc4a-6a4b-4e82-9af8-86a80f7f6f5a"
+	blankConsultationID := "   "
+
+	tests := []struct {
+		name    string
+		params  PatientClinicalNoteParams
+		want    PatientClinicalNoteParams
+		wantErr error
+	}{
+		{
+			name: "standalone note trims content without consultation reference",
+			params: PatientClinicalNoteParams{
+				PatientID:      " " + patientID + " ",
+				ProfessionalID: " " + professionalID + " ",
+				Content:        "  Evolución estable  ",
+			},
+			want: PatientClinicalNoteParams{
+				PatientID:      patientID,
+				ProfessionalID: professionalID,
+				Content:        "Evolución estable",
+			},
+		},
+		{
+			name: "consultation reference is trimmed and preserved when valid UUID",
+			params: PatientClinicalNoteParams{
+				PatientID:       patientID,
+				ProfessionalID:  professionalID,
+				Content:         "Control vinculado.",
+				ConsultationID:  stringPtr(" " + consultationID + " "),
+				SetConsultation: true,
+			},
+			want: PatientClinicalNoteParams{
+				PatientID:       patientID,
+				ProfessionalID:  professionalID,
+				Content:         "Control vinculado.",
+				ConsultationID:  &consultationID,
+				SetConsultation: true,
+			},
+		},
+		{
+			name: "blank consultation reference normalizes to nil",
+			params: PatientClinicalNoteParams{
+				PatientID:       patientID,
+				ProfessionalID:  professionalID,
+				Content:         "Control sin referencia.",
+				ConsultationID:  &blankConsultationID,
+				SetConsultation: true,
+			},
+			want: PatientClinicalNoteParams{
+				PatientID:       patientID,
+				ProfessionalID:  professionalID,
+				Content:         "Control sin referencia.",
+				ConsultationID:  nil,
+				SetConsultation: true,
+			},
+		},
+		{
+			name: "malformed consultation reference is rejected",
+			params: PatientClinicalNoteParams{
+				PatientID:      patientID,
+				ProfessionalID: professionalID,
+				Content:        "Control vinculado.",
+				ConsultationID: stringPtr("not-a-uuid"),
+			},
+			wantErr: ErrValidation,
+		},
+		{
+			name: "blank content is rejected",
+			params: PatientClinicalNoteParams{
+				PatientID:      patientID,
+				ProfessionalID: professionalID,
+				Content:        "   ",
+			},
+			wantErr: ErrValidation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validatePatientClinicalNoteParams(tt.params)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+
+			assertPatientClinicalNoteParams(t, got, tt.want)
+		})
+	}
+}
+
+func assertPatientClinicalNoteParams(t *testing.T, got, want PatientClinicalNoteParams) {
+	t.Helper()
+
+	if got.PatientID != want.PatientID {
+		t.Fatalf("patientID = %q, want %q", got.PatientID, want.PatientID)
+	}
+	if got.ProfessionalID != want.ProfessionalID {
+		t.Fatalf("professionalID = %q, want %q", got.ProfessionalID, want.ProfessionalID)
+	}
+	if got.Content != want.Content {
+		t.Fatalf("content = %q, want %q", got.Content, want.Content)
+	}
+	if got.SetConsultation != want.SetConsultation {
+		t.Fatalf("set consultation = %v, want %v", got.SetConsultation, want.SetConsultation)
+	}
+	assertStringPtr(t, "consultation", got.ConsultationID, want.ConsultationID)
+}
+
 func assertUpdateClinicalHistoryParams(t *testing.T, got, want UpdateClinicalHistoryParams) {
 	t.Helper()
 

--- a/services/directory-service/internal/directory/repository_postgres_integration_helpers_test.go
+++ b/services/directory-service/internal/directory/repository_postgres_integration_helpers_test.go
@@ -203,6 +203,12 @@ func countClinicalNotes(t *testing.T, db *sql.DB) int {
 	return countTableRows(t, db, "clinical_notes")
 }
 
+func countClinicalHistory(t *testing.T, db *sql.DB) int {
+	t.Helper()
+
+	return countTableRows(t, db, "clinical_history")
+}
+
 func countTableRows(t *testing.T, db *sql.DB, table string) int {
 	t.Helper()
 

--- a/services/directory-service/internal/http/server.go
+++ b/services/directory-service/internal/http/server.go
@@ -35,6 +35,11 @@ type directoryRepository interface {
 	ListPatientEncounters(ctx context.Context, patientID, professionalID string) ([]directory.Encounter, error)
 	GetClinicalHistory(ctx context.Context, patientID string) (directory.ClinicalHistory, error)
 	UpdateClinicalHistory(ctx context.Context, params directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error)
+	CreatePatientClinicalNote(ctx context.Context, params directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error)
+	ListPatientClinicalNotes(ctx context.Context, patientID string) ([]directory.PatientClinicalNote, error)
+	GetPatientClinicalNote(ctx context.Context, patientID, noteID string) (directory.PatientClinicalNote, error)
+	UpdatePatientClinicalNote(ctx context.Context, noteID string, params directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error)
+	DeletePatientClinicalNote(ctx context.Context, patientID, noteID string) error
 	CreateProfessional(ctx context.Context, params directory.CreateProfessionalParams) (directory.Professional, error)
 	ListProfessionals(ctx context.Context) ([]directory.Professional, error)
 	GetProfessionalByID(ctx context.Context, id string) (directory.Professional, error)
@@ -87,6 +92,12 @@ type loginResponse struct {
 type createEncounterRequest struct {
 	OccurredAt string `json:"occurred_at"`
 	Note       string `json:"note"`
+}
+
+type patientClinicalNoteRequest struct {
+	Content         string  `json:"content"`
+	ConsultationID  *string `json:"consultation_id"`
+	SetConsultation bool    `json:"-"`
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
@@ -207,6 +218,14 @@ func (s *Server) patientByID(w http.ResponseWriter, r *http.Request) {
 		s.patientClinicalHistory(w, r, parts[0])
 		return
 	}
+	if len(parts) == 2 && parts[1] == "clinical-notes" {
+		s.patientClinicalNotes(w, r, parts[0])
+		return
+	}
+	if len(parts) == 3 && parts[1] == "clinical-notes" {
+		s.patientClinicalNoteByID(w, r, parts[0], parts[2])
+		return
+	}
 
 	http.NotFound(w, r)
 }
@@ -249,6 +268,30 @@ func (s *Server) patientClinicalHistory(w http.ResponseWriter, r *http.Request, 
 		s.updateClinicalHistory(w, r, patientID)
 	default:
 		writeMethodNotAllowed(w, http.MethodGet, http.MethodPatch)
+	}
+}
+
+func (s *Server) patientClinicalNotes(w http.ResponseWriter, r *http.Request, patientID string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listPatientClinicalNotes(w, r, patientID)
+	case http.MethodPost:
+		s.createPatientClinicalNote(w, r, patientID)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
+	}
+}
+
+func (s *Server) patientClinicalNoteByID(w http.ResponseWriter, r *http.Request, patientID, noteID string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getPatientClinicalNote(w, r, patientID, noteID)
+	case http.MethodPatch:
+		s.updatePatientClinicalNote(w, r, patientID, noteID)
+	case http.MethodDelete:
+		s.deletePatientClinicalNote(w, r, patientID, noteID)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPatch, http.MethodDelete)
 	}
 }
 
@@ -494,6 +537,187 @@ func (s *Server) updateClinicalHistory(w http.ResponseWriter, r *http.Request, p
 	}
 
 	writeJSON(w, http.StatusOK, history)
+}
+
+func (s *Server) listPatientClinicalNotes(w http.ResponseWriter, r *http.Request, patientID string) {
+	if _, err := s.currentDoctorUser(r); errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	notes, err := s.repo.ListPatientClinicalNotes(r.Context(), patientID)
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "patient not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list clinical notes")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"items": notes})
+}
+
+func (s *Server) createPatientClinicalNote(w http.ResponseWriter, r *http.Request, patientID string) {
+	user, err := s.currentDoctorUser(r)
+	if errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	request, err := decodePatientClinicalNoteRequest(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	note, err := s.repo.CreatePatientClinicalNote(r.Context(), directory.PatientClinicalNoteParams{
+		PatientID:       patientID,
+		ProfessionalID:  *user.ProfessionalID,
+		Content:         request.Content,
+		ConsultationID:  request.ConsultationID,
+		SetConsultation: request.SetConsultation,
+	})
+	if errors.Is(err, directory.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "failed to create clinical note")
+		return
+	}
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "patient not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create clinical note")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, note)
+}
+
+func (s *Server) getPatientClinicalNote(w http.ResponseWriter, r *http.Request, patientID, noteID string) {
+	if _, err := s.currentDoctorUser(r); errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	note, err := s.repo.GetPatientClinicalNote(r.Context(), patientID, noteID)
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "clinical note not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load clinical note")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, note)
+}
+
+func (s *Server) updatePatientClinicalNote(w http.ResponseWriter, r *http.Request, patientID, noteID string) {
+	user, err := s.currentDoctorUser(r)
+	if errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	request, err := decodePatientClinicalNoteRequest(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	note, err := s.repo.UpdatePatientClinicalNote(r.Context(), noteID, directory.PatientClinicalNoteParams{
+		PatientID:       patientID,
+		ProfessionalID:  *user.ProfessionalID,
+		Content:         request.Content,
+		ConsultationID:  request.ConsultationID,
+		SetConsultation: request.SetConsultation,
+	})
+	if errors.Is(err, directory.ErrValidation) {
+		writeError(w, http.StatusBadRequest, "failed to update clinical note")
+		return
+	}
+	if errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "clinical note not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update clinical note")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, note)
+}
+
+func (s *Server) deletePatientClinicalNote(w http.ResponseWriter, r *http.Request, patientID, noteID string) {
+	if _, err := s.currentDoctorUser(r); errors.Is(err, directory.ErrUnauthorized) {
+		writeUnauthorized(w)
+		return
+	} else if errors.Is(err, directory.ErrForbidden) {
+		writeForbidden(w, authorizationErrorMessage(err))
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current user")
+		return
+	}
+
+	if err := s.repo.DeletePatientClinicalNote(r.Context(), patientID, noteID); errors.Is(err, directory.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "clinical note not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete clinical note")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func decodePatientClinicalNoteRequest(r *http.Request) (patientClinicalNoteRequest, error) {
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+		return patientClinicalNoteRequest{}, err
+	}
+
+	var request patientClinicalNoteRequest
+	if value, ok := raw["content"]; ok {
+		if err := json.Unmarshal(value, &request.Content); err != nil {
+			return patientClinicalNoteRequest{}, err
+		}
+	}
+	if value, ok := raw["consultation_id"]; ok {
+		request.SetConsultation = true
+		if string(value) != "null" {
+			if err := json.Unmarshal(value, &request.ConsultationID); err != nil {
+				return patientClinicalNoteRequest{}, err
+			}
+		}
+	}
+
+	return request, nil
 }
 
 func (s *Server) createProfessional(w http.ResponseWriter, r *http.Request) {

--- a/services/directory-service/internal/http/server_test.go
+++ b/services/directory-service/internal/http/server_test.go
@@ -405,6 +405,238 @@ func TestClinicalHistoryReturnsNotFoundForMissingPatient(t *testing.T) {
 	}
 }
 
+func TestListPatientClinicalNotesReturnsOrderedItemsForDoctor(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	consultationID := "2ba4fc4a-6a4b-4e82-9af8-86a80f7f6f5a"
+	now := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		listPatientClinicalNotesFn: func(_ context.Context, gotPatientID string) ([]directory.PatientClinicalNote, error) {
+			if gotPatientID != patientID {
+				t.Fatalf("patientID = %q, want %q", gotPatientID, patientID)
+			}
+			return []directory.PatientClinicalNote{
+				{ID: "note-new", PatientID: patientID, ProfessionalID: professionalID, Content: "Más reciente", ConsultationID: &consultationID, CreatedAt: now.Add(time.Minute), UpdatedAt: now.Add(time.Minute)},
+				{ID: "note-old", PatientID: patientID, ProfessionalID: professionalID, Content: "Anterior", CreatedAt: now, UpdatedAt: now},
+			}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/patients/"+patientID+"/clinical-notes", nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var response struct {
+		Items []directory.PatientClinicalNote `json:"items"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(response.Items))
+	}
+	if response.Items[0].ID != "note-new" || response.Items[1].ID != "note-old" {
+		t.Fatalf("note order = [%s %s], want [note-new note-old]", response.Items[0].ID, response.Items[1].ID)
+	}
+	if response.Items[0].ConsultationID == nil || *response.Items[0].ConsultationID != consultationID {
+		t.Fatalf("consultation_id = %v, want %s", response.Items[0].ConsultationID, consultationID)
+	}
+	if response.Items[1].ConsultationID != nil {
+		t.Fatalf("standalone consultation_id = %v, want nil", response.Items[1].ConsultationID)
+	}
+}
+
+func TestCreatePatientClinicalNoteReturnsCreatedStandaloneNote(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	now := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		createPatientClinicalNoteFn: func(_ context.Context, params directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error) {
+			if params.PatientID != patientID {
+				t.Fatalf("patientID = %q, want %q", params.PatientID, patientID)
+			}
+			if params.ProfessionalID != professionalID {
+				t.Fatalf("professionalID = %q, want %q", params.ProfessionalID, professionalID)
+			}
+			if params.Content != " Nota autónoma " {
+				t.Fatalf("content = %q, want raw payload", params.Content)
+			}
+			if params.ConsultationID != nil {
+				t.Fatalf("consultationID = %v, want nil", params.ConsultationID)
+			}
+			return directory.PatientClinicalNote{ID: "note-1", PatientID: patientID, ProfessionalID: professionalID, Content: "Nota autónoma", CreatedAt: now, UpdatedAt: now}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/patients/"+patientID+"/clinical-notes", bytes.NewBufferString(`{"content":" Nota autónoma "}`))
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusCreated)
+	}
+
+	var note directory.PatientClinicalNote
+	if err := json.NewDecoder(recorder.Body).Decode(&note); err != nil {
+		t.Fatalf("decode note: %v", err)
+	}
+	if note.ID != "note-1" || note.Content != "Nota autónoma" {
+		t.Fatalf("note = %+v, want created standalone note", note)
+	}
+}
+
+func TestPatchPatientClinicalNoteClearsConsultationReference(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	noteID := "85daae39-e679-4a14-b1e9-fcfbd2912f60"
+	now := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		updatePatientClinicalNoteFn: func(_ context.Context, gotNoteID string, params directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error) {
+			if gotNoteID != noteID {
+				t.Fatalf("noteID = %q, want %q", gotNoteID, noteID)
+			}
+			if params.PatientID != patientID || params.ProfessionalID != professionalID {
+				t.Fatalf("params ownership = %+v, want patient/professional ids", params)
+			}
+			if params.Content != "Nota actualizada." {
+				t.Fatalf("content = %q, want Nota actualizada.", params.Content)
+			}
+			if !params.SetConsultation || params.ConsultationID != nil {
+				t.Fatalf("consultation clear params = set %v value %v, want explicit nil", params.SetConsultation, params.ConsultationID)
+			}
+			return directory.PatientClinicalNote{ID: noteID, PatientID: patientID, ProfessionalID: professionalID, Content: "Nota actualizada.", CreatedAt: now, UpdatedAt: now}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPatch, "/patients/"+patientID+"/clinical-notes/"+noteID, bytes.NewBufferString(`{"content":"Nota actualizada.","consultation_id":null}`))
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var note directory.PatientClinicalNote
+	if err := json.NewDecoder(recorder.Body).Decode(&note); err != nil {
+		t.Fatalf("decode note: %v", err)
+	}
+	if note.ConsultationID != nil || note.Content != "Nota actualizada." {
+		t.Fatalf("note = %+v, want updated note without consultation", note)
+	}
+}
+
+func TestDeletePatientClinicalNoteReturnsNoContent(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+	noteID := "85daae39-e679-4a14-b1e9-fcfbd2912f60"
+
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+		},
+		deletePatientClinicalNoteFn: func(_ context.Context, gotPatientID, gotNoteID string) error {
+			if gotPatientID != patientID || gotNoteID != noteID {
+				t.Fatalf("delete args = patient %q note %q, want patient %q note %q", gotPatientID, gotNoteID, patientID, noteID)
+			}
+			return nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/patients/"+patientID+"/clinical-notes/"+noteID, nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestPatientClinicalNotesReturnForbiddenForSecretary(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	repo := &stubDirectoryRepository{
+		getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+			return directory.User{ID: "user-1", Email: "secretary@clinic.local", Role: "secretary", ProfessionalID: &professionalID, Active: true}, nil
+		},
+	}
+
+	server := NewServer(testConfig(), repo)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/patients/0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca/clinical-notes", nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestPatientClinicalNotesMapValidationAndMissingPatient(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+
+	tests := []struct {
+		name       string
+		repoError  error
+		wantStatus int
+	}{
+		{name: "validation", repoError: directory.ErrValidation, wantStatus: http.StatusBadRequest},
+		{name: "missing patient", repoError: directory.ErrNotFound, wantStatus: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubDirectoryRepository{
+				getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+					return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+				},
+				createPatientClinicalNoteFn: func(context.Context, directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error) {
+					return directory.PatientClinicalNote{}, tt.repoError
+				},
+			}
+
+			server := NewServer(testConfig(), repo)
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/patients/"+patientID+"/clinical-notes", bytes.NewBufferString(`{"content":"Nota"}`))
+			request.Header.Set("Authorization", "Bearer test-token")
+
+			server.ServeHTTP(recorder, request)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
 func TestLoginReturnsAccessToken(t *testing.T) {
 	repo := &stubDirectoryRepository{
 		authenticateUserFn: func(_ context.Context, email, password string) (directory.User, error) {
@@ -797,20 +1029,25 @@ func TestInternalPatientByDocumentReturnsPatientWithoutAuth(t *testing.T) {
 }
 
 type stubDirectoryRepository struct {
-	createPatientFn         func(context.Context, directory.CreatePatientParams) (directory.Patient, error)
-	listPatientsFn          func(context.Context) ([]directory.Patient, error)
-	getPatientByIDFn        func(context.Context, string) (directory.Patient, error)
-	getPatientByDocumentFn  func(context.Context, string) (directory.Patient, error)
-	createEncounterFn       func(context.Context, directory.CreateEncounterParams) (directory.Encounter, error)
-	listPatientEncountersFn func(context.Context, string, string) ([]directory.Encounter, error)
-	getClinicalHistoryFn    func(context.Context, string) (directory.ClinicalHistory, error)
-	updateClinicalHistoryFn func(context.Context, directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error)
-	createProfessionalFn    func(context.Context, directory.CreateProfessionalParams) (directory.Professional, error)
-	listProfessionalsFn     func(context.Context) ([]directory.Professional, error)
-	getProfessionalByIDFn   func(context.Context, string) (directory.Professional, error)
-	authenticateUserFn      func(context.Context, string, string) (directory.User, error)
-	createSessionFn         func(context.Context, string, string, time.Time) error
-	getUserBySessionTokenFn func(context.Context, string, time.Time) (directory.User, error)
+	createPatientFn             func(context.Context, directory.CreatePatientParams) (directory.Patient, error)
+	listPatientsFn              func(context.Context) ([]directory.Patient, error)
+	getPatientByIDFn            func(context.Context, string) (directory.Patient, error)
+	getPatientByDocumentFn      func(context.Context, string) (directory.Patient, error)
+	createEncounterFn           func(context.Context, directory.CreateEncounterParams) (directory.Encounter, error)
+	listPatientEncountersFn     func(context.Context, string, string) ([]directory.Encounter, error)
+	getClinicalHistoryFn        func(context.Context, string) (directory.ClinicalHistory, error)
+	updateClinicalHistoryFn     func(context.Context, directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error)
+	createPatientClinicalNoteFn func(context.Context, directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error)
+	listPatientClinicalNotesFn  func(context.Context, string) ([]directory.PatientClinicalNote, error)
+	getPatientClinicalNoteFn    func(context.Context, string, string) (directory.PatientClinicalNote, error)
+	updatePatientClinicalNoteFn func(context.Context, string, directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error)
+	deletePatientClinicalNoteFn func(context.Context, string, string) error
+	createProfessionalFn        func(context.Context, directory.CreateProfessionalParams) (directory.Professional, error)
+	listProfessionalsFn         func(context.Context) ([]directory.Professional, error)
+	getProfessionalByIDFn       func(context.Context, string) (directory.Professional, error)
+	authenticateUserFn          func(context.Context, string, string) (directory.User, error)
+	createSessionFn             func(context.Context, string, string, time.Time) error
+	getUserBySessionTokenFn     func(context.Context, string, time.Time) (directory.User, error)
 }
 
 func (s *stubDirectoryRepository) CreatePatient(ctx context.Context, params directory.CreatePatientParams) (directory.Patient, error) {
@@ -867,6 +1104,41 @@ func (s *stubDirectoryRepository) UpdateClinicalHistory(ctx context.Context, par
 		return directory.ClinicalHistory{}, errors.New("unexpected UpdateClinicalHistory call")
 	}
 	return s.updateClinicalHistoryFn(ctx, params)
+}
+
+func (s *stubDirectoryRepository) CreatePatientClinicalNote(ctx context.Context, params directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error) {
+	if s.createPatientClinicalNoteFn == nil {
+		return directory.PatientClinicalNote{}, errors.New("unexpected CreatePatientClinicalNote call")
+	}
+	return s.createPatientClinicalNoteFn(ctx, params)
+}
+
+func (s *stubDirectoryRepository) ListPatientClinicalNotes(ctx context.Context, patientID string) ([]directory.PatientClinicalNote, error) {
+	if s.listPatientClinicalNotesFn == nil {
+		return nil, errors.New("unexpected ListPatientClinicalNotes call")
+	}
+	return s.listPatientClinicalNotesFn(ctx, patientID)
+}
+
+func (s *stubDirectoryRepository) GetPatientClinicalNote(ctx context.Context, patientID, noteID string) (directory.PatientClinicalNote, error) {
+	if s.getPatientClinicalNoteFn == nil {
+		return directory.PatientClinicalNote{}, errors.New("unexpected GetPatientClinicalNote call")
+	}
+	return s.getPatientClinicalNoteFn(ctx, patientID, noteID)
+}
+
+func (s *stubDirectoryRepository) UpdatePatientClinicalNote(ctx context.Context, noteID string, params directory.PatientClinicalNoteParams) (directory.PatientClinicalNote, error) {
+	if s.updatePatientClinicalNoteFn == nil {
+		return directory.PatientClinicalNote{}, errors.New("unexpected UpdatePatientClinicalNote call")
+	}
+	return s.updatePatientClinicalNoteFn(ctx, noteID, params)
+}
+
+func (s *stubDirectoryRepository) DeletePatientClinicalNote(ctx context.Context, patientID, noteID string) error {
+	if s.deletePatientClinicalNoteFn == nil {
+		return errors.New("unexpected DeletePatientClinicalNote call")
+	}
+	return s.deletePatientClinicalNoteFn(ctx, patientID, noteID)
 }
 
 func (s *stubDirectoryRepository) CreateProfessional(ctx context.Context, params directory.CreateProfessionalParams) (directory.Professional, error) {

--- a/services/directory-service/migrations/004_clinical_history_foundation.sql
+++ b/services/directory-service/migrations/004_clinical_history_foundation.sql
@@ -15,3 +15,15 @@ CREATE TABLE IF NOT EXISTS clinical_history (
 );
 
 CREATE INDEX IF NOT EXISTS clinical_history_patient_id_idx ON clinical_history (patient_id);
+
+ALTER TABLE clinical_notes ALTER COLUMN chart_id DROP NOT NULL;
+ALTER TABLE clinical_notes ALTER COLUMN encounter_id DROP NOT NULL;
+ALTER TABLE clinical_notes ADD COLUMN IF NOT EXISTS consultation_id UUID;
+
+CREATE INDEX IF NOT EXISTS clinical_notes_patient_standalone_created_idx
+    ON clinical_notes (patient_id, created_at DESC)
+    WHERE kind = 'standalone';
+
+CREATE INDEX IF NOT EXISTS clinical_notes_consultation_id_idx
+    ON clinical_notes (consultation_id)
+    WHERE consultation_id IS NOT NULL;

--- a/services/directory-service/openapi/openapi.yaml
+++ b/services/directory-service/openapi/openapi.yaml
@@ -261,6 +261,130 @@ paths:
         '500':
           $ref: '#/components/responses/ClinicalHistoryInternalServerError'
 
+  /patients/{id}/clinical-notes:
+    get:
+      summary: List standalone patient clinical notes
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+      responses:
+        '200':
+          description: Clinical notes listed in reverse chronological order
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatientClinicalNoteListResponse'
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/PatientNotFound'
+        '500':
+          $ref: '#/components/responses/ListClinicalNotesInternalServerError'
+    post:
+      summary: Create standalone patient clinical note
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatientClinicalNoteRequest'
+      responses:
+        '201':
+          description: Clinical note created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatientClinicalNote'
+        '400':
+          $ref: '#/components/responses/CreateClinicalNoteBadRequest'
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/PatientNotFound'
+        '500':
+          $ref: '#/components/responses/CreateClinicalNoteInternalServerError'
+
+  /patients/{id}/clinical-notes/{noteID}:
+    get:
+      summary: Get standalone patient clinical note
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+        - $ref: '#/components/parameters/ClinicalNoteID'
+      responses:
+        '200':
+          description: Clinical note found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatientClinicalNote'
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/ClinicalNoteNotFound'
+        '500':
+          $ref: '#/components/responses/GetClinicalNoteInternalServerError'
+    patch:
+      summary: Update standalone patient clinical note
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+        - $ref: '#/components/parameters/ClinicalNoteID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatientClinicalNoteRequest'
+      responses:
+        '200':
+          description: Clinical note updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatientClinicalNote'
+        '400':
+          $ref: '#/components/responses/UpdateClinicalNoteBadRequest'
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/ClinicalNoteNotFound'
+        '500':
+          $ref: '#/components/responses/UpdateClinicalNoteInternalServerError'
+    delete:
+      summary: Delete standalone patient clinical note
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ResourceID'
+        - $ref: '#/components/parameters/ClinicalNoteID'
+      responses:
+        '204':
+          description: Clinical note deleted
+        '401':
+          $ref: '#/components/responses/AuthUnauthorized'
+        '403':
+          $ref: '#/components/responses/ClinicalForbidden'
+        '404':
+          $ref: '#/components/responses/ClinicalNoteNotFound'
+        '500':
+          $ref: '#/components/responses/DeleteClinicalNoteInternalServerError'
+
   /professionals:
     get:
       summary: List professionals
@@ -355,6 +479,13 @@ components:
       required: true
       schema:
         type: string
+    ClinicalNoteID:
+      name: noteID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
   responses:
     CreatePatientBadRequest:
       description: Invalid JSON body or patient validation failure.
@@ -570,6 +701,92 @@ components:
             failed_to_update_clinical_history:
               value:
                 error: failed to update clinical history
+    ClinicalNoteNotFound:
+      description: Standalone clinical note not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            clinical_note_not_found:
+              value:
+                error: clinical note not found
+    CreateClinicalNoteBadRequest:
+      description: Invalid JSON body or clinical note validation failure.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            invalid_json_body:
+              value:
+                error: invalid json body
+            failed_to_create_clinical_note:
+              value:
+                error: failed to create clinical note
+    UpdateClinicalNoteBadRequest:
+      description: Invalid JSON body or clinical note validation failure.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            invalid_json_body:
+              value:
+                error: invalid json body
+            failed_to_update_clinical_note:
+              value:
+                error: failed to update clinical note
+    ListClinicalNotesInternalServerError:
+      description: Unexpected failure while listing clinical notes.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            failed_to_list_clinical_notes:
+              value:
+                error: failed to list clinical notes
+    GetClinicalNoteInternalServerError:
+      description: Unexpected failure while loading clinical note.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            failed_to_load_clinical_note:
+              value:
+                error: failed to load clinical note
+    CreateClinicalNoteInternalServerError:
+      description: Unexpected failure while creating clinical note.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            failed_to_create_clinical_note:
+              value:
+                error: failed to create clinical note
+    UpdateClinicalNoteInternalServerError:
+      description: Unexpected failure while updating clinical note.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            failed_to_update_clinical_note:
+              value:
+                error: failed to update clinical note
+    DeleteClinicalNoteInternalServerError:
+      description: Unexpected failure while deleting clinical note.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            failed_to_delete_clinical_note:
+              value:
+                error: failed to delete clinical note
   schemas:
     ErrorResponse:
       type: object
@@ -808,6 +1025,65 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    PatientClinicalNote:
+      type: object
+      required:
+        - id
+        - patient_id
+        - professional_id
+        - content
+        - consultation_id
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        patient_id:
+          type: string
+          format: uuid
+        professional_id:
+          type: string
+          format: uuid
+        content:
+          type: string
+          minLength: 1
+        consultation_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Optional consultation UUID reference; no cross-service foreign key is enforced.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    PatientClinicalNoteListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PatientClinicalNote'
+
+    PatientClinicalNoteRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - content
+      properties:
+        content:
+          type: string
+          minLength: 1
+        consultation_id:
+          type: string
+          format: uuid
+          nullable: true
 
     Encounter:
       type: object


### PR DESCRIPTION
Closes #48

## PR Type
- [x] New feature

## Summary
- Adds standalone patient clinical notes in directory-service.
- Supports optional nullable `consultation_id` without cross-service FK enforcement.
- Preserves existing encounter note compatibility while adding patient notes CRUD.

## Changes

| File | Change |
|------|--------|
| `services/directory-service/migrations/004_clinical_history_foundation.sql` | Allows standalone clinical notes and adds optional consultation reference |
| `services/directory-service/internal/directory/clinical.go` | Adds patient clinical note model, validation, repository CRUD |
| `services/directory-service/internal/http/server.go` | Adds patient clinical note HTTP routes and handlers |
| `services/directory-service/openapi/openapi.yaml` | Documents patient clinical note contract |
| `services/directory-service/internal/**/*test.go` | Adds focused unit, HTTP, and Postgres integration coverage |

## Test Plan
- [x] Focused notes tests passed during SDD apply
- [x] Combined clinical history/notes/encounter targeted tests passed during SDD apply
- [x] `go test ./internal/directory ./internal/http` passed during SDD apply
- [x] No build was run

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers