### PR TITLE
feat(clinical): add patient history frontend

### DIFF
--- a/services/appointments-service/internal/appointments/consultation_openapi_contract_test.go
+++ b/services/appointments-service/internal/appointments/consultation_openapi_contract_test.go
@@ -1,0 +1,125 @@
+package appointments
+
+import (
+	"bufio"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestConsultationOpenAPIEnumsMatchDomainContract(t *testing.T) {
+	t.Parallel()
+
+	document := readAppointmentsOpenAPI(t)
+
+	wantStatuses := []string{
+		string(ConsultationStatusScheduled),
+		string(ConsultationStatusRequested),
+		string(ConsultationStatusCheckedIn),
+		string(ConsultationStatusCompleted),
+		string(ConsultationStatusCancelled),
+		string(ConsultationStatusNoShow),
+	}
+	wantSources := []string{
+		string(ConsultationSourceOnline),
+		string(ConsultationSourceSecretary),
+		string(ConsultationSourceDoctor),
+		string(ConsultationSourcePatient),
+	}
+
+	tests := []struct {
+		name     string
+		schema   string
+		property string
+		want     []string
+	}{
+		{name: "consultation response status", schema: "Consultation", property: "status", want: wantStatuses},
+		{name: "consultation response source", schema: "Consultation", property: "source", want: wantSources},
+		{name: "create consultation source", schema: "CreateConsultationRequest", property: "source", want: wantSources},
+		{name: "update consultation status", schema: "UpdateConsultationStatusRequest", property: "status", want: wantStatuses},
+		{name: "update consultation source echo", schema: "UpdateConsultationStatusRequest", property: "source", want: wantSources},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := openAPIEnumValues(t, document, tt.schema, tt.property)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("%s.%s enum = %#v, want %#v", tt.schema, tt.property, got, tt.want)
+			}
+		})
+	}
+}
+
+func readAppointmentsOpenAPI(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile("../../openapi/openapi.yaml")
+	if err != nil {
+		t.Fatalf("read appointments OpenAPI document: %v", err)
+	}
+	return string(raw)
+}
+
+func openAPIEnumValues(t *testing.T, document, schema, property string) []string {
+	t.Helper()
+
+	scanner := bufio.NewScanner(strings.NewReader(document))
+	schemaHeader := "    " + schema + ":"
+	propertyHeader := "        " + property + ":"
+
+	inSchema := false
+	inProperty := false
+	inEnum := false
+	values := []string{}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if !inSchema {
+			if line == schemaHeader {
+				inSchema = true
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "    ") && !strings.HasPrefix(line, "      ") && line != schemaHeader {
+			break
+		}
+
+		if !inProperty {
+			if line == propertyHeader {
+				inProperty = true
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "        ") && !strings.HasPrefix(line, "          ") && line != propertyHeader {
+			break
+		}
+
+		if !inEnum {
+			if trimmed == "enum:" {
+				inEnum = true
+			}
+			continue
+		}
+
+		if !strings.HasPrefix(trimmed, "- ") {
+			break
+		}
+		values = append(values, strings.TrimSpace(strings.TrimPrefix(trimmed, "- ")))
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan appointments OpenAPI document: %v", err)
+	}
+	if len(values) == 0 {
+		t.Fatalf("enum not found for %s.%s", schema, property)
+	}
+	return values
+}

--- a/services/appointments-service/openapi/openapi.yaml
+++ b/services/appointments-service/openapi/openapi.yaml
@@ -1563,6 +1563,7 @@ components:
           type: string
           enum:
             - scheduled
+            - requested
             - checked_in
             - completed
             - cancelled
@@ -1573,6 +1574,7 @@ components:
             - online
             - secretary
             - doctor
+            - patient
         scheduled_start:
           type: string
           format: date-time
@@ -1623,6 +1625,7 @@ components:
             - online
             - secretary
             - doctor
+            - patient
         scheduled_start:
           type: string
           format: date-time
@@ -1655,6 +1658,7 @@ components:
           type: string
           enum:
             - scheduled
+            - requested
             - checked_in
             - completed
             - cancelled
@@ -1665,6 +1669,7 @@ components:
             - online
             - secretary
             - doctor
+            - patient
           nullable: true
           description: Optional immutable source echo; changing it is rejected.
         check_in_time:

--- a/services/directory-service/internal/http/server.go
+++ b/services/directory-service/internal/http/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"slices"
 	"strings"
@@ -515,8 +516,8 @@ func (s *Server) updateClinicalHistory(w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
-	var request directory.UpdateClinicalHistoryParams
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	request, err := decodeClinicalHistoryUpdateRequest(r)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
@@ -537,6 +538,26 @@ func (s *Server) updateClinicalHistory(w http.ResponseWriter, r *http.Request, p
 	}
 
 	writeJSON(w, http.StatusOK, history)
+}
+
+func decodeClinicalHistoryUpdateRequest(r *http.Request) (directory.UpdateClinicalHistoryParams, error) {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	var request directory.UpdateClinicalHistoryParams
+	if err := decoder.Decode(&request); err != nil {
+		return directory.UpdateClinicalHistoryParams{}, err
+	}
+
+	var extra struct{}
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return directory.UpdateClinicalHistoryParams{}, errors.New("multiple json documents")
+		}
+		return directory.UpdateClinicalHistoryParams{}, err
+	}
+
+	return request, nil
 }
 
 func (s *Server) listPatientClinicalNotes(w http.ResponseWriter, r *http.Request, patientID string) {

--- a/services/directory-service/internal/http/server_test.go
+++ b/services/directory-service/internal/http/server_test.go
@@ -362,6 +362,52 @@ func TestPatchClinicalHistoryUpdatesProvidedFieldsForDoctor(t *testing.T) {
 	}
 }
 
+func TestPatchClinicalHistoryRejectsInvalidPayloads(t *testing.T) {
+	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
+	patientID := "0f0f6c4d-7bbb-4d8e-94f9-f13fca1d16ca"
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown field", body: `{"allergies":"Penicilina","patient_id":"other-patient"}`},
+		{name: "multiple json documents", body: `{"allergies":"Penicilina"}{"habitual_medication":"Losartán"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubDirectoryRepository{
+				getUserBySessionTokenFn: func(context.Context, string, time.Time) (directory.User, error) {
+					return directory.User{ID: "user-1", Email: "doctor@clinic.local", Role: "doctor", ProfessionalID: &professionalID, Active: true}, nil
+				},
+				updateClinicalHistoryFn: func(context.Context, directory.UpdateClinicalHistoryParams) (directory.ClinicalHistory, error) {
+					t.Fatal("UpdateClinicalHistory must not be called for invalid clinical history payload")
+					return directory.ClinicalHistory{}, nil
+				},
+			}
+
+			server := NewServer(testConfig(), repo)
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPatch, "/patients/"+patientID+"/clinical-history", bytes.NewBufferString(tt.body))
+			request.Header.Set("Authorization", "Bearer test-token")
+
+			server.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+
+			var response map[string]string
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if response["error"] != "invalid json body" {
+				t.Fatalf("error = %q, want invalid json body", response["error"])
+			}
+		})
+	}
+}
+
 func TestClinicalHistoryReturnsForbiddenForSecretary(t *testing.T) {
 	professionalID := "f58d7e2f-c5fc-4884-b7bb-a3d14577a995"
 	repo := &stubDirectoryRepository{

--- a/web/src/api/clinical.test.ts
+++ b/web/src/api/clinical.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requestMock = vi.fn();
+
+vi.mock('./http', () => ({
+  request: requestMock,
+}));
+
+describe('clinical API patient history and standalone notes', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+  });
+
+  it('uses authenticated directory routes for clinical history reads and writes', async () => {
+    requestMock.mockResolvedValue({ id: 'history-1', patient_id: 'patient-1' });
+
+    const clinical = await import('./clinical');
+
+    await clinical.getClinicalHistory('patient-1');
+    await clinical.updateClinicalHistory('patient-1', {
+      allergies: 'Penicilina',
+      habitual_medication: null,
+      weight_kg: 72.5,
+    });
+
+    expect(requestMock).toHaveBeenNthCalledWith(1, '/directory-api', '/patients/patient-1/clinical-history', {
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(2, '/directory-api', '/patients/patient-1/clinical-history', {
+      method: 'PATCH',
+      body: {
+        allergies: 'Penicilina',
+        habitual_medication: null,
+        weight_kg: 72.5,
+      },
+      auth: true,
+    });
+  });
+
+  it('uses authenticated standalone note CRUD routes and preserves nullable consultation references', async () => {
+    requestMock.mockResolvedValue({ items: [] });
+
+    const clinical = await import('./clinical');
+
+    await clinical.listPatientClinicalNotes('patient-1');
+    await clinical.createPatientClinicalNote('patient-1', { content: 'Nota suelta', consultation_id: null });
+    await clinical.updatePatientClinicalNote('patient-1', 'note-1', { content: 'Nota editada', consultation_id: 'consultation-1' });
+    await clinical.deletePatientClinicalNote('patient-1', 'note-1');
+
+    expect(requestMock).toHaveBeenNthCalledWith(1, '/directory-api', '/patients/patient-1/clinical-notes', {
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(2, '/directory-api', '/patients/patient-1/clinical-notes', {
+      method: 'POST',
+      body: { content: 'Nota suelta', consultation_id: null },
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(3, '/directory-api', '/patients/patient-1/clinical-notes/note-1', {
+      method: 'PATCH',
+      body: { content: 'Nota editada', consultation_id: 'consultation-1' },
+      auth: true,
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(4, '/directory-api', '/patients/patient-1/clinical-notes/note-1', {
+      method: 'DELETE',
+      auth: true,
+    });
+  });
+});

--- a/web/src/api/clinical.ts
+++ b/web/src/api/clinical.ts
@@ -1,5 +1,15 @@
 import { request } from './http';
-import type { CreateEncounterPayload, Encounter, EncounterListResponse } from '../types/clinical';
+import type {
+  ClinicalHistory,
+  CreateEncounterPayload,
+  CreatePatientClinicalNotePayload,
+  Encounter,
+  EncounterListResponse,
+  PatientClinicalNote,
+  PatientClinicalNoteListResponse,
+  UpdateClinicalHistoryPayload,
+  UpdatePatientClinicalNotePayload,
+} from '../types/clinical';
 
 const DIRECTORY_API_BASE = '/directory-api';
 
@@ -13,6 +23,49 @@ export function createPatientEncounter(patientId: string, payload: CreateEncount
   return request<Encounter>(DIRECTORY_API_BASE, `/patients/${patientId}/encounters`, {
     method: 'POST',
     body: payload,
+    auth: true,
+  });
+}
+
+export function getClinicalHistory(patientId: string) {
+  return request<ClinicalHistory>(DIRECTORY_API_BASE, `/patients/${patientId}/clinical-history`, {
+    auth: true,
+  });
+}
+
+export function updateClinicalHistory(patientId: string, payload: UpdateClinicalHistoryPayload) {
+  return request<ClinicalHistory>(DIRECTORY_API_BASE, `/patients/${patientId}/clinical-history`, {
+    method: 'PATCH',
+    body: payload,
+    auth: true,
+  });
+}
+
+export function listPatientClinicalNotes(patientId: string) {
+  return request<PatientClinicalNoteListResponse>(DIRECTORY_API_BASE, `/patients/${patientId}/clinical-notes`, {
+    auth: true,
+  });
+}
+
+export function createPatientClinicalNote(patientId: string, payload: CreatePatientClinicalNotePayload) {
+  return request<PatientClinicalNote>(DIRECTORY_API_BASE, `/patients/${patientId}/clinical-notes`, {
+    method: 'POST',
+    body: payload,
+    auth: true,
+  });
+}
+
+export function updatePatientClinicalNote(patientId: string, noteId: string, payload: UpdatePatientClinicalNotePayload) {
+  return request<PatientClinicalNote>(DIRECTORY_API_BASE, `/patients/${patientId}/clinical-notes/${noteId}`, {
+    method: 'PATCH',
+    body: payload,
+    auth: true,
+  });
+}
+
+export function deletePatientClinicalNote(patientId: string, noteId: string) {
+  return request<unknown>(DIRECTORY_API_BASE, `/patients/${patientId}/clinical-notes/${noteId}`, {
+    method: 'DELETE',
     auth: true,
   });
 }

--- a/web/src/api/http.test.ts
+++ b/web/src/api/http.test.ts
@@ -80,6 +80,16 @@ describe('request auth headers', () => {
 
     expect(headers.has('Authorization')).toBe(false);
   });
+
+  it('allows authenticated DELETE requests that return no content', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(request('/directory-api', '/patients/patient-1/clinical-notes/note-1', { method: 'DELETE', auth: true })).resolves.toBeUndefined();
+
+    const [, init] = fetchMock.mock.calls[0];
+
+    expect(init?.method).toBe('DELETE');
+  });
 });
 
 function jsonResponse(payload: unknown) {

--- a/web/src/api/http.ts
+++ b/web/src/api/http.ts
@@ -3,7 +3,7 @@ import { readStoredSession } from '../auth/session';
 type QueryValue = string | number | boolean | null | undefined;
 
 type RequestOptions = {
-  method?: 'GET' | 'POST' | 'PATCH';
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   body?: unknown;
   headers?: HeadersInit;
   query?: Record<string, QueryValue>;
@@ -58,7 +58,13 @@ export async function request<T>(baseUrl: string, path: string, options: Request
     throw new ApiError(payload.error ?? `Request failed with status ${response.status}`, response.status);
   }
 
-  return (await response.json()) as T;
+  const text = await response.text();
+
+  if (!text) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text) as T;
 }
 
 async function readJsonSafely<T>(response: Response): Promise<T | null> {

--- a/web/src/features/patients/PatientsWorkspace.test.tsx
+++ b/web/src/features/patients/PatientsWorkspace.test.tsx
@@ -1,12 +1,28 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../../api/http';
 import { PatientsWorkspace } from './PatientsWorkspace';
 
-const { listPatientsMock, listPatientEncountersMock, createPatientEncounterMock } = vi.hoisted(() => ({
+const {
+  listPatientsMock,
+  listPatientEncountersMock,
+  createPatientEncounterMock,
+  getClinicalHistoryMock,
+  updateClinicalHistoryMock,
+  listPatientClinicalNotesMock,
+  createPatientClinicalNoteMock,
+  updatePatientClinicalNoteMock,
+  deletePatientClinicalNoteMock,
+} = vi.hoisted(() => ({
   listPatientsMock: vi.fn(),
   listPatientEncountersMock: vi.fn(),
   createPatientEncounterMock: vi.fn(),
+  getClinicalHistoryMock: vi.fn(),
+  updateClinicalHistoryMock: vi.fn(),
+  listPatientClinicalNotesMock: vi.fn(),
+  createPatientClinicalNoteMock: vi.fn(),
+  updatePatientClinicalNoteMock: vi.fn(),
+  deletePatientClinicalNoteMock: vi.fn(),
 }));
 
 vi.mock('../../api/directory', () => ({
@@ -16,6 +32,12 @@ vi.mock('../../api/directory', () => ({
 vi.mock('../../api/clinical', () => ({
   listPatientEncounters: listPatientEncountersMock,
   createPatientEncounter: createPatientEncounterMock,
+  getClinicalHistory: getClinicalHistoryMock,
+  updateClinicalHistory: updateClinicalHistoryMock,
+  listPatientClinicalNotes: listPatientClinicalNotesMock,
+  createPatientClinicalNote: createPatientClinicalNoteMock,
+  updatePatientClinicalNote: updatePatientClinicalNoteMock,
+  deletePatientClinicalNote: deletePatientClinicalNoteMock,
 }));
 
 describe('PatientsWorkspace', () => {
@@ -23,6 +45,14 @@ describe('PatientsWorkspace', () => {
     listPatientsMock.mockReset();
     listPatientEncountersMock.mockReset();
     createPatientEncounterMock.mockReset();
+    getClinicalHistoryMock.mockReset();
+    updateClinicalHistoryMock.mockReset();
+    listPatientClinicalNotesMock.mockReset();
+    createPatientClinicalNoteMock.mockReset();
+    updatePatientClinicalNoteMock.mockReset();
+    deletePatientClinicalNoteMock.mockReset();
+    getClinicalHistoryMock.mockResolvedValue(clinicalHistory());
+    listPatientClinicalNotesMock.mockResolvedValue({ items: [] });
   });
 
   it('shows doctor clinical data when mode allows encounters', async () => {
@@ -33,7 +63,161 @@ describe('PatientsWorkspace', () => {
 
     expect(await screen.findByText(/modo clínico habilitado/i)).toBeInTheDocument();
     expect(await screen.findByText('Control inicial')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /guardar nota/i })).toBeEnabled();
+    expect(await screen.findByDisplayValue('Penicilina')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^guardar nota$/i })).toBeEnabled();
+  });
+
+  it('lets doctors edit the clinical history ficha without losing unsaved input on save errors', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    listPatientEncountersMock.mockResolvedValue({ items: [] });
+    updateClinicalHistoryMock.mockRejectedValue(new ApiError('weight_kg debe ser positivo', 400));
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'doctor-clinical', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />);
+
+    const allergiesInput = await screen.findByLabelText(/alergias/i);
+    const weightInput = await screen.findByLabelText(/peso/i);
+
+    fireEvent.change(allergiesInput, { target: { value: 'Penicilina y dipirona' } });
+    fireEvent.change(weightInput, { target: { value: '-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /guardar ficha/i }));
+
+    expect(await screen.findByText('weight_kg debe ser positivo')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Penicilina y dipirona')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('-1')).toBeInTheDocument();
+    expect(updateClinicalHistoryMock).toHaveBeenCalledWith('patient-1', expect.objectContaining({
+      allergies: 'Penicilina y dipirona',
+      weight_kg: -1,
+    }));
+  });
+
+  it('keeps standalone notes visible when only the clinical history section fails', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    listPatientEncountersMock.mockResolvedValue({ items: [] });
+    getClinicalHistoryMock.mockRejectedValue(new ApiError('No se pudo cargar ficha', 500));
+    listPatientClinicalNotesMock.mockResolvedValue({ items: [patientClinicalNote()] });
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'doctor-clinical', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByText('No se pudo cargar ficha')).toBeInTheDocument();
+    expect(await screen.findByText('Control de alergias actualizado')).toBeInTheDocument();
+    expect(screen.queryByText(/no se pudieron cargar las notas clínicas/i)).not.toBeInTheDocument();
+  });
+
+  it('clears previous patient ficha values when the newly selected patient history load fails', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
+    listPatientEncountersMock.mockResolvedValue({ items: [] });
+    getClinicalHistoryMock.mockImplementation((patientId: string) => {
+      if (patientId === 'patient-2') {
+        return Promise.reject(new ApiError('No se pudo cargar ficha de María', 500));
+      }
+
+      return Promise.resolve(clinicalHistory());
+    });
+    listPatientClinicalNotesMock.mockImplementation((patientId: string) => Promise.resolve({
+      items: patientId === 'patient-2'
+        ? [patientClinicalNote({ patient_id: 'patient-2', content: 'Nota propia de María' })]
+        : [],
+    }));
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'doctor-clinical', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByDisplayValue('Penicilina')).toBeInTheDocument();
+
+    const searchInput = screen.getByLabelText('Buscar paciente');
+    fireEvent.focus(searchInput);
+    fireEvent.click(await screen.findByRole('option', { name: /María Gómez/i }));
+
+    expect(await screen.findByText('No se pudo cargar ficha de María')).toBeInTheDocument();
+    expect(await screen.findByText('Nota propia de María')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Penicilina')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Losartán')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Control anual')).not.toBeInTheDocument();
+  });
+
+  it('ignores late clinical history and notes responses after switching patients', async () => {
+    const patientOneHistory = deferred<ReturnType<typeof clinicalHistory>>();
+    const patientOneNotes = deferred<{ items: ReturnType<typeof patientClinicalNote>[] }>();
+
+    listPatientsMock.mockResolvedValue({ items: [activePatient(), secondPatient()] });
+    listPatientEncountersMock.mockResolvedValue({ items: [] });
+    getClinicalHistoryMock.mockImplementation((patientId: string) => {
+      if (patientId === 'patient-1') {
+        return patientOneHistory.promise;
+      }
+
+      return Promise.resolve(clinicalHistory({
+        id: 'history-2',
+        patient_id: 'patient-2',
+        allergies: 'Cefalexina',
+        habitual_medication: 'Metformina',
+        general_observations: 'Seguimiento María',
+      }));
+    });
+    listPatientClinicalNotesMock.mockImplementation((patientId: string) => {
+      if (patientId === 'patient-1') {
+        return patientOneNotes.promise;
+      }
+
+      return Promise.resolve({ items: [patientClinicalNote({ patient_id: 'patient-2', content: 'Nota propia de María' })] });
+    });
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'doctor-clinical', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />);
+
+    const searchInput = await screen.findByLabelText('Buscar paciente');
+    fireEvent.focus(searchInput);
+    fireEvent.click(await screen.findByRole('option', { name: /María Gómez/i }));
+
+    expect(await screen.findByDisplayValue('Cefalexina')).toBeInTheDocument();
+    expect(await screen.findByText('Nota propia de María')).toBeInTheDocument();
+
+    await act(async () => {
+      patientOneHistory.resolve(clinicalHistory({ allergies: 'Penicilina tardía', habitual_medication: 'Losartán tardío', general_observations: 'Control anual tardío' }));
+      patientOneNotes.resolve({ items: [patientClinicalNote({ content: 'Nota tardía de Juan' })] });
+    });
+
+    expect(screen.getByDisplayValue('Cefalexina')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Metformina')).toBeInTheDocument();
+    expect(screen.getByText('Nota propia de María')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Penicilina tardía')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Losartán tardío')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Control anual tardío')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nota tardía de Juan')).not.toBeInTheDocument();
+  });
+
+  it('lets doctors create, edit, and delete standalone patient notes with optional consultation id', async () => {
+    listPatientsMock.mockResolvedValue({ items: [activePatient()] });
+    listPatientEncountersMock.mockResolvedValue({ items: [] });
+    listPatientClinicalNotesMock.mockResolvedValue({ items: [patientClinicalNote()] });
+    createPatientClinicalNoteMock.mockResolvedValue(patientClinicalNote({ id: 'note-2', content: 'Nueva nota suelta', consultation_id: null, created_at: '2026-01-04T10:00:00Z', updated_at: '2026-01-04T10:00:00Z' }));
+    updatePatientClinicalNoteMock.mockResolvedValue(patientClinicalNote({ id: 'note-2', content: 'Nota corregida', consultation_id: null, created_at: '2026-01-04T10:00:00Z', updated_at: '2026-01-04T10:05:00Z' }));
+    deletePatientClinicalNoteMock.mockResolvedValue({});
+
+    render(<PatientsWorkspace patientsMode={{ kind: 'doctor-clinical', professionalId: 'professional-1' }} onSessionInvalid={vi.fn()} />);
+
+    expect(await screen.findByText('Control de alergias actualizado')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/nueva nota clínica/i), { target: { value: 'Nueva nota suelta' } });
+    fireEvent.change(screen.getByLabelText(/consulta asociada/i), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: /guardar nota clínica/i }));
+
+    expect(await screen.findByText('Nueva nota suelta')).toBeInTheDocument();
+    expect(createPatientClinicalNoteMock).toHaveBeenCalledWith('patient-1', { content: 'Nueva nota suelta', consultation_id: null });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /editar nota clínica/i })[0]);
+    fireEvent.change(screen.getByLabelText(/editar contenido de nota clínica/i), { target: { value: 'Nota corregida' } });
+    fireEvent.click(screen.getByRole('button', { name: /guardar cambios de nota clínica/i }));
+
+    await waitFor(() => {
+      expect(updatePatientClinicalNoteMock).toHaveBeenCalledWith('patient-1', 'note-2', { content: 'Nota corregida', consultation_id: null });
+    });
+    expect(await screen.findByText('Nota corregida')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /eliminar nota clínica/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Nota corregida')).not.toBeInTheDocument();
+    });
+    expect(deletePatientClinicalNoteMock).toHaveBeenCalledWith('patient-1', 'note-2');
   });
 
   it('keeps secretary in operational patient flow while denying encounters', async () => {
@@ -46,6 +230,8 @@ describe('PatientsWorkspace', () => {
     expect(screen.queryByRole('button', { name: /guardar nota/i })).not.toBeInTheDocument();
     expect(screen.getByText(/trabajo clínico oculto para secretaría/i)).toBeInTheDocument();
     expect(listPatientEncountersMock).not.toHaveBeenCalled();
+    expect(getClinicalHistoryMock).not.toHaveBeenCalled();
+    expect(listPatientClinicalNotesMock).not.toHaveBeenCalled();
   });
 
   it('offers directory support to secretary when no active patients exist', async () => {
@@ -262,5 +448,60 @@ function encounter() {
       created_at: '2026-01-02T10:00:00Z',
       updated_at: '2026-01-02T10:00:00Z',
     },
+  };
+}
+
+function clinicalHistory(overrides: Partial<ReturnType<typeof clinicalHistoryBase>> = {}) {
+  return {
+    ...clinicalHistoryBase(),
+    ...overrides,
+  };
+}
+
+function clinicalHistoryBase() {
+  return {
+    id: 'history-1',
+    patient_id: 'patient-1',
+    weight_kg: 72.5,
+    height_cm: 178,
+    antecedentes: 'HTA familiar',
+    allergies: 'Penicilina',
+    habitual_medication: 'Losartán',
+    chronic_conditions: null,
+    habits: 'Camina 3 veces por semana',
+    general_observations: 'Control anual',
+    created_at: '2026-01-02T10:00:00Z',
+    updated_at: '2026-01-02T10:00:00Z',
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function patientClinicalNote(overrides: Partial<ReturnType<typeof patientClinicalNoteBase>> = {}) {
+  return {
+    ...patientClinicalNoteBase(),
+    ...overrides,
+  };
+}
+
+function patientClinicalNoteBase() {
+  return {
+    id: 'note-1',
+    patient_id: 'patient-1',
+    professional_id: 'professional-1',
+    consultation_id: 'consultation-1',
+    kind: 'standalone',
+    content: 'Control de alergias actualizado',
+    created_at: '2026-01-03T10:00:00Z',
+    updated_at: '2026-01-03T10:00:00Z',
   };
 }

--- a/web/src/features/patients/PatientsWorkspace.tsx
+++ b/web/src/features/patients/PatientsWorkspace.tsx
@@ -2,9 +2,18 @@ import { type FocusEvent, useCallback, useEffect, useMemo, useRef, useState } fr
 import { EmptyState, PageContainer, SectionCard } from '../../app-shell/AppShell.primitives';
 import { type PatientsMode } from '../../auth/actorCapabilities';
 import { resolveAuthenticatedViewError } from '../../auth/authenticatedViewPolicy';
-import { createPatientEncounter, listPatientEncounters } from '../../api/clinical';
+import {
+  createPatientClinicalNote,
+  createPatientEncounter,
+  deletePatientClinicalNote,
+  getClinicalHistory,
+  listPatientClinicalNotes,
+  listPatientEncounters,
+  updateClinicalHistory,
+  updatePatientClinicalNote,
+} from '../../api/clinical';
 import { listPatients } from '../../api/directory';
-import type { CreateEncounterPayload, Encounter, Patient } from '../../types/clinical';
+import type { ClinicalHistory, CreateEncounterPayload, Encounter, Patient, PatientClinicalNote, UpdateClinicalHistoryPayload } from '../../types/clinical';
 import { filterPatients, normalizePatientSearchValue } from '../patient-search/matching';
 
 type PatientsWorkspaceProps = {
@@ -18,26 +27,73 @@ type EncounterFormState = {
   occurred_at: string;
 };
 
+type ClinicalHistoryFormState = {
+  weight_kg: string;
+  height_cm: string;
+  antecedentes: string;
+  allergies: string;
+  habitual_medication: string;
+  chronic_conditions: string;
+  habits: string;
+  general_observations: string;
+};
+
+type PatientClinicalNoteFormState = {
+  content: string;
+  consultation_id: string;
+};
+
 const EMPTY_ENCOUNTER_FORM: EncounterFormState = {
   note: '',
   occurred_at: '',
+};
+
+const EMPTY_HISTORY_FORM: ClinicalHistoryFormState = {
+  weight_kg: '',
+  height_cm: '',
+  antecedentes: '',
+  allergies: '',
+  habitual_medication: '',
+  chronic_conditions: '',
+  habits: '',
+  general_observations: '',
+};
+
+const EMPTY_NOTE_FORM: PatientClinicalNoteFormState = {
+  content: '',
+  consultation_id: '',
 };
 
 export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirectorySupport }: PatientsWorkspaceProps) {
   const [patients, setPatients] = useState<Patient[]>([]);
   const [selectedPatientId, setSelectedPatientId] = useState('');
   const [encounters, setEncounters] = useState<Encounter[]>([]);
+  const [clinicalHistory, setClinicalHistory] = useState<ClinicalHistory | null>(null);
+  const [historyForm, setHistoryForm] = useState<ClinicalHistoryFormState>(EMPTY_HISTORY_FORM);
+  const [patientClinicalNotes, setPatientClinicalNotes] = useState<PatientClinicalNote[]>([]);
+  const [clinicalNoteForm, setClinicalNoteForm] = useState<PatientClinicalNoteFormState>(EMPTY_NOTE_FORM);
+  const [editingClinicalNoteId, setEditingClinicalNoteId] = useState('');
+  const [editingClinicalNoteForm, setEditingClinicalNoteForm] = useState<PatientClinicalNoteFormState>(EMPTY_NOTE_FORM);
   const [sidebarQuery, setSidebarQuery] = useState('');
   const [form, setForm] = useState<EncounterFormState>(EMPTY_ENCOUNTER_FORM);
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [isLoadingEncounters, setIsLoadingEncounters] = useState(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [isSavingHistory, setIsSavingHistory] = useState(false);
+  const [isLoadingClinicalNotes, setIsLoadingClinicalNotes] = useState(false);
+  const [isSavingClinicalNote, setIsSavingClinicalNote] = useState(false);
   const [isCreatingEncounter, setIsCreatingEncounter] = useState(false);
   const [patientsError, setPatientsError] = useState('');
   const [encountersError, setEncountersError] = useState('');
+  const [historyError, setHistoryError] = useState('');
+  const [clinicalNotesError, setClinicalNotesError] = useState('');
   const [formError, setFormError] = useState('');
+  const [clinicalNoteFormError, setClinicalNoteFormError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchControlRef = useRef<HTMLDivElement | null>(null);
+  const clinicalHistoryRequestRef = useRef(0);
+  const clinicalNotesRequestRef = useRef(0);
 
   const activePatients = useMemo(() => patients.filter((patient) => patient.active), [patients]);
   const filteredPatients = useMemo(() => filterPatients(activePatients, sidebarQuery), [activePatients, sidebarQuery]);
@@ -83,8 +139,13 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
       setPatients([]);
       setSelectedPatientId('');
       setEncounters([]);
+      setClinicalHistory(null);
+      setHistoryForm(EMPTY_HISTORY_FORM);
+      setPatientClinicalNotes([]);
       setPatientsError('');
       setEncountersError(patientsMode.message);
+      setHistoryError(patientsMode.message);
+      setClinicalNotesError(patientsMode.message);
       setIsBootstrapping(false);
       return;
     }
@@ -93,6 +154,8 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
       setIsBootstrapping(true);
       setPatientsError('');
       setEncountersError(patientsMode.kind === 'secretary-operational' ? clinicalDeniedMessage : '');
+      setHistoryError(patientsMode.kind === 'secretary-operational' ? clinicalDeniedMessage : '');
+      setClinicalNotesError(patientsMode.kind === 'secretary-operational' ? clinicalDeniedMessage : '');
 
       const response = await listPatients();
       setPatients(response.items);
@@ -104,6 +167,8 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
       );
       setPatientsError(nextError.errorMessage);
       setEncountersError(nextError.deniedMessage);
+      setHistoryError(nextError.deniedMessage);
+      setClinicalNotesError(nextError.deniedMessage);
     } finally {
       setIsBootstrapping(false);
     }
@@ -138,6 +203,96 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
     [canAccessClinical, clinicalDeniedMessage, resolveViewError],
   );
 
+  const loadClinicalHistory = useCallback(
+    async (patientId: string) => {
+      const requestId = clinicalHistoryRequestRef.current + 1;
+      clinicalHistoryRequestRef.current = requestId;
+
+      if (!canAccessClinical) {
+        setClinicalHistory(null);
+        setHistoryForm(EMPTY_HISTORY_FORM);
+        setHistoryError(clinicalDeniedMessage);
+        return;
+      }
+
+      try {
+        setIsLoadingHistory(true);
+        setHistoryError('');
+        setClinicalHistory(null);
+        setHistoryForm(EMPTY_HISTORY_FORM);
+
+        const history = await getClinicalHistory(patientId);
+        if (clinicalHistoryRequestRef.current !== requestId) {
+          return;
+        }
+
+        setClinicalHistory(history);
+        setHistoryForm(clinicalHistoryToForm(history));
+      } catch (error) {
+        if (clinicalHistoryRequestRef.current !== requestId) {
+          return;
+        }
+
+        setClinicalHistory(null);
+        setHistoryForm(EMPTY_HISTORY_FORM);
+        const nextError = resolveViewError(
+          error,
+          'No se pudo cargar la ficha clínica del paciente.',
+          'No tenés permiso para consultar la ficha clínica.',
+        );
+        setHistoryError(nextError.deniedMessage || nextError.errorMessage);
+      } finally {
+        if (clinicalHistoryRequestRef.current === requestId) {
+          setIsLoadingHistory(false);
+        }
+      }
+    },
+    [canAccessClinical, clinicalDeniedMessage, resolveViewError],
+  );
+
+  const loadClinicalNotes = useCallback(
+    async (patientId: string) => {
+      const requestId = clinicalNotesRequestRef.current + 1;
+      clinicalNotesRequestRef.current = requestId;
+
+      if (!canAccessClinical) {
+        setPatientClinicalNotes([]);
+        setClinicalNotesError(clinicalDeniedMessage);
+        return;
+      }
+
+      try {
+        setIsLoadingClinicalNotes(true);
+        setClinicalNotesError('');
+        setPatientClinicalNotes([]);
+
+        const response = await listPatientClinicalNotes(patientId);
+        if (clinicalNotesRequestRef.current !== requestId) {
+          return;
+        }
+
+        setPatientClinicalNotes(sortPatientClinicalNotes(response.items));
+      } catch (error) {
+        if (clinicalNotesRequestRef.current !== requestId) {
+          return;
+        }
+
+        setPatientClinicalNotes([]);
+        const nextError = resolveViewError(
+          error,
+          'No se pudieron cargar las notas clínicas del paciente.',
+          'No tenés permiso para consultar notas clínicas.',
+        );
+        setClinicalNotesError(nextError.deniedMessage || nextError.errorMessage);
+      } finally {
+        if (clinicalNotesRequestRef.current === requestId) {
+          setIsLoadingClinicalNotes(false);
+        }
+      }
+    },
+    [canAccessClinical, clinicalDeniedMessage, resolveViewError],
+  );
+
   useEffect(() => {
     void bootstrap();
   }, [bootstrap]);
@@ -165,17 +320,29 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
     if (!selectedPatientId) {
       setEncounters([]);
       setEncountersError(canAccessClinical ? '' : clinicalDeniedMessage);
+      setClinicalHistory(null);
+      setHistoryForm(EMPTY_HISTORY_FORM);
+      setHistoryError(canAccessClinical ? '' : clinicalDeniedMessage);
+      setPatientClinicalNotes([]);
+      setClinicalNotesError(canAccessClinical ? '' : clinicalDeniedMessage);
       return;
     }
 
     if (!canAccessClinical) {
       setEncounters([]);
       setEncountersError(clinicalDeniedMessage);
+      setClinicalHistory(null);
+      setHistoryForm(EMPTY_HISTORY_FORM);
+      setHistoryError(clinicalDeniedMessage);
+      setPatientClinicalNotes([]);
+      setClinicalNotesError(clinicalDeniedMessage);
       return;
     }
 
     void loadEncounters(selectedPatientId);
-  }, [canAccessClinical, clinicalDeniedMessage, loadEncounters, selectedPatientId]);
+    void loadClinicalHistory(selectedPatientId);
+    void loadClinicalNotes(selectedPatientId);
+  }, [canAccessClinical, clinicalDeniedMessage, loadClinicalHistory, loadClinicalNotes, loadEncounters, selectedPatientId]);
 
   async function handleCreateEncounter() {
     if (!canAccessClinical) {
@@ -226,6 +393,143 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
     } finally {
       setIsCreatingEncounter(false);
     }
+  }
+
+  async function handleSaveClinicalHistory() {
+    if (!canAccessClinical) {
+      setHistoryError(clinicalDeniedMessage);
+      return;
+    }
+
+    if (!selectedPatientId) {
+      setHistoryError('Elegí un paciente antes de guardar la ficha.');
+      return;
+    }
+
+    const payload = historyFormToPayload(historyForm);
+    if (!payload) {
+      setHistoryError('Peso y altura deben ser números válidos.');
+      return;
+    }
+
+    try {
+      setIsSavingHistory(true);
+      setHistoryError('');
+      setSuccessMessage('');
+
+      const history = await updateClinicalHistory(selectedPatientId, payload);
+      setClinicalHistory(history);
+      setHistoryForm(clinicalHistoryToForm(history));
+      setSuccessMessage('Ficha clínica guardada correctamente.');
+    } catch (error) {
+      const nextError = resolveViewError(
+        error,
+        'No se pudo guardar la ficha clínica.',
+        'No tenés permiso para guardar la ficha clínica.',
+      );
+      setHistoryError(nextError.deniedMessage || nextError.errorMessage);
+    } finally {
+      setIsSavingHistory(false);
+    }
+  }
+
+  async function handleCreateClinicalNote() {
+    if (!canAccessClinical) {
+      setClinicalNoteFormError(clinicalDeniedMessage);
+      return;
+    }
+
+    if (!selectedPatientId) {
+      setClinicalNoteFormError('Elegí un paciente antes de guardar una nota clínica.');
+      return;
+    }
+
+    const content = clinicalNoteForm.content.trim();
+    if (!content) {
+      setClinicalNoteFormError('Escribí una nota clínica antes de guardar.');
+      return;
+    }
+
+    try {
+      setIsSavingClinicalNote(true);
+      setClinicalNoteFormError('');
+      setClinicalNotesError('');
+      setSuccessMessage('');
+
+      const note = await createPatientClinicalNote(selectedPatientId, {
+        content,
+        consultation_id: normalizeNullableText(clinicalNoteForm.consultation_id),
+      });
+      setPatientClinicalNotes((current) => sortPatientClinicalNotes([note, ...current]));
+      setClinicalNoteForm(EMPTY_NOTE_FORM);
+      setSuccessMessage('Nota clínica guardada correctamente.');
+    } catch (error) {
+      const nextError = resolveViewError(
+        error,
+        'No se pudo guardar la nota clínica.',
+        'No tenés permiso para guardar notas clínicas.',
+      );
+      setClinicalNoteFormError(nextError.deniedMessage || nextError.errorMessage);
+    } finally {
+      setIsSavingClinicalNote(false);
+    }
+  }
+
+  async function handleUpdateClinicalNote(noteId: string) {
+    if (!selectedPatientId) {
+      return;
+    }
+
+    const content = editingClinicalNoteForm.content.trim();
+    if (!content) {
+      setClinicalNotesError('La nota clínica editada no puede quedar vacía.');
+      return;
+    }
+
+    try {
+      setClinicalNotesError('');
+      const note = await updatePatientClinicalNote(selectedPatientId, noteId, {
+        content,
+        consultation_id: normalizeNullableText(editingClinicalNoteForm.consultation_id),
+      });
+      setPatientClinicalNotes((current) => sortPatientClinicalNotes(current.map((item) => (item.id === noteId ? note : item))));
+      setEditingClinicalNoteId('');
+      setEditingClinicalNoteForm(EMPTY_NOTE_FORM);
+    } catch (error) {
+      const nextError = resolveViewError(
+        error,
+        'No se pudo editar la nota clínica.',
+        'No tenés permiso para editar notas clínicas.',
+      );
+      setClinicalNotesError(nextError.deniedMessage || nextError.errorMessage);
+    }
+  }
+
+  async function handleDeleteClinicalNote(noteId: string) {
+    if (!selectedPatientId) {
+      return;
+    }
+
+    try {
+      setClinicalNotesError('');
+      await deletePatientClinicalNote(selectedPatientId, noteId);
+      setPatientClinicalNotes((current) => current.filter((note) => note.id !== noteId));
+    } catch (error) {
+      const nextError = resolveViewError(
+        error,
+        'No se pudo eliminar la nota clínica.',
+        'No tenés permiso para eliminar notas clínicas.',
+      );
+      setClinicalNotesError(nextError.deniedMessage || nextError.errorMessage);
+    }
+  }
+
+  function startEditingClinicalNote(note: PatientClinicalNote) {
+    setEditingClinicalNoteId(note.id);
+    setEditingClinicalNoteForm({
+      content: note.content,
+      consultation_id: note.consultation_id ?? '',
+    });
   }
 
   function handleSearchBlur(event: FocusEvent<HTMLDivElement>) {
@@ -427,6 +731,170 @@ export function PatientsWorkspace({ patientsMode, onSessionInvalid, onOpenDirect
           <SectionCard className="stack">
             <div className="section-header">
               <div>
+                <h3>Ficha clínica</h3>
+                <p>Datos base vivos del paciente. Separada de notas, encounters, SOAP, recetas y estudios.</p>
+              </div>
+              {canAccessClinical && selectedPatientId ? (
+                <button className="button secondary" type="button" onClick={() => void loadClinicalHistory(selectedPatientId)} disabled={isLoadingHistory}>
+                  {isLoadingHistory ? 'Actualizando...' : 'Recargar ficha'}
+                </button>
+              ) : null}
+            </div>
+
+            {historyError ? <div className="inline-note inline-note-error">{historyError}</div> : null}
+
+            {!selectedPatient ? (
+              <div className="empty-state empty-state-soft">Elegí un paciente para ver su ficha clínica.</div>
+            ) : !canAccessClinical ? (
+              <div className="empty-state">
+                <strong>Ficha clínica bloqueada</strong>
+                <span>{clinicalDeniedMessage}</span>
+              </div>
+            ) : isLoadingHistory && !clinicalHistory ? (
+              <div className="empty-state empty-state-soft">Cargando ficha clínica...</div>
+            ) : (
+              <>
+                <div className="form-grid">
+                  <div className="field">
+                    <label htmlFor="history-weight">Peso (kg)</label>
+                    <input id="history-weight" inputMode="decimal" value={historyForm.weight_kg} onChange={(event) => setHistoryForm((current) => ({ ...current, weight_kg: event.target.value }))} />
+                  </div>
+                  <div className="field">
+                    <label htmlFor="history-height">Altura (cm)</label>
+                    <input id="history-height" inputMode="decimal" value={historyForm.height_cm} onChange={(event) => setHistoryForm((current) => ({ ...current, height_cm: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="history-antecedentes">Antecedentes</label>
+                    <textarea id="history-antecedentes" value={historyForm.antecedentes} onChange={(event) => setHistoryForm((current) => ({ ...current, antecedentes: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="history-allergies">Alergias</label>
+                    <textarea id="history-allergies" value={historyForm.allergies} onChange={(event) => setHistoryForm((current) => ({ ...current, allergies: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="history-medication">Medicación habitual</label>
+                    <textarea id="history-medication" value={historyForm.habitual_medication} onChange={(event) => setHistoryForm((current) => ({ ...current, habitual_medication: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="history-conditions">Condiciones crónicas</label>
+                    <textarea id="history-conditions" value={historyForm.chronic_conditions} onChange={(event) => setHistoryForm((current) => ({ ...current, chronic_conditions: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="history-habits">Hábitos</label>
+                    <textarea id="history-habits" value={historyForm.habits} onChange={(event) => setHistoryForm((current) => ({ ...current, habits: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="history-observations">Observaciones generales</label>
+                    <textarea id="history-observations" value={historyForm.general_observations} onChange={(event) => setHistoryForm((current) => ({ ...current, general_observations: event.target.value }))} />
+                  </div>
+                </div>
+                <div className="toolbar">
+                  <button className="button" type="button" onClick={() => void handleSaveClinicalHistory()} disabled={!selectedPatientId || isSavingHistory}>
+                    {isSavingHistory ? 'Guardando...' : 'Guardar ficha'}
+                  </button>
+                  <span className="helper helper-inline">No actualiza notas ni encounters automáticamente.</span>
+                </div>
+              </>
+            )}
+          </SectionCard>
+
+          <SectionCard className="stack">
+            <div className="section-header">
+              <div>
+                <h3>Notas clínicas independientes</h3>
+                <p>Notas por paciente, opcionalmente asociadas por UUID técnico a una consulta.</p>
+              </div>
+              {canAccessClinical && selectedPatientId ? (
+                <button className="button secondary" type="button" onClick={() => void loadClinicalNotes(selectedPatientId)} disabled={isLoadingClinicalNotes}>
+                  {isLoadingClinicalNotes ? 'Actualizando...' : 'Recargar notas'}
+                </button>
+              ) : null}
+            </div>
+
+            {clinicalNotesError ? <div className="inline-note inline-note-error">{clinicalNotesError}</div> : null}
+
+            {!selectedPatient ? (
+              <div className="empty-state empty-state-soft">Elegí un paciente para ver sus notas clínicas.</div>
+            ) : !canAccessClinical ? (
+              <div className="empty-state">
+                <strong>Notas clínicas bloqueadas</strong>
+                <span>{clinicalDeniedMessage}</span>
+              </div>
+            ) : (
+              <>
+                <div className="form-grid">
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="patient-clinical-note-content">Nueva nota clínica</label>
+                    <textarea id="patient-clinical-note-content" value={clinicalNoteForm.content} onChange={(event) => setClinicalNoteForm((current) => ({ ...current, content: event.target.value }))} />
+                  </div>
+                  <div className="field form-grid-span-full">
+                    <label htmlFor="patient-clinical-note-consultation">Consulta asociada (UUID opcional)</label>
+                    <input id="patient-clinical-note-consultation" value={clinicalNoteForm.consultation_id} onChange={(event) => setClinicalNoteForm((current) => ({ ...current, consultation_id: event.target.value }))} />
+                  </div>
+                </div>
+
+                {clinicalNoteFormError ? <div className="inline-note inline-note-error">{clinicalNoteFormError}</div> : null}
+
+                <div className="toolbar">
+                  <button className="button" type="button" onClick={() => void handleCreateClinicalNote()} disabled={!selectedPatientId || isSavingClinicalNote}>
+                    {isSavingClinicalNote ? 'Guardando...' : 'Guardar nota clínica'}
+                  </button>
+                </div>
+
+                {isLoadingClinicalNotes ? (
+                  <div className="empty-state empty-state-soft">Cargando notas clínicas...</div>
+                ) : patientClinicalNotes.length === 0 ? (
+                  <div className="empty-state empty-state-soft">Sin notas clínicas independientes todavía.</div>
+                ) : (
+                  <div className="list">
+                    {patientClinicalNotes.map((note) => (
+                      <article key={note.id} className="encounter-card">
+                        {editingClinicalNoteId === note.id ? (
+                          <>
+                            <div className="field">
+                              <label htmlFor={`edit-clinical-note-${note.id}`}>Editar contenido de nota clínica</label>
+                              <textarea id={`edit-clinical-note-${note.id}`} value={editingClinicalNoteForm.content} onChange={(event) => setEditingClinicalNoteForm((current) => ({ ...current, content: event.target.value }))} />
+                            </div>
+                            <div className="field">
+                              <label htmlFor={`edit-clinical-note-consultation-${note.id}`}>Editar consulta asociada</label>
+                              <input id={`edit-clinical-note-consultation-${note.id}`} value={editingClinicalNoteForm.consultation_id} onChange={(event) => setEditingClinicalNoteForm((current) => ({ ...current, consultation_id: event.target.value }))} />
+                            </div>
+                            <div className="toolbar">
+                              <button className="button" type="button" onClick={() => void handleUpdateClinicalNote(note.id)}>Guardar cambios de nota clínica</button>
+                              <button className="button secondary" type="button" onClick={() => setEditingClinicalNoteId('')}>Cancelar edición</button>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <div className="section-header">
+                              <div>
+                                <span className="surface-tab-eyebrow">Nota clínica</span>
+                                <h4>{formatDateTime(note.created_at)}</h4>
+                              </div>
+                              <span className="badge neutral">{note.consultation_id ? 'Con consulta' : 'Standalone'}</span>
+                            </div>
+                            <p className="encounter-note">{note.content}</p>
+                            <div className="appointment-meta">
+                              <span className="muted">Profesional: {note.professional_id}</span>
+                              <span className="muted">Consulta: {note.consultation_id ?? 'sin vínculo'}</span>
+                            </div>
+                            <div className="toolbar">
+                              <button className="button secondary" type="button" onClick={() => startEditingClinicalNote(note)}>Editar nota clínica</button>
+                              <button className="button secondary" type="button" onClick={() => void handleDeleteClinicalNote(note.id)}>Eliminar nota clínica</button>
+                            </div>
+                          </>
+                        )}
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </SectionCard>
+
+          <SectionCard className="stack">
+            <div className="section-header">
+              <div>
                 <h3>Encounters</h3>
                 <p>Listado descendente por fecha para ver la actividad clínica cuando el actor lo tiene habilitado.</p>
               </div>
@@ -553,6 +1021,67 @@ function sortEncounters(encounters: Encounter[]) {
     const rightTime = Date.parse(right.occurred_at) || Date.parse(right.created_at) || 0;
     return rightTime - leftTime;
   });
+}
+
+function sortPatientClinicalNotes(notes: PatientClinicalNote[]) {
+  return [...notes].sort((left, right) => {
+    const leftTime = Date.parse(left.created_at) || Date.parse(left.updated_at) || 0;
+    const rightTime = Date.parse(right.created_at) || Date.parse(right.updated_at) || 0;
+    return rightTime - leftTime;
+  });
+}
+
+function clinicalHistoryToForm(history: ClinicalHistory): ClinicalHistoryFormState {
+  return {
+    weight_kg: numberToFormValue(history.weight_kg),
+    height_cm: numberToFormValue(history.height_cm),
+    antecedentes: history.antecedentes ?? '',
+    allergies: history.allergies ?? '',
+    habitual_medication: history.habitual_medication ?? '',
+    chronic_conditions: history.chronic_conditions ?? '',
+    habits: history.habits ?? '',
+    general_observations: history.general_observations ?? '',
+  };
+}
+
+function historyFormToPayload(form: ClinicalHistoryFormState): UpdateClinicalHistoryPayload | null {
+  const weight = numberFieldToPayload(form.weight_kg);
+  const height = numberFieldToPayload(form.height_cm);
+
+  if (weight === undefined || height === undefined) {
+    return null;
+  }
+
+  return {
+    weight_kg: weight,
+    height_cm: height,
+    antecedentes: normalizeNullableText(form.antecedentes),
+    allergies: normalizeNullableText(form.allergies),
+    habitual_medication: normalizeNullableText(form.habitual_medication),
+    chronic_conditions: normalizeNullableText(form.chronic_conditions),
+    habits: normalizeNullableText(form.habits),
+    general_observations: normalizeNullableText(form.general_observations),
+  };
+}
+
+function numberToFormValue(value: number | null) {
+  return value === null ? '' : String(value);
+}
+
+function numberFieldToPayload(value: string): number | null | undefined {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function normalizeNullableText(value: string) {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
 }
 
 function formatDate(value: string) {

--- a/web/src/types/clinical.ts
+++ b/web/src/types/clinical.ts
@@ -31,3 +31,49 @@ export type CreateEncounterPayload = {
   note: string;
   occurred_at?: string;
 };
+
+export type ClinicalHistory = {
+  id: string;
+  patient_id: string;
+  weight_kg: number | null;
+  height_cm: number | null;
+  antecedentes: string | null;
+  allergies: string | null;
+  habitual_medication: string | null;
+  chronic_conditions: string | null;
+  habits: string | null;
+  general_observations: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UpdateClinicalHistoryPayload = Partial<{
+  weight_kg: number | null;
+  height_cm: number | null;
+  antecedentes: string | null;
+  allergies: string | null;
+  habitual_medication: string | null;
+  chronic_conditions: string | null;
+  habits: string | null;
+  general_observations: string | null;
+}>;
+
+export type PatientClinicalNote = {
+  id: string;
+  patient_id: string;
+  professional_id: string;
+  consultation_id?: string | null;
+  kind: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PatientClinicalNoteListResponse = ListResponse<PatientClinicalNote>;
+
+export type CreatePatientClinicalNotePayload = {
+  content: string;
+  consultation_id?: string | null;
+};
+
+export type UpdatePatientClinicalNotePayload = Partial<CreatePatientClinicalNotePayload>;


### PR DESCRIPTION
## Summary
- Adds frontend patient clinical history editing and standalone clinical notes CRUD.
- Guards clinical history/notes loaders against stale async responses after patient switching.
- Includes final contract cleanup: directory PATCH invalid-payload hardening and appointments OpenAPI consultation enum alignment.

## Tests
- ✅ `npm test -- src/api/clinical.test.ts src/api/http.test.ts src/features/patients/PatientsWorkspace.test.tsx`
- ✅ `go test ./internal/http`
- ✅ `go test ./internal/appointments -run 'TestConsultation(OpenAPIEnumsMatchDomainContract|StatusIsValid|SourceIsValid)'`

## Notes
- No build run by project preference.
- Local Docker smoke can be run with `docker compose -f deploy/docker-compose.yml up --build`.